### PR TITLE
Add support for OpenAI's JSON message response

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,39 @@ the steps in the next section for adding an environment variable to your project
     }
 
 
+### How to ensure OpenAI returns JSON as the chat message content
+
+Use `responseFormat` *and* specify in the prompt that OpenAI should return JSON only:
+
+    import AIProxy
+
+    let openAIService = AIProxy.openAIService(
+        partialKey: "<the-partial-key-from-the-dashboard>"
+    )
+    do {
+        let response = try await service.chatCompletionRequest(body: .init(
+            model: "gpt-4o",
+            messages: [
+                .init(
+                    role: "system",
+                    content: .text("Return valid JSON only")
+                ),
+                .init(
+                    role: "user",
+                    content: .text("Return alice and bob in a list of names")
+                )
+            ],
+            responseFormat: .type("json_object")
+        ))
+        print(response.choices.first?.message.content)
+    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
+    } catch {
+        print(error.localizedDescription)
+    }
+
+
+
 ### Specify your own `clientID` to annotate requests
 
 If your app already has client or user IDs that you want to annotate AIProxy requests with,

--- a/Sources/AIProxy/AIProxyDeviceCheck.swift
+++ b/Sources/AIProxy/AIProxyDeviceCheck.swift
@@ -7,6 +7,16 @@
 
 import Foundation
 import DeviceCheck
+import OSLog
+
+private let deviceCheckWarning = """
+    AIProxy warning: DeviceCheck is not available on this device.
+
+    To use AIProxy on an iOS simulator, set an AIPROXY_DEVICE_CHECK_BYPASS environment variable.
+
+    See the README at https://github.com/lzell/AIProxySwift for instructions.
+    """
+
 
 struct AIProxyDeviceCheck {
 
@@ -23,7 +33,9 @@ struct AIProxyDeviceCheck {
     /// - Returns: A base 64 encoded DeviceCheck token, if possible
     internal static func getToken() async -> String? {
         guard DCDevice.current.isSupported else {
-            aiproxyLogger.error("DeviceCheck is not available on this device. Are you on the simulator?")
+            if ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] == nil {
+                aiproxyLogger.warning("\(deviceCheckWarning, privacy: .public)")
+            }
             return nil
         }
 

--- a/Sources/AIProxy/AIProxyError.swift
+++ b/Sources/AIProxy/AIProxyError.swift
@@ -41,6 +41,6 @@ public enum AIProxyError: Error {
     /// to place a really low rate limit in the AIProxy dashboard, and then fire a couple requests
     /// from the simulator to reach the rate limit. You wouldn't want to do this once your app is in
     /// production, because the rate limits that you apply will rate limit live users!
-    case unsuccessfulRequest(statusCode: Int, responseBody: String?)
+    case unsuccessfulRequest(statusCode: Int, responseBody: String)
 }
 

--- a/Sources/AIProxy/OpenAI/OpenAIChatCodables.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIChatCodables.swift
@@ -14,10 +14,18 @@ import Foundation
 public struct OpenAIChatCompletionRequestBody: Encodable {
     public let model: String
     public let messages: [OpenAIChatMessage]
+    public let responseFormat: OpenAIChatResponseFormat?
 
-    public init(model: String, messages: [OpenAIChatMessage]) {
+    enum CodingKeys: String, CodingKey {
+        case model
+        case messages
+        case responseFormat = "response_format"
+    }
+
+    public init(model: String, messages: [OpenAIChatMessage], responseFormat: OpenAIChatResponseFormat? = nil) {
         self.model = model
         self.messages = messages
+        self.responseFormat = responseFormat
     }
 }
 
@@ -28,6 +36,22 @@ public struct OpenAIChatMessage: Encodable {
     public init(role: String, content: OpenAIChatContent) {
         self.role = role
         self.content = content
+    }
+}
+
+public enum OpenAIChatResponseFormat: Encodable {
+    case type(String)
+
+    enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .type(let format):
+            try container.encode(format, forKey: .type)
+        }
     }
 }
 

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -48,8 +48,10 @@ public final class OpenAIService {
         }
 
         if (httpResponse.statusCode > 299) {
-            throw AIProxyError.unsuccessfulRequest(statusCode: httpResponse.statusCode,
-                                                   responseBody: String(data: data, encoding: .utf8))
+            throw AIProxyError.unsuccessfulRequest(
+                statusCode: httpResponse.statusCode,
+                responseBody: String(data: data, encoding: .utf8) ?? ""
+            )
         }
 
         return try JSONDecoder().decode(OpenAIChatCompletionResponseBody.self, from: data)

--- a/Tests/AIProxyTests/OpenAIServiceTests.swift
+++ b/Tests/AIProxyTests/OpenAIServiceTests.swift
@@ -8,6 +8,15 @@ final class OpenAIServiceTests: XCTestCase {
         return encoder
     }()
 
+    // MARK: - ResponseFormat
+    func testResponseFormatIsEncodable() {
+        let responseFormat = OpenAIChatResponseFormat.type("json_object")
+        XCTAssertEqual(
+            #"{"type":"json_object"}"#,
+            jsonEncode(responseFormat)
+        )
+    }
+
     // MARK: - ChatContentPart
     func testTextChatContentPartIsEncodable() {
         let chatContentPart: OpenAIChatContentPart = .text("abc")
@@ -121,6 +130,25 @@ final class OpenAIServiceTests: XCTestCase {
             XCTFail()
         }
     }
+
+    func testChatCompletionRequestWithResponseFormatIsEncodableToJson() {
+        let chatRequestBody = OpenAIChatCompletionRequestBody(
+            model: "gpt-4o",
+            messages: [.init(role: "system", content: .text("return JSON only"))],
+            responseFormat: .type("json_object")
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        if let jsonData = try? encoder.encode(chatRequestBody),
+            let jsonStr = String(data: jsonData, encoding: .utf8) {
+            XCTAssertEqual(jsonStr, #"{"messages":[{"content":"return JSON only","role":"system"}],"model":"gpt-4o","response_format":{"type":"json_object"}}"#)
+        } else {
+            XCTFail()
+        }
+    }
+
 
     func testChatCompletionRequestBodyWithImageIsEncodableToJson() {
         let image = create1x1Image()


### PR DESCRIPTION
- OpenAI can return JSON messages as part of the chat completion response. See the `response_format` description [in the OpenAI Chat reference](https://platform.openai.com/docs/api-reference/chat/create) for details.
 
- This patch adds support for JSON messages, and updates the README to include a usage example