### PR TITLE
Bug fix: stop polling replicate on failed prediction

### DIFF
--- a/Sources/AIProxy/Replicate/ReplicateError.swift
+++ b/Sources/AIProxy/Replicate/ReplicateError.swift
@@ -2,6 +2,8 @@ import Foundation
 
 enum ReplicateError: LocalizedError {
     case reachedRetryLimit
+    case predictionCanceled
+    case predictionFailed
     case predictionDidNotIncludeURL
     case predictionDidNotIncludeOutput
 
@@ -13,6 +15,10 @@ enum ReplicateError: LocalizedError {
             return "A prediction was created, but replicate did not respond with a URL to poll"
         case .predictionDidNotIncludeOutput:
             return "A prediction was successful, but replicate did not include the output schema"
+        case .predictionFailed:
+            return "The prediction failed. If this is a NSFW prediction, please ensure disableSafetyChecker is set to true."
+        case .predictionCanceled:
+            return "The prediction was canceled"
         }
     }
 }

--- a/Sources/AIProxy/Replicate/ReplicateService.swift
+++ b/Sources/AIProxy/Replicate/ReplicateService.swift
@@ -278,10 +278,16 @@ public final class ReplicateService {
                 url: url,
                 output: ReplicatePredictionResponseBody<U>.self
             )
-            if response.status == .succeeded {
+            switch response.status {
+            case .canceled:
+                throw ReplicateError.predictionCanceled
+            case .failed:
+                throw ReplicateError.predictionFailed
+            case .succeeded:
                 return response
+            case .none, .processing, .starting:
+                try await Task.sleep(nanoseconds: 1_000_000_000)
             }
-            try await Task.sleep(nanoseconds: 1_000_000_000)
         }
         throw ReplicateError.reachedRetryLimit
     }


### PR DESCRIPTION
Previously, if a prediction failed on replicate we would continue polling a total of `pollAttempts` times. With this fix, the polling stops as soon as replicate returns a prediction status of `failed` or `canceled`