### PR TITLE
Make Flux replicate type aliases public

### DIFF
--- a/Sources/AIProxy/Replicate/ReplicateFluxDevOutputSchema.swift
+++ b/Sources/AIProxy/Replicate/ReplicateFluxDevOutputSchema.swift
@@ -9,4 +9,4 @@ import Foundation
 
 /// Output schema for use with requests to Black Forest Lab's Flux Dev model:
 /// https://replicate.com/black-forest-labs/flux-dev/api/schema#output-schema
-typealias ReplicateFluxDevOutputSchema = [URL]
+public typealias ReplicateFluxDevOutputSchema = [URL]

--- a/Sources/AIProxy/Replicate/ReplicateFluxProOutputSchema.swift
+++ b/Sources/AIProxy/Replicate/ReplicateFluxProOutputSchema.swift
@@ -9,4 +9,4 @@ import Foundation
 
 /// Output schema for use with requests to Black Forest Lab's Flux Pro model:
 /// https://replicate.com/black-forest-labs/flux-pro/api/schema#output-schema
-typealias ReplicateFluxProOutputSchema = URL
+public typealias ReplicateFluxProOutputSchema = URL

--- a/Sources/AIProxy/Replicate/ReplicateFluxSchnellOutputSchema.swift
+++ b/Sources/AIProxy/Replicate/ReplicateFluxSchnellOutputSchema.swift
@@ -9,4 +9,4 @@ import Foundation
 
 /// Output schema for use with requests to Black Forest Lab's Flux Schnell model:
 /// https://replicate.com/black-forest-labs/flux-schnell/api/schema#output-schema
-typealias ReplicateFluxSchnellOutputSchema = [URL]
+public typealias ReplicateFluxSchnellOutputSchema = [URL]


### PR DESCRIPTION
Fix a regression in 0.16.0 which caused existing client code to throw compilation error:

```
Generic parameter 'U' could not be inferred
Cannot find type 'ReplicateFluxDevOutputSchemas' in scope
```