### PR TITLE
Drop minimum swift version to 5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
- Support developers using an older version of Xcode
- I tested this back to Xcode 15.0.1, and up to Xcode 16.0 beta 3
- This change addresses the following error:

```
Dependencies could not be resolved because 'aiproxyswift' contains incompatible tools version (5.10.0)
```
