### PR TITLE
Add visionOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     platforms: [
          .iOS(.v15),
          .macOS(.v13),
+         .visionOS(.v1)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.


### PR DESCRIPTION
Hi! 

My app Meshing uses AIProxy and I want to use it in the visionOS project as well. I took a fork, and built AIProxySwift locally, and it works for Vision Pro with one line of change