### PR TITLE
Add detail param to OpenAI chat completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ On macOS, use `NSImage(named:)` in place of `UIImage(named:)`
                     content: .parts(
                         [
                             .text("What do you see?"),
-                            .imageURL(imageURL)
+                            .imageURL(imageURL, detail: .auto)
                         ]
                     )
                 )

--- a/Sources/AIProxy/OpenAI/OpenAIChatCompletionRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIChatCompletionRequestBody.swift
@@ -186,7 +186,20 @@ public enum OpenAIChatCompletionContentPart: Encodable {
 
     /// The URL is a "local URL" containing base64 encoded image data. See the helper `AIProxy.openaiEncodedImage`
     /// to construct this URL.
-    case imageURL(url: URL, detail: String?)
+    ///
+    /// By controlling the detail parameter, which has three options, low, high, or auto, you have control over 
+    /// how the model processes the image and generates its textual understanding. By default, the model will use
+    /// the auto setting which will look at the image input size and decide if it should use the low or high setting.
+    ///
+    /// "low" will enable the "low res" mode. The model will receive a low-res 512px x 512px version of the image, and 
+    /// represent the image with a budget of 85 tokens. This allows the API to return faster responses and consume 
+    /// fewer input tokens for use cases that do not require high detail.
+    ///
+    /// "high" will enable "high res" mode, which first allows the model to first see the low res image (using 85 
+    /// tokens) and then creates detailed crops using 170 tokens for each 512px x 512px tile.
+
+
+    case imageURL(URL, detail: Detail? = nil)
 
     private enum RootKey: String, CodingKey {
         case type
@@ -214,6 +227,14 @@ public enum OpenAIChatCompletionContentPart: Encodable {
             }
         }
     }
+}
+
+extension OpenAIChatCompletionContentPart {
+  public enum Detail: String, Encodable {
+    case auto
+    case low
+    case high
+  }
 }
 
 /// An object specifying the format that the model must output. Compatible with GPT-4o, GPT-4o mini, GPT-4

--- a/Sources/AIProxy/OpenAI/OpenAIChatCompletionRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIChatCompletionRequestBody.swift
@@ -187,18 +187,16 @@ public enum OpenAIChatCompletionContentPart: Encodable {
     /// The URL is a "local URL" containing base64 encoded image data. See the helper `AIProxy.openaiEncodedImage`
     /// to construct this URL.
     ///
-    /// By controlling the detail parameter, which has three options, low, high, or auto, you have control over 
+    /// By controlling the detail parameter, which has three options, low, high, or auto, you have control over
     /// how the model processes the image and generates its textual understanding. By default, the model will use
     /// the auto setting which will look at the image input size and decide if it should use the low or high setting.
     ///
-    /// "low" will enable the "low res" mode. The model will receive a low-res 512px x 512px version of the image, and 
-    /// represent the image with a budget of 85 tokens. This allows the API to return faster responses and consume 
+    /// "low" will enable the "low res" mode. The model will receive a low-res 512px x 512px version of the image, and
+    /// represent the image with a budget of 85 tokens. This allows the API to return faster responses and consume
     /// fewer input tokens for use cases that do not require high detail.
     ///
-    /// "high" will enable "high res" mode, which first allows the model to first see the low res image (using 85 
+    /// "high" will enable "high res" mode, which first allows the model to first see the low res image (using 85
     /// tokens) and then creates detailed crops using 170 tokens for each 512px x 512px tile.
-
-
     case imageURL(URL, detail: Detail? = nil)
 
     private enum RootKey: String, CodingKey {

--- a/Sources/AIProxy/OpenAI/OpenAIChatCompletionRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIChatCompletionRequestBody.swift
@@ -186,7 +186,7 @@ public enum OpenAIChatCompletionContentPart: Encodable {
 
     /// The URL is a "local URL" containing base64 encoded image data. See the helper `AIProxy.openaiEncodedImage`
     /// to construct this URL.
-    case imageURL(URL)
+    case imageURL(url: URL, detail: String?)
 
     private enum RootKey: String, CodingKey {
         case type
@@ -196,6 +196,7 @@ public enum OpenAIChatCompletionContentPart: Encodable {
 
     private enum ImageKey: CodingKey {
         case url
+        case detail
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -204,10 +205,13 @@ public enum OpenAIChatCompletionContentPart: Encodable {
         case .text(let text):
             try container.encode("text", forKey: .type)
             try container.encode(text, forKey: .text)
-        case .imageURL(let imageURL):
+        case .imageURL(let url, let detail):
             try container.encode("image_url", forKey: .type)
             var nestedContainer = container.nestedContainer(keyedBy: ImageKey.self, forKey: .imageURL)
-            try nestedContainer.encode(imageURL, forKey: .url)
+            try nestedContainer.encode(url, forKey: .url)
+            if let detail = detail {
+                try nestedContainer.encode(detail, forKey: .detail)
+            }
         }
     }
 }


### PR DESCRIPTION
This change adds the `detail` parameter to chat completions, which has three options, low, high, or auto. 

This gives you control when using Vision (available for GPT-4o, GPT-4o mini, and GPT-4 Turbo) over how the model processes the image and generates its textual understanding. By default, the model will use the auto setting which will look at the image input size and decide if it should use the low or high setting.

`low` will enable the "low res" mode. The model will receive a low-res 512px x 512px version of the image, and represent the image with a budget of 85 tokens. This allows the API to return faster responses and consume fewer input tokens for use cases that do not require high detail.

`high` will enable "high res" mode, which first allows the model to first see the low res image (using 85 tokens) and then creates detailed crops using 170 tokens for each 512px x 512px tile.
