### PR TITLE
Add support for streaming chat completions from OpenAI

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -1,4 +1,9 @@
 import OSLog
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
 
 let aiproxyLogger = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "UnknownApp",
@@ -30,6 +35,23 @@ public struct AIProxy {
     ) -> OpenAIService {
         return OpenAIService(partialKey: partialKey, clientID: clientID)
     }
+
+
+#if canImport(AppKit)
+    public static func openAIEncodedImage(
+        image: NSImage,
+        compressionQuality: CGFloat = 1.0
+    ) -> URL? {
+        return OpenAIUtils.encodeImageAsURL(image, compressionQuality)
+    }
+#elseif canImport(UIKit)
+    public static func openAIEncodedImage(
+        image: UIImage,
+        compressionQuality: CGFloat = 1.0
+    ) -> URL? {
+        return OpenAIUtils.encodeImageAsURL(image, compressionQuality)
+    }
+#endif
 
     private init() {
         fatalError("This type is not designed to be instantiated")

--- a/Sources/AIProxy/OpenAI/OpenAIChatCodables.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIChatCodables.swift
@@ -7,25 +7,41 @@
 
 import Foundation
 
+
 // MARK: - Request Codables
 
 /// Chat completion request body. See the OpenAI reference for available fields.
 /// Contributions are welcome if you need something beyond the simple fields I've added so far.
 public struct OpenAIChatCompletionRequestBody: Encodable {
+    // Required
     public let model: String
     public let messages: [OpenAIChatMessage]
+
+    // Optional
     public let responseFormat: OpenAIChatResponseFormat?
+    public var stream: Bool?
+    public var streamOptions: OpenAIChatStreamOptions?
 
     enum CodingKeys: String, CodingKey {
-        case model
         case messages
+        case model
         case responseFormat = "response_format"
+        case stream
+        case streamOptions = "stream_options"
     }
 
-    public init(model: String, messages: [OpenAIChatMessage], responseFormat: OpenAIChatResponseFormat? = nil) {
-        self.model = model
+    public init(
+        model: String,
+        messages: [OpenAIChatMessage],
+        responseFormat: OpenAIChatResponseFormat? = nil,
+        stream: Bool? = nil,
+        streamOptions: OpenAIChatStreamOptions? = nil
+    ) {
         self.messages = messages
+        self.model = model
         self.responseFormat = responseFormat
+        self.stream = stream
+        self.streamOptions = streamOptions
     }
 }
 
@@ -95,12 +111,26 @@ public enum OpenAIChatContentPart: Encodable {
     }
 }
 
+public struct OpenAIChatStreamOptions: Encodable {
+   /// If set, an additional chunk will be streamed before the data: [DONE] message.
+   /// The usage field on this chunk shows the token usage statistics for the entire request,
+   /// and the choices field will always be an empty array. All other chunks will also include
+   /// a usage field, but with a null value.
+   let includeUsage: Bool
+
+   enum CodingKeys: String, CodingKey {
+       case includeUsage = "include_usage"
+   }
+}
+
+
 private struct OpenAIImageURL: Encodable {
     let url: URL
 }
 
 
 // MARK: - Response Codables
+// MARK: Non-streaming
 public struct OpenAIChatCompletionResponseBody: Decodable {
     public let model: String
     public let choices: [OpenAIChatChoice]
@@ -119,4 +149,52 @@ public struct OpenAIChatChoice: Decodable {
 public struct OpenAIChoiceMessage: Decodable {
     public let role: String
     public let content: String
+}
+
+
+// MARK: Streaming
+public struct OpenAIChatCompletionChunk: Codable {
+    public let choices: [OpenAIChunkChoice]
+}
+
+public struct OpenAIChunkChoice: Codable {
+    public let delta: OpenAIChunkDelta
+    public let finishReason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case delta
+        case finishReason = "finish_reason"
+    }
+}
+
+public struct OpenAIChunkDelta: Codable {
+    public let role: String?
+    public let content: String?
+}
+
+
+// MARK: - Internal extensions
+extension OpenAIChatCompletionChunk {
+    /// Creates a ChatCompletionChunk from a streamed line of the /v1/chat/completions response
+    static func from(line: String) -> Self? {
+        guard line.hasPrefix("data: ") else {
+            aiproxyLogger.warning("Received unexpected line from aiproxy: \(line)")
+            return nil
+        }
+
+        guard line != "data: [DONE]" else {
+            aiproxyLogger.debug("Streaming response has finished")
+            return nil
+        }
+
+        guard let chunkJSON = line.dropFirst(6).data(using: .utf8),
+              let chunk = try? JSONDecoder().decode(OpenAIChatCompletionChunk.self, from: chunkJSON) else
+        {
+            aiproxyLogger.warning("Received unexpected JSON from aiproxy: \(line)")
+            return nil
+        }
+
+        // aiproxyLogger.debug("Received a chunk: \(line)")
+        return chunk
+    }
 }

--- a/Sources/AIProxy/OpenAI/OpenAIUtils.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIUtils.swift
@@ -1,0 +1,59 @@
+//
+//  OpenAIUtils.swift
+//
+//
+//  Created by Lou Zell on 7/9/24.
+//
+
+import Foundation
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+
+struct OpenAIUtils {
+#if canImport(AppKit)
+    static func encodeImageAsURL(
+        _ image: NSImage,
+        _ compressionQuality: CGFloat
+    ) -> URL? {
+        guard let jpegData = image.jpegData(compressionQuality: compressionQuality) else {
+            return nil
+        }
+        return URL(string: "data:image/jpeg;base64,\(jpegData.base64EncodedString())")
+    }
+#elseif canImport(UIKit)
+    static func encodeImageAsURL(
+        _ image: UIImage,
+        _ compressionQuality: CGFloat
+    ) -> URL? {
+        guard let jpegData = image.jpegData(compressionQuality: compressionQuality) else {
+            return nil
+        }
+        return URL(string: "data:image/jpeg;base64,\(jpegData.base64EncodedString())")
+    }
+#endif
+    private init() {
+        fatalError("This type is not designed to be instantiated")
+    }
+}
+
+
+#if canImport(AppKit)
+extension NSImage {
+    func jpegData(compressionQuality: CGFloat = 1.0) -> Data? {
+        guard let tiffData = self.tiffRepresentation else {
+            return nil
+        }
+        guard let bitmapImage = NSBitmapImageRep(data: tiffData) else {
+            return nil
+        }
+        let jpegData = bitmapImage.representation(
+            using: .jpeg,
+            properties: [.compressionFactor: compressionQuality]
+        )
+        return jpegData
+    }
+}
+#endif


### PR DESCRIPTION
- Added codable representations for OpenAI's streaming chat objects
- Added `AIProxy.openAIEncodedImage(image:)` helper function to encode a UIImage or NSImage into the format that OpenAI expects
- Added `OpenAIService#streamingChatCompletionRequest` as the entry point for kicking off streaming chats
- Made non-200 status codes available to the caller in the new streaming chat case. This is handy if you'd like to take special action on `429` (rate limited).
- Added streaming example and multi-modal example (sending an image and text in the request) to README.md