### PR TITLE
Add OpenMeteo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,42 @@ For a SwiftUI example, see [this gist](https://gist.github.com/lzell/a878b787f24
     }
 
 
+### How to fetch the weather with OpenMeteo
+
+This pattern is slightly different than the others, because OpenMeteo has an official lib that
+we'd like to rely on. To run the snippet below, you'll need to add AIProxySwift and
+OpenMeteoSDK to your Xcode project. Add OpenMeteoSDK:
+
+- In Xcode, go to `File > Add Package Dependences`
+- Enter the package URL `https://github.com/open-meteo/sdk`
+- Choose your dependency rule (e.g. the `main` branch for the most up-to-date package)
+
+Next, use AIProxySwift's core functionality to get a URLRequest and URLSession, and pass those
+into the OpenMeteoSDK:
+
+
+    import AIProxy
+    import OpenMeteoSdk
+
+    do {
+        let request = try await AIProxy.request(
+            partialKey: "partial-key-from-your-aiproxy-developer-dashboard",
+            serviceURL: "service-url-from-your-aiproxy-developer-dashboard",
+            proxyPath: "/v1/forecast?latitude=52.52&longitude=13.41&hourly=temperature_2m&format=flatbuffers"
+        )
+        let session = AIProxy.session()
+        let responses = try await WeatherApiResponse.fetch(request: request, session: session)
+        // Do something with `responses`. For a usage example, follow these instructions:
+        // 1. Navigate to https://open-meteo.com/en/docs
+        // 2. Scroll to the 'API response' section
+        // 3. Tap on Swift
+        // 4. Scroll to 'Usage'
+        print(responses)
+    } catch {
+        print("Could not fetch the weather: \(error.localizedDescription)")
+    }
+
+
 ### Specify your own `clientID` to annotate requests
 
 If your app already has client or user IDs that you want to annotate AIProxy requests with,

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -11,6 +11,53 @@ let aiproxyLogger = Logger(
 )
 
 public struct AIProxy {
+    /// - Parameters:
+    ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your provider's key.
+    ///     AIProxy takes your key, encrypts it, and stores part of the result on our servers. The part that you include
+    ///     here is the other part. Both pieces are needed to decrypt your key and fulfill the request to your provider.
+    ///
+    ///   - serviceURL: The service URL is displayed in the AIProxy dashboard when you submit your provider's key.
+    ///
+    ///   - clientID: An optional clientID to attribute requests to specific users or devices. It is OK to leave this blank for
+    ///     most applications. You would set this if you already have an analytics system, and you'd like to annotate AIProxy
+    ///     requests with IDs that are known to other parts of your system.
+    ///
+    ///     If you do not supply your own clientID, the internals of this lib will generate UUIDs for you. The default UUIDs are
+    ///     persistent on macOS and can be accurately used to attribute all requests to the same device. The default UUIDs
+    ///     on iOS are pesistent until the end user chooses to rotate their vendor identification number.
+    ///
+    ///   - proxyPath: The path that you want to forward the request onto. For example, if you are trying to reach
+    ///     api.example.com/v1/chat/completions, then you would set the proxyPath to `/v1/chat/completions`
+    ///
+    ///   - body: An optional request body
+    ///
+    ///   - verb: The HTTP verb to use for this request. If you leave the default selection of 'automatic', then requests that
+    ///     contain a body will default to `POST` while requests with no body will default to `GET`
+    ///
+    /// - Returns: A request containing all headers that AIProxy expects. The request is ready to be used with a url session
+    ///            that you create with `AIProxy.session()`
+    public static func request(
+        partialKey: String,
+        serviceURL: String,
+        clientID: String? = nil,
+        proxyPath: String,
+        body: Data? = nil,
+        verb: AIProxyHTTPVerb = .automatic
+    ) async throws -> URLRequest {
+        return try await AIProxyURLRequest.create(
+            partialKey: partialKey,
+            serviceURL: serviceURL,
+            clientID: clientID,
+            proxyPath: proxyPath,
+            body: body,
+            verb: verb
+        )
+    }
+
+    /// Returns a URLSession for communication with AIProxy.
+    public static func session() -> URLSession {
+        return AIProxyURLSession.create()
+    }
 
     /// AIProxy's OpenAI service
     ///
@@ -43,7 +90,6 @@ public struct AIProxy {
             clientID: clientID
         )
     }
-
 
     /// AIProxy's Anthropic service
     ///

--- a/Sources/AIProxy/AIProxyHTTPVerb.swift
+++ b/Sources/AIProxy/AIProxyHTTPVerb.swift
@@ -1,0 +1,26 @@
+//
+//  AIProxyHTTPVerb.swift
+//
+//
+//  Created by Lou Zell on 8/6/24.
+//
+
+import Foundation
+
+/// The HTTP verb to associate with a request.
+/// If you select 'automatic', a request with a body will default to 'POST' while a request without a body will default to 'GET'
+public enum AIProxyHTTPVerb: String {
+    case automatic
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+
+    func toString(hasBody: Bool) -> String {
+        if self != .automatic {
+            return self.rawValue
+        }
+        return hasBody ? AIProxyHTTPVerb.post.rawValue : AIProxyHTTPVerb.get.rawValue
+    }
+}

--- a/Sources/AIProxy/AIProxyURLRequest.swift
+++ b/Sources/AIProxy/AIProxyURLRequest.swift
@@ -1,0 +1,66 @@
+//
+//  AIProxyURLRequest.swift
+//
+//
+//  Created by Lou Zell on 8/6/24.
+//
+
+import Foundation
+
+struct AIProxyURLRequest {
+
+    /// Creates a URLRequest that is configured for use with an AIProxy URLSession.
+    static func create(
+        partialKey: String,
+        serviceURL: String,
+        clientID: String?,
+        proxyPath: String,
+        body: Data?,
+        verb: AIProxyHTTPVerb
+    ) async throws -> URLRequest {
+        let deviceCheckToken = await AIProxyDeviceCheck.getToken()
+
+        guard var urlComponents = URLComponents(string: serviceURL),
+              let proxyPathComponents = URLComponents(string: proxyPath) else {
+            throw AIProxyError.assertion(
+                "Could not create urlComponents, please check the aiproxyEndpoint constant"
+            )
+        }
+
+        urlComponents.path += proxyPathComponents.path
+        urlComponents.queryItems = proxyPathComponents.queryItems
+
+        guard let url = urlComponents.url else {
+            throw AIProxyError.assertion("Could not create a request URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = verb.toString(hasBody: body != nil)
+        request.httpBody = body
+        request.addValue(partialKey, forHTTPHeaderField: "aiproxy-partial-key")
+
+        if let clientID = (clientID ?? AIProxyIdentifier.getClientID()) {
+            request.addValue(clientID, forHTTPHeaderField: "aiproxy-client-id")
+        }
+
+        if let deviceCheckToken = deviceCheckToken {
+            request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
+        }
+
+        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            request.addValue("v1|\(appVersion)", forHTTPHeaderField: "aiproxy-metadata")
+        }
+
+    #if DEBUG && targetEnvironment(simulator)
+        if let deviceCheckBypass = ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] {
+            request.addValue(deviceCheckBypass, forHTTPHeaderField: "aiproxy-devicecheck-bypass")
+        }
+    #endif
+
+        return request
+    }
+
+    init() {
+        fatalError("This is a namespace. Please use the factory method AIProxyURLRequest.create()")
+    }
+}

--- a/Sources/AIProxy/AIProxyURLSession.swift
+++ b/Sources/AIProxy/AIProxyURLSession.swift
@@ -1,0 +1,25 @@
+//
+//  AIProxyURLSession.swift
+//
+//
+//  Created by Lou Zell on 8/5/24.
+//
+
+import Foundation
+
+struct AIProxyURLSession {
+    private static let delegate = AIProxyCertificatePinningDelegate()
+
+    /// Creates a URLSession that is configured for communication with aiproxy.pro
+    static func create() -> URLSession {
+        return URLSession(
+            configuration: .default,
+            delegate: self.delegate,
+            delegateQueue: nil
+        )
+    }
+
+    init() {
+        fatalError("This is a namespace. Please use the factory method AIProxyURLSession.create()")
+    }
+}

--- a/Sources/AIProxy/Anthropic/AnthropicService.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicService.swift
@@ -33,7 +33,7 @@ public final class AnthropicService {
     ) async throws -> AnthropicMessageResponseBody {
         var body = body
         body.stream = false
-        let session = self.getServiceSession()
+        let session = AIProxyURLSession.create()
         let request = try await buildAIProxyRequest(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
@@ -56,17 +56,6 @@ public final class AnthropicService {
     
         return try AnthropicMessageResponseBody.safeDecode(from: data)
     }
-
-    private func getServiceSession() -> URLSession {
-        if self.serviceURL.starts(with: "http://localhost") {
-            return URLSession(configuration: .default)
-        }
-        return URLSession(
-            configuration: .default,
-            delegate: self.secureDelegate,
-            delegateQueue: nil
-        )
-    }
 }
 
 // MARK: - Private Helpers
@@ -81,40 +70,14 @@ private func buildAIProxyRequest(
     path: String,
     contentType: String
 ) async throws -> URLRequest {
-    let deviceCheckToken = await AIProxyDeviceCheck.getToken()
-    let clientID = clientID ?? AIProxyIdentifier.getClientID()
-    let baseURL = serviceURL
-
-    guard var urlComponents = URLComponents(string: baseURL) else {
-        throw AIProxyError.assertion(
-            "Could not create urlComponents, please check the aiproxyEndpoint constant"
-        )
-    }
-
-    urlComponents.path = urlComponents.path.appending(path)
-    guard let url = urlComponents.url else {
-        throw AIProxyError.assertion("Could not create a request URL")
-    }
-
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.httpBody = postBody
+    var request = try await AIProxyURLRequest.create(
+        partialKey: partialKey,
+        serviceURL: serviceURL,
+        clientID: clientID,
+        proxyPath: path,
+        body: postBody,
+        verb: .post
+    )
     request.addValue(contentType, forHTTPHeaderField: "Content-Type")
-    request.addValue(partialKey, forHTTPHeaderField: "aiproxy-partial-key")
-
-    if let clientID = clientID {
-        request.addValue(clientID, forHTTPHeaderField: "aiproxy-client-id")
-    }
-
-    if let deviceCheckToken = deviceCheckToken {
-        request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
-    }
-
-#if DEBUG && targetEnvironment(simulator)
-    if let deviceCheckBypass = ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] {
-        request.addValue(deviceCheckBypass, forHTTPHeaderField: "aiproxy-devicecheck-bypass")
-    }
-#endif
-
     return request
 }

--- a/Sources/AIProxy/StabilityAI/StabilityAIService.swift
+++ b/Sources/AIProxy/StabilityAI/StabilityAIService.swift
@@ -31,7 +31,7 @@ public final class StabilityAIService {
     public func ultraRequest(
         body: StabilityAIUltraRequestBody
     ) async throws -> StabilityAIUltraResponse {
-        let session = self.getServiceSession()
+        let session = AIProxyURLSession.create()
         let boundary = UUID().uuidString
         let request = try await buildAIProxyRequest(
             partialKey: self.partialKey,
@@ -61,17 +61,6 @@ public final class StabilityAIService {
             seed: httpResponse.allHeaderFields["seed"] as? String
         )
     }
-
-    private func getServiceSession() -> URLSession {
-        if self.serviceURL.starts(with: "http://localhost") {
-            return URLSession(configuration: .default)
-        }
-        return URLSession(
-            configuration: .default,
-            delegate: self.secureDelegate,
-            delegateQueue: nil
-        )
-    }
 }
 
 // MARK: - Private Helpers
@@ -85,41 +74,15 @@ private func buildAIProxyRequest(
     contentType: String,
     accept: String
 ) async throws -> URLRequest {
-    let deviceCheckToken = await AIProxyDeviceCheck.getToken()
-    let clientID = clientID ?? AIProxyIdentifier.getClientID()
-    let baseURL = serviceURL
-
-    guard var urlComponents = URLComponents(string: baseURL) else {
-        throw AIProxyError.assertion(
-            "Could not create urlComponents, please check the aiproxyEndpoint constant"
-        )
-    }
-
-    urlComponents.path = urlComponents.path.appending(path)
-    guard let url = urlComponents.url else {
-        throw AIProxyError.assertion("Could not create a request URL")
-    }
-
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.httpBody = postBody
+    var request = try await AIProxyURLRequest.create(
+        partialKey: partialKey,
+        serviceURL: serviceURL,
+        clientID: clientID,
+        proxyPath: path,
+        body: postBody,
+        verb: .post
+    )
     request.addValue(contentType, forHTTPHeaderField: "Content-Type")
     request.addValue(accept, forHTTPHeaderField: "Accept")
-    request.addValue(partialKey, forHTTPHeaderField: "aiproxy-partial-key")
-
-    if let clientID = clientID {
-        request.addValue(clientID, forHTTPHeaderField: "aiproxy-client-id")
-    }
-
-    if let deviceCheckToken = deviceCheckToken {
-        request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
-    }
-
-#if DEBUG && targetEnvironment(simulator)
-    if let deviceCheckBypass = ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] {
-        request.addValue(deviceCheckBypass, forHTTPHeaderField: "aiproxy-devicecheck-bypass")
-    }
-#endif
-
     return request
 }


### PR DESCRIPTION
- Added an example of fetching the weather with OpenMeteo through AIProxy
- Added new public methods for getting URLRequests and URLSessions that are configured for use with AIProxy

This patch provides public methods `AIProxy.request(...)` and `AIProxy.session()` that build their respective objects in a way that AIProxy expects. This makes it easier for developers that are writing their own clients, or that have an official client that they'd like to make work with AIProxy. For example, OpenMeteo already has an official lib. We don't want to recreate all of that lib in this package. Instead, we expose the parts of the core that are required to make the OpenMeteo lib communicate through our servers.

## OpenMeteo example

    import AIProxy
    import OpenMeteoSdk

    do {
        let request = try await AIProxy.request(
            partialKey: "partial-key",
            serviceURL: "service-url",
            proxyPath: "/v1/forecast?latitude=52.52&longitude=13.41&hourly=temperature_2m&format=flatbuffers"
        )
        let session = AIProxy.session()
        let responses = try await WeatherApiResponse.fetch(request: request, session: session)
        print(responses)
    } catch {
        print("Could not fetch the weather: \(error.localizedDescription)")
    }

