### PR TITLE
Add serviceURL to public parameters

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -16,7 +16,12 @@ public struct AIProxy {
     ///
     /// - Parameters:
     ///   - partialKey: The partial key that was displayed in the AIProxy dashboard when you
-    ///     configured your project
+    ///     submitted your OpenAI key
+    ///
+    ///   - serviceURL: The service URL that was displayed in the AIProxy dashboard when you
+    ///     submitted your OpenAI key. This argument is required for keys that you submitted after
+    ///     July 22nd, 2024. If you are an existing customer that configured your AIProxy project
+    ///     before July 22nd, you may continue to leave this blank.
     ///
     ///   - clientID: An optional clientID to attribute requests to specific users or devices. It is OK to
     ///     leave this blank for most applications. You would set this if you already have an
@@ -31,9 +36,14 @@ public struct AIProxy {
     /// - Returns: An instance of OpenAIService configured and ready to make requests
     public static func openAIService(
         partialKey: String,
+        serviceURL: String? = nil,
         clientID: String? = nil
     ) -> OpenAIService {
-        return OpenAIService(partialKey: partialKey, clientID: clientID)
+        return OpenAIService(
+            partialKey: partialKey,
+            serviceURL: serviceURL,
+            clientID: clientID
+        )
     }
 
 

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -12,26 +12,24 @@ let aiproxyLogger = Logger(
 
 public struct AIProxy {
 
-    /// Entrypoint for AIProxy's OpenAI service
+    /// AIProxy's OpenAI service
     ///
     /// - Parameters:
-    ///   - partialKey: The partial key that was displayed in the AIProxy dashboard when you
-    ///     submitted your OpenAI key
+    ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your OpenAI key.
+    ///     AIProxy takes your OpenAI key, encrypts it, and stores part of the result on our servers. The part that you include
+    ///     here is the other part. Both pieces are needed to decrypt your key and fulfill the request to OpenAI.
     ///
-    ///   - serviceURL: The service URL that was displayed in the AIProxy dashboard when you
-    ///     submitted your OpenAI key. This argument is required for keys that you submitted after
-    ///     July 22nd, 2024. If you are an existing customer that configured your AIProxy project
-    ///     before July 22nd, you may continue to leave this blank.
+    ///   - serviceURL: The service URL is displayed in the AIProxy dashboard when you submit your OpenAI key.
+    ///     This argument is required for keys that you submitted after July 22nd, 2024. If you are an existing customer that
+    ///     configured your AIProxy project before July 22nd, you may continue to leave this blank.
     ///
-    ///   - clientID: An optional clientID to attribute requests to specific users or devices. It is OK to
-    ///     leave this blank for most applications. You would set this if you already have an
-    ///     analytics system, and you'd like to annotate AIProxy requests with IDs that are known
-    ///     to other parts of your system.
+    ///   - clientID: An optional clientID to attribute requests to specific users or devices. It is OK to leave this blank for
+    ///     most applications. You would set this if you already have an analytics system, and you'd like to annotate AIProxy
+    ///     requests with IDs that are known to other parts of your system.
     ///
-    ///     If you do not supply your own clientID, the internals of this lib will generate UUIDs
-    ///     for you. The default UUIDs are persistent on macOS and can be accurately used to
-    ///     attribute all requests to the same device. The default UUIDs on iOS are pesistent until
-    ///     the end user chooses to rotate their vendor identification number.
+    ///     If you do not supply your own clientID, the internals of this lib will generate UUIDs for you. The default UUIDs are
+    ///     persistent on macOS and can be accurately used to attribute all requests to the same device. The default UUIDs
+    ///     on iOS are pesistent until the end user chooses to rotate their vendor identification number.
     ///
     /// - Returns: An instance of OpenAIService configured and ready to make requests
     public static func openAIService(


### PR DESCRIPTION
- New customers are required to pass a `serviceURL` to the `AIProxy.openAIService` method:
  - The service URL is displayed in the AIProxy dashboard when you submit your OpenAI key.
  - This argument is required for keys that you submitted after July 22nd, 2024.
  - If you are an existing customer that configured your AIProxy project before July 22nd, you may continue to leave this blank.

- This PR is in preparation for the v2 release of the backend
- Also added consistent 95 column breaks to the docstring