### PR TITLE
Add Anthropic support

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -45,19 +45,64 @@ public struct AIProxy {
     }
 
 
+    /// AIProxy's Anthropic service
+    ///
+    /// - Parameters:
+    ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your Anthropic key.
+    ///     AIProxy takes your Anthropic key, encrypts it, and stores part of the result on our servers. The part that you include
+    ///     here is the other part. Both pieces are needed to decrypt your key and fulfill the request to Anthropic.
+    ///
+    ///   - serviceURL: The service URL is displayed in the AIProxy dashboard when you submit your Anthropic key.
+    ///
+    ///   - clientID: An optional clientID to attribute requests to specific users or devices. It is OK to leave this blank for
+    ///     most applications. You would set this if you already have an analytics system, and you'd like to annotate AIProxy
+    ///     requests with IDs that are known to other parts of your system.
+    ///
+    ///     If you do not supply your own clientID, the internals of this lib will generate UUIDs for you. The default UUIDs are
+    ///     persistent on macOS and can be accurately used to attribute all requests to the same device. The default UUIDs
+    ///     on iOS are pesistent until the end user chooses to rotate their vendor identification number.
+    ///
+    /// - Returns: An instance of AnthropicService configured and ready to make requests
+    public static func anthropicService(
+        partialKey: String,
+        serviceURL: String,
+        clientID: String? = nil
+    ) -> AnthropicService {
+        return AnthropicService(
+            partialKey: partialKey,
+            serviceURL: serviceURL,
+            clientID: clientID
+        )
+    }
+
 #if canImport(AppKit)
+    public static func encodeImageAsJpeg(
+        image: NSImage,
+        compressionQuality: CGFloat = 1.0
+    ) -> Data? {
+        return AIProxyUtils.encodeImageAsJpeg(image, compressionQuality)
+    }
+
     public static func openAIEncodedImage(
         image: NSImage,
         compressionQuality: CGFloat = 1.0
     ) -> URL? {
-        return OpenAIUtils.encodeImageAsURL(image, compressionQuality)
+        return AIProxyUtils.encodeImageAsURL(image, compressionQuality)
     }
+
 #elseif canImport(UIKit)
+    public static func encodeImageAsJpeg(
+        image: UIImage,
+        compressionQuality: CGFloat = 1.0
+    ) -> Data? {
+        return AIProxyUtils.encodeImageAsJpeg(image, compressionQuality)
+    }
+
     public static func openAIEncodedImage(
         image: UIImage,
         compressionQuality: CGFloat = 1.0
     ) -> URL? {
-        return OpenAIUtils.encodeImageAsURL(image, compressionQuality)
+        return AIProxyUtils.encodeImageAsURL(image, compressionQuality)
     }
 #endif
 

--- a/Sources/AIProxy/AIProxyUtils.swift
+++ b/Sources/AIProxy/AIProxyUtils.swift
@@ -12,23 +12,39 @@ import AppKit
 import UIKit
 #endif
 
-struct OpenAIUtils {
+struct AIProxyUtils {
+
 #if canImport(AppKit)
+    static func encodeImageAsJpeg(
+        _ image: NSImage,
+        _ compressionQuality: CGFloat
+    ) -> Data? {
+        return image.jpegData(compressionQuality: compressionQuality)
+    }
+
     static func encodeImageAsURL(
         _ image: NSImage,
         _ compressionQuality: CGFloat
     ) -> URL? {
-        guard let jpegData = image.jpegData(compressionQuality: compressionQuality) else {
+        guard let jpegData = self.encodeImageAsJpeg(image, compressionQuality) else {
             return nil
         }
         return URL(string: "data:image/jpeg;base64,\(jpegData.base64EncodedString())")
     }
+
 #elseif canImport(UIKit)
+    static func encodeImageAsJpeg(
+        _ image: UIImage,
+        _ compressionQuality: CGFloat
+    ) -> Data? {
+        return image.jpegData(compressionQuality: compressionQuality)
+    }
+
     static func encodeImageAsURL(
         _ image: UIImage,
         _ compressionQuality: CGFloat
     ) -> URL? {
-        guard let jpegData = image.jpegData(compressionQuality: compressionQuality) else {
+        guard let jpegData = self.encodeImageAsJpeg(image, compressionQuality) else {
             return nil
         }
         return URL(string: "data:image/jpeg;base64,\(jpegData.base64EncodedString())")

--- a/Sources/AIProxy/Anthropic/AnthropicMessageRequestBody.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicMessageRequestBody.swift
@@ -1,0 +1,448 @@
+//
+//  AnthropicMessageRequestBody.swift
+//
+//
+//  Created by Lou Zell on 7/25/24.
+//
+
+import Foundation
+
+/// All docstrings in this file are from: https://docs.anthropic.com/en/api/messages
+/// Important: to encode this type, please use the `safeEncode` method. Special handling is applied
+/// to accommodate a flexible JSON schema for Anthropic tool use.
+public struct AnthropicMessageRequestBody: Encodable {
+    // Required
+
+    /// The maximum number of tokens to generate before stopping.
+    ///
+    /// Note that our models may stop before reaching this maximum. This parameter only specifies the
+    /// absolute maximum number of tokens to generate.
+    ///
+    /// Different models have different maximum values for this parameter. See the 'Max output'
+    /// value for each model listed here: https://docs.anthropic.com/en/docs/models-overview
+    public let maxTokens: Int
+
+    /// Input messages.
+    ///
+    /// Our models are trained to operate on alternating user and assistant conversational turns.
+    /// When creating a new Message, you specify the prior conversational turns with the messages
+    /// parameter, and the model then generates the next Message in the conversation.
+    ///
+    /// Each input message must be an object with a role and content. You can specify a single
+    /// user-role message, or you can include multiple user and assistant messages. The first
+    /// message must always use the user role.
+    ///
+    /// If the final message uses the assistant role, the response content will continue
+    /// immediately from the content in that message. This can be used to constrain part of the
+    /// model's response.
+    ///
+    /// Example with a single user message:
+    ///
+    ///     [{"role": "user", "content": "Hello, Claude"}]
+    ///
+    /// Example with multiple conversational turns:
+    ///
+    ///     [
+    ///       {"role": "user", "content": "Hello there."},
+    ///       {"role": "assistant", "content": "Hi, I'm Claude. How can I help you?"},
+    ///       {"role": "user", "content": "Can you explain LLMs in plain English?"},
+    ///     ]
+    ///
+    /// Example with a partially-filled response from Claude:
+    ///
+    ///     [
+    ///       {"role": "user", "content": "What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun"},
+    ///       {"role": "assistant", "content": "The best answer is ("},
+    ///     ]
+    ///
+    /// Starting with Claude 3 models, you can also send image content blocks:
+    ///
+    ///     {"role": "user", "content": [
+    ///       {
+    ///         "type": "image",
+    ///         "source": {
+    ///           "type": "base64",
+    ///           "media_type": "image/jpeg",
+    ///           "data": "/9j/4AAQSkZJRg...",
+    ///         }
+    ///       },
+    ///       {"type": "text", "text": "What is in this image?"}
+    ///     ]}
+    ///
+    /// See this for more input examples: https://docs.anthropic.com/en/api/messages-examples#vision
+    public let messages: [AnthropicInputMessage]
+
+    /// The model that will complete your prompt.
+    /// See this resource for a list of model strings you may use:
+    /// https://docs.anthropic.com/en/docs/about-claude/models#model-names
+    public let model: String
+
+
+    // Optional
+    /// An object describing metadata about the request.
+    public let metadata: AnthropicRequestMetadata?
+
+    /// Custom text sequences that will cause the model to stop generating.
+    ///
+    /// Our models will normally stop when they have naturally completed their turn, which will
+    /// result in a response stop_reason of "end_turn".
+    ///
+    /// If you want the model to stop generating when it encounters custom strings of text, you can
+    /// use the stop_sequences parameter. If the model encounters one of the custom sequences, the
+    /// response stop_reason value will be "stop_sequence" and the response stop_sequence value
+    /// will contain the matched stop sequence.
+    public let stopSequences: [String]?
+
+    /// Whether to incrementally stream the response using server-sent events.
+    /// See https://docs.anthropic.com/en/api/messages-streaming
+    public var stream: Bool?
+
+    /// A system prompt is a way of providing context and instructions to Claude, such as
+    /// specifying a particular goal or role. See our guide to system prompts.
+    public let system: String?
+
+    /// Amount of randomness injected into the response.
+    ///
+    /// Defaults to 1.0. Ranges from 0.0 to 1.0. Use temperature closer to 0.0 for analytical /
+    /// multiple choice, and closer to 1.0 for creative and generative tasks.
+    ///
+    /// Note that even with temperature of 0.0, the results will not be fully deterministic.
+    public let temperature: Double?
+
+    /// How the model should use the provided tools. The model can use a specific tool, any available tool, or decide by itself.
+    /// More information here: https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+    public let toolChoice: AnthropicToolChoice?
+
+    /// Definitions of tools that the model may use.
+    ///
+    /// If you include tools in your API request, the model may return `tool_use` content blocks that
+    /// represent the model's use of those tools. You can then run those tools using the tool input
+    /// generated by the model and then optionally return results back to the model using
+    /// `tool_result` content blocks.
+    ///
+    /// Each tool definition includes:
+    ///
+    /// - name: Name of the tool.
+    /// - description: Optional, but strongly-recommended description of the tool.
+    /// - input_schema: JSON schema for the tool input shape that the model will produce in tool_use output content blocks.
+    ///
+    /// For example, if you defined tools as:
+    ///
+    ///     [
+    ///       {
+    ///         "name": "get_stock_price",
+    ///         "description": "Get the current stock price for a given ticker symbol.",
+    ///         "input_schema": {
+    ///           "type": "object",
+    ///           "properties": {
+    ///             "ticker": {
+    ///               "type": "string",
+    ///               "description": "The stock ticker symbol, e.g. AAPL for Apple Inc."
+    ///             }
+    ///           },
+    ///           "required": ["ticker"]
+    ///         }
+    ///       }
+    ///     ]
+    ///
+    /// And then asked the model "What's the S&P 500 at today?", the model might produce tool_use
+    /// content blocks in the response like this:
+    ///
+    ///     [
+    ///       {
+    ///         "type": "tool_use",
+    ///         "id": "toolu_01D7FLrfh4GYq7yT1ULFeyMV",
+    ///         "name": "get_stock_price",
+    ///         "input": { "ticker": "^GSPC" }
+    ///       }
+    ///     ]
+    ///
+    /// You might then run your get_stock_price tool with {"ticker": "^GSPC"} as an input, and
+    /// return the following back to the model in a subsequent user message:
+    ///
+    ///     [
+    ///       {
+    ///         "type": "tool_result",
+    ///         "tool_use_id": "toolu_01D7FLrfh4GYq7yT1ULFeyMV",
+    ///         "content": "259.75 USD"
+    ///       }
+    ///     ]
+    ///
+    /// Tools can be used for workflows that include running client-side tools and functions, or
+    /// more generally whenever you want the model to produce a particular JSON structure of
+    /// output.
+    ///
+    /// See this guide for more details: https://docs.anthropic.com/en/docs/tool-use
+    public var tools: [AnthropicTool]?
+
+    /// Only sample from the top K options for each subsequent token.
+    ///
+    /// Used to remove "long tail" low probability responses.
+    /// Learn more technical details here: https://towardsdatascience.com/how-to-sample-from-language-models-682bceb97277
+    ///
+    /// Recommended for advanced use cases only. You usually only need to use `temperature`.
+    public let topK: Int?
+
+    /// Use nucleus sampling.
+    ///
+    /// In nucleus sampling, we compute the cumulative distribution over all the options for each
+    /// subsequent token in decreasing probability order and cut it off once it reaches a
+    /// particular probability specified by `top_p`.
+    ///
+    /// You should either alter `temperature` or `top_p`, but not both.
+    ///
+    /// Recommended for advanced use cases only. You usually only need to use `temperature`.
+    public let topP: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        // Required
+        case maxTokens = "max_tokens"
+        case messages
+        case model
+
+        // Optional
+        case metadata
+        case stopSequences = "stop_sequences"
+        case stream
+        case system
+        case temperature
+        case toolChoice = "tool_choice"
+        case tools
+        case topK = "top_k"
+        case topP = "top_p"
+    }
+
+    // This memberwise initializer is autogenerated.
+    // To regenerate, use `cmd-shift-a` > Generate Memberwise Initializer
+    // To format, place the cursor in the initializer's parameter list and use `ctrl-m`
+    public init(
+        maxTokens: Int,
+        messages: [AnthropicInputMessage],
+        model: String,
+        metadata: AnthropicRequestMetadata? = nil,
+        stopSequences: [String]? = nil,
+        stream: Bool? = nil,
+        system: String? = nil,
+        temperature: Double? = nil,
+        toolChoice: AnthropicToolChoice? = nil,
+        tools: [AnthropicTool]? = nil,
+        topK: Int? = nil,
+        topP: Double? = nil
+    ) {
+        self.maxTokens = maxTokens
+        self.messages = messages
+        self.model = model
+        self.metadata = metadata
+        self.stopSequences = stopSequences
+        self.stream = stream
+        self.system = system
+        self.temperature = temperature
+        self.toolChoice = toolChoice
+        self.tools = tools
+        self.topK = topK
+        self.topP = topP
+    }
+}
+
+
+public enum AnthropicImageMediaType: String {
+    case jpeg = "image/jpeg"
+    case png = "image/png"
+    case gif = "image/gif"
+    case webp = "image/webp"
+}
+
+
+public enum AnthropicInputContent: Encodable {
+    case image(mediaType: AnthropicImageMediaType, data: String)
+    case text(String)
+
+    private enum CodingKeys: String, CodingKey {
+        case image
+        case source
+        case text
+        case type
+    }
+
+    private enum SourceCodingKeys: String, CodingKey {
+        case type
+        case mediaType = "media_type"
+        case data
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .image(mediaType: let mediaType, data: let data):
+            try container.encode("image", forKey: .type)
+            var nested = container.nestedContainer(keyedBy: SourceCodingKeys.self, forKey: .source)
+            try nested.encode("base64", forKey: .type)
+            try nested.encode(mediaType.rawValue, forKey: .mediaType)
+            try nested.encode(data, forKey: .data)
+        case .text(let txt):
+            try container.encode("text", forKey: .type)
+            try container.encode(txt, forKey: .text)
+        }
+    }
+}
+
+
+public struct AnthropicInputMessage: Encodable {
+    public init(
+        content: [AnthropicInputContent],
+        role: AnthropicInputMessageRole
+    ) {
+        self.content = content
+        self.role = role
+    }
+
+    /// The content of the input to send to Claude.
+    /// Supports text, images, and tools
+    public let content: [AnthropicInputContent]
+
+    /// One of `user` or `assistant`.
+    /// Note that if you want to include a system prompt, you can use the top-level `system`
+    /// parameter on `AnthropicMessageRequestBody`
+    public let role: AnthropicInputMessageRole
+}
+
+
+public enum AnthropicInputMessageRole: String, Encodable {
+    case assistant
+    case user
+}
+
+
+public struct AnthropicRequestMetadata: Encodable {
+    /// An external identifier for the user who is associated with the request.
+    ///
+    /// This should be a uuid, hash value, or other opaque identifier. Anthropic may use this id to
+    /// help detect abuse. Do not include any identifying information such as name, email address, or
+    /// phone number.
+    let userID: String?
+}
+
+
+public enum AnthropicToolChoice: Encodable {
+    case any
+    case auto
+    case tool(name: String)
+}
+
+
+public struct AnthropicTool: Encodable {
+    /// Description of what this tool does.
+    /// Tool descriptions should be as detailed as possible. The more information that the
+    /// model has about what the tool is and how to use it, the better it will perform. You can
+    /// use natural language descriptions to reinforce important aspects of the tool input JSON
+    /// schema.
+    public let description: String
+
+    /// A JSON schema for this tool's input.
+    /// This defines the shape of the `input` that your tool accepts and that the model will
+    /// produce. For example:
+    ///
+    ///     {
+    ///       "type": "object",
+    ///       "properties": {
+    ///         "location": {
+    ///           "type": "string",
+    ///           "description": "The city and state, e.g. San Francisco, CA"
+    ///         }
+    ///       },
+    ///       "required": ["location"]
+    ///     }
+    public var inputSchema: [String: Any]
+
+    /// The tool name.
+    public let name: String
+
+    private enum CodingKeys: String, CodingKey {
+        case description
+        case inputSchema = "input_schema"
+        case name
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.description, forKey: .description)
+        try container.encode(self.name, forKey: .name)
+        if self.inputSchema.count > 0 {
+            throw AIProxyError.assertion("Inconsistency. Expected serialization using escape hatch.")
+        }
+    }
+
+    // This memberwise initializer is autogenerated.
+    // To regenerate, use `cmd-shift-a` > Generate Memberwise Initializer
+    // To format, place the cursor in the initializer's parameter list and use `ctrl-m`
+    public init(
+        description: String,
+        inputSchema: [String : Any],
+        name: String
+    ) {
+        self.description = description
+        self.inputSchema = inputSchema
+        self.name = name
+    }
+}
+
+
+// Special handling of tool encoding
+internal extension AnthropicMessageRequestBody {
+    func safeEncode() throws -> Data {
+        if self.tools == nil {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+            return try encoder.encode(self)
+        }
+
+        // This request contains tools, which requires special handling
+        return try encodeWithTools()
+    }
+
+    /// Provides an escape hatch for users to supply the tool schema using [String: Any], instead of enforcing codables
+    /// for all variations of a flexible JSON schema:
+    private func encodeWithTools() throws -> Data {
+        guard let originalTools = self.tools else {
+            throw AIProxyError.assertion("Should only call encodeWithTools if the request contains tools")
+        }
+
+        var copy = self
+
+        // Remove any inputSchema that the user supplied. They are of type [String: Any]
+        // and not compatible with Encodable:
+        var indicesToMutate = [Int]()
+        for (idx, _) in (copy.tools ?? []).enumerated() {
+            copy.tools![idx].inputSchema = [:]
+            indicesToMutate.append(idx)
+        }
+
+        // Now the encoder is safe to use:
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let jsonData = try encoder.encode(copy)
+
+        // Then deserialize to a json object
+        guard var jsonObject = try JSONSerialization.jsonObject(
+            with: jsonData,
+            options: []
+        ) as? [String: Any] else
+        {
+            throw AIProxyError.assertion("Could not convert request into a JSONObject")
+        }
+
+        guard var jsonTools = jsonObject["tools"] as? [[String: Any]],
+              jsonTools.count == originalTools.count else
+        {
+            throw AIProxyError.assertion("Different number of jsonTools than originalTools")
+        }
+
+        // Then drop the tools into the dictionary
+        for idx in indicesToMutate {
+            jsonTools[idx]["input_schema"] = originalTools[idx].inputSchema
+        }
+        jsonObject["tools"] = jsonTools
+
+        return try JSONSerialization.data(withJSONObject: jsonObject, options: [.sortedKeys])
+    }
+}

--- a/Sources/AIProxy/Anthropic/AnthropicMessageResponseBody.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicMessageResponseBody.swift
@@ -1,0 +1,123 @@
+//
+//  AnthropicMessageResponseBody.swift
+//
+//
+//  Created by Lou Zell on 7/28/24.
+//
+
+import Foundation
+
+/// All docstrings in this file are from: https://docs.anthropic.com/en/api/messages
+/// Important: to decode this type, please use the `safeDecode` static method. Special handling is applied
+/// to accommodate a flexible JSON schema for Anthropic tool use.
+public struct AnthropicMessageResponseBody: Decodable {
+    public var content: [AnthropicMessageResponseContent]
+    public let id: String
+    public let model: String
+    public let role: String
+    public let stopReason: String?
+    public let stopSequence: String?
+    public let type: String
+    public let usage: AnthropicMessageUsage
+
+    private enum CodingKeys: String, CodingKey {
+        case content
+        case id
+        case model
+        case role
+        case stopReason = "stop_reason"
+        case stopSequence = "stop_sequence"
+        case type
+        case usage
+    }
+}
+
+
+public enum AnthropicMessageResponseContent: Decodable {
+    case text(String)
+    case toolUse(id: String, name: String, input: [String: Any])
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case text
+        case id
+        case name
+        case input
+    }
+
+    private enum ContentType: String, Decodable {
+        case text
+        case toolUse = "tool_use"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(ContentType.self, forKey: .type)
+        switch type {
+        case .text:
+            let value = try container.decode(String.self, forKey: .text)
+            self = .text(value)
+        case .toolUse:
+            throw AIProxyError.assertion("Inconsistency. Expected deserialization using escape hatch.")
+        }
+    }
+}
+
+
+public struct AnthropicMessageUsage: Decodable {
+    let inputTokens: Int
+    let outputTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case inputTokens = "input_tokens"
+        case outputTokens = "output_tokens"
+    }
+}
+
+
+// Special handling of tool decoding
+internal extension AnthropicMessageResponseBody {
+    static func safeDecode(from data: Data) throws -> AnthropicMessageResponseBody {
+        guard var jsonObject = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else
+        {
+            throw AIProxyError.assertion("Could not convert response into a JSONObject")
+        }
+
+        // If there are any 'type': "tool_use", pluck them out
+        var indicesToPluck = [Int]()
+        let contents = (jsonObject["content"] as? [[String: Any]]) ?? []
+        for (index, messageContent) in contents.enumerated() {
+            if (messageContent["type"] as? String == "tool_use") {
+                indicesToPluck.append(index)
+            }
+        }
+
+        // Build up the replacement content
+        var replacement = [[String: Any]]()
+        let idxSet = Set(indicesToPluck)
+        for (index, messageContent) in contents.enumerated() {
+            if (!idxSet.contains(index)) {
+                replacement.append(messageContent)
+            }
+        }
+        jsonObject["content"] = replacement
+
+        // Use decodable on the remainder
+        let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        let decoder = JSONDecoder()
+        var mappedResult = try decoder.decode(Self.self, from: data)
+
+        // Reinsert the plucked out content
+        for idx in indicesToPluck {
+            // This algorithm assumes the indices are sorted in ascending order.
+            // Insert them in their proper location.
+            guard let toolId = contents[idx]["id"] as? String,
+                  let toolName = contents[idx]["name"] as? String,
+                  let toolInput = contents[idx]["input"] as? [String: Any] else {
+                throw AIProxyError.assertion("Unexpected Anthropic tool fields in the response")
+            }
+            mappedResult.content.insert(.toolUse(id: toolId, name: toolName, input: toolInput), at: idx)
+        }
+        return mappedResult
+    }
+}

--- a/Sources/AIProxy/Anthropic/AnthropicService.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicService.swift
@@ -1,0 +1,120 @@
+//
+//  AnthropicService.swift
+//
+//
+//  Created by Lou Zell on 7/25/24.
+//
+
+import Foundation
+
+public final class AnthropicService {
+    private let secureDelegate = AIProxyCertificatePinningDelegate()
+    private let partialKey: String
+    private let serviceURL: String
+    private let clientID: String?
+
+    /// Creates an instance of OpenAIService. Note that the initializer is not public.
+    /// Customers are expected to use the factory `AIProxy.openAIService` defined in AIProxy.swift
+    internal init(partialKey: String, serviceURL: String, clientID: String?) {
+        self.partialKey = partialKey
+        self.serviceURL = serviceURL
+        self.clientID = clientID
+    }
+
+    /// Initiates a non-streaming request to /v1/messages.
+    ///
+    /// - Parameters:
+    ///   - messageRequestBody: The request body to send to aiproxy and anthropic. See this reference:
+    ///                         https://docs.anthropic.com/en/api/messages
+    /// - Returns: The message response, See this reference:
+    ///            https://platform.openai.com/docs/api-reference/chat/object
+    public func messageRequest(
+        body: AnthropicMessageRequestBody
+    ) async throws -> AnthropicMessageResponseBody {
+        var body = body
+        body.stream = false
+        let session = self.getServiceSession()
+        let request = try await buildAIProxyRequest(
+            partialKey: self.partialKey,
+            serviceURL: self.serviceURL,
+            clientID: self.clientID,
+            postBody: try body.safeEncode(),
+            path: "/v1/messages",
+            contentType: "application/json"
+        )
+        let (data, res) = try await session.data(for: request)
+        guard let httpResponse = res as? HTTPURLResponse else {
+            throw AIProxyError.assertion("Network response is not an http response")
+        }
+
+        if (httpResponse.statusCode > 299) {
+            throw AIProxyError.unsuccessfulRequest(
+                statusCode: httpResponse.statusCode,
+                responseBody: String(data: data, encoding: .utf8) ?? ""
+            )
+        }
+    
+        return try AnthropicMessageResponseBody.safeDecode(from: data)
+    }
+
+    private func getServiceSession() -> URLSession {
+        if self.serviceURL.starts(with: "http://localhost") {
+            return URLSession(configuration: .default)
+        }
+        return URLSession(
+            configuration: .default,
+            delegate: self.secureDelegate,
+            delegateQueue: nil
+        )
+    }
+}
+
+// MARK: - Private Helpers
+
+/// Builds and AI Proxy request.
+/// Used for both streaming and non-streaming chat.
+private func buildAIProxyRequest(
+    partialKey: String,
+    serviceURL: String,
+    clientID: String?,
+    postBody: Data,
+    path: String,
+    contentType: String
+) async throws -> URLRequest {
+    let deviceCheckToken = await AIProxyDeviceCheck.getToken()
+    let clientID = clientID ?? AIProxyIdentifier.getClientID()
+    let baseURL = serviceURL
+
+    guard var urlComponents = URLComponents(string: baseURL) else {
+        throw AIProxyError.assertion(
+            "Could not create urlComponents, please check the aiproxyEndpoint constant"
+        )
+    }
+
+    urlComponents.path = urlComponents.path.appending(path)
+    guard let url = urlComponents.url else {
+        throw AIProxyError.assertion("Could not create a request URL")
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = postBody
+    request.addValue(contentType, forHTTPHeaderField: "Content-Type")
+    request.addValue(partialKey, forHTTPHeaderField: "aiproxy-partial-key")
+
+    if let clientID = clientID {
+        request.addValue(clientID, forHTTPHeaderField: "aiproxy-client-id")
+    }
+
+    if let deviceCheckToken = deviceCheckToken {
+        request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
+    }
+
+#if DEBUG && targetEnvironment(simulator)
+    if let deviceCheckBypass = ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] {
+        request.addValue(deviceCheckBypass, forHTTPHeaderField: "aiproxy-devicecheck-bypass")
+    }
+#endif
+
+    return request
+}

--- a/Tests/AIProxyTests/AnthropicMessageRequestTests.swift
+++ b/Tests/AIProxyTests/AnthropicMessageRequestTests.swift
@@ -1,0 +1,92 @@
+//
+//  File.swift
+//
+//
+//  Created by Lou Zell on 7/28/24.
+//
+
+import Foundation
+
+import XCTest
+import Foundation
+@testable import AIProxy
+
+
+final class AnthropicMessageRequestTests: XCTestCase {
+
+    func testRequestIsEncodable() {
+        let request = AnthropicMessageRequestBody(
+            maxTokens: 1024,
+            messages: [
+                AnthropicInputMessage(content: [.text("hello world")], role: .user)
+            ],
+            model: "claude-3-5-sonnet-20240620"
+        )
+        let data = try! request.safeEncode()
+        XCTAssertEqual(
+            #"{"max_tokens":1024,"messages":[{"content":[{"text":"hello world","type":"text"}],"role":"user"}],"model":"claude-3-5-sonnet-20240620"}"#
+            ,
+            String(data: data, encoding: .utf8)!
+        )
+    }
+
+    func testRequestWithToolUseIsEncodable() {
+        let request = AnthropicMessageRequestBody(
+            maxTokens: 1024,
+            messages: [
+                .init(
+                    content: [.text("What's the temp in San Francisco?")],
+                    role: .user
+                )
+            ],
+            model: "claude-3-5-sonnet-20240620",
+            tools: [
+                .init(
+                    description: "Call this function when the user wants the weather",
+                    inputSchema: [
+                        "type": "object",
+                        "properties": [
+                            "location": [
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA"
+                            ],
+                            "unit": [
+                              "type": "string",
+                              "enum": ["celsius", "fahrenheit"],
+                              "description": "The unit of temperature. Default to fahrenheit",
+                              "default": "fahrenheit"
+                            ]
+                        ],
+                        "required": ["location", "unit"]
+                    ],
+                    name: "get_weather"
+                )
+            ]
+        )
+        let data = try! request.safeEncode()
+        XCTAssertEqual(
+            #"{"max_tokens":1024,"messages":[{"content":[{"text":"What's the temp in San Francisco?","type":"text"}],"role":"user"}],"model":"claude-3-5-sonnet-20240620","tools":[{"description":"Call this function when the user wants the weather","input_schema":{"properties":{"location":{"description":"The city and state, e.g. San Francisco, CA","type":"string"},"unit":{"default":"fahrenheit","description":"The unit of temperature. Default to fahrenheit","enum":["celsius","fahrenheit"],"type":"string"}},"required":["location","unit"],"type":"object"},"name":"get_weather"}]}"#
+            ,
+            String(data: data, encoding: .utf8)!
+        )
+    }
+
+    func testRequestWithImageIsEncodable() {
+        let request = AnthropicMessageRequestBody(
+            maxTokens: 1024,
+            messages: [
+                AnthropicInputMessage(content: [.image(
+                    mediaType: .jpeg,
+                    data: "encoded-image"
+                )], role: .user)
+            ],
+            model: "claude-3-5-sonnet-20240620"
+        )
+        let data = try! request.safeEncode()
+        XCTAssertEqual(
+            #"{"max_tokens":1024,"messages":[{"content":[{"source":{"data":"encoded-image","media_type":"image\/jpeg","type":"base64"},"type":"image"}],"role":"user"}],"model":"claude-3-5-sonnet-20240620"}"#
+            ,
+            String(data: data, encoding: .utf8)!
+        )
+    }
+}

--- a/Tests/AIProxyTests/AnthropicMessageResponseTests.swift
+++ b/Tests/AIProxyTests/AnthropicMessageResponseTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+import Foundation
+@testable import AIProxy
+
+
+final class AnthropicMessageResponseTests: XCTestCase {
+
+    func testMessageResponseIsDecodable() {
+        let sampleResponse = """
+        {
+          "id": "msg_01XVo4dCtcbBTds8pG1BC6Xf",
+          "type": "message",
+          "role": "assistant",
+          "model": "claude-3-5-sonnet-20240620",
+          "content": [
+            {
+              "type": "text",
+              "text": "Hello!"
+            }
+          ],
+          "stop_reason": "end_turn",
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 9,
+            "output_tokens": 28
+          }
+        }
+        """
+        let decoder = JSONDecoder()
+
+        let res = try! decoder.decode(
+            AnthropicMessageResponseBody.self,
+            from: sampleResponse.data(using: .utf8)!
+        )
+        switch res.content.first! {
+        case .text(let string):
+            XCTAssertEqual("Hello!", string)
+        default:
+            XCTFail()
+        }
+    }
+
+    func testMessageResponseWithToolUseIsDecodable() {
+        let sampleResponse = """
+        {
+          "id": "msg_011UvQXaEMMwmN4kapqwUpN2",
+          "type": "message",
+          "role": "assistant",
+          "model": "claude-3-5-sonnet-20240620",
+          "content": [
+            {
+              "type": "text",
+              "text": "To get Nvidia's stock price, we need to use the stock symbol for Nvidia, which is NVDA. I'll use the available function to retrieve this information for you."
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01GZovj2vHs5AKsNAshWFgUT",
+              "name": "get_stock_symbol",
+              "input": {
+                "ticker": "NVDA"
+              }
+            }
+          ],
+          "stop_reason": "tool_use",
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 389,
+            "output_tokens": 96
+          }
+        }
+        """
+
+        let res = try! AnthropicMessageResponseBody.safeDecode(from: sampleResponse.data(using: .utf8)!)
+
+        switch res.content.last! {
+        case .toolUse(id: _, name: let toolName, input: let input):
+            XCTAssertEqual("get_stock_symbol", toolName)
+            XCTAssertEqual("NVDA", input["ticker"] as? String)
+        default:
+            XCTFail()
+        }
+    }
+}


### PR DESCRIPTION
- Added support for proxying Anthropic API calls through AIProxy
- Added README examples for:
  - Sending a text message to Claude
  - Sending a multi-modal (text and image) message to Claude
  - Sending a tool schema to Claude
 
The tool usage is interesting in that the request body accepts a `[String: Any]` schema to define the schema that Claude should adhere to. The special handling that juggles a mix of Encodable with JSONSerialization is related to this use case.