### PR TITLE
Do not json deserialize whisper response for 'text' responseFormat

### DIFF
--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -170,6 +170,13 @@ public final class OpenAIService {
             )
         }
 
+        if (body.responseFormat == "text") {
+            guard let text = String(data: data, encoding: .utf8) else {
+                throw AIProxyError.assertion("Could not represent OpenAI's whisper response as string")
+            }
+            return OpenAICreateTranscriptionResponseBody(text: text, language: nil, duration: nil, words: nil, segments: nil)
+        }
+
         return try JSONDecoder().decode(OpenAICreateTranscriptionResponseBody.self, from: data)
     }
 }


### PR DESCRIPTION
If a customer specifies that the whisper response format is text, then we don't want to json deserialize the http response body from OpenAI.

Before this change, a request format like the following would raise on the `let response = try` line:

```swift
let requestBody = OpenAICreateTranscriptionRequestBody(
    file: try Data(contentsOf: url),
    model: "whisper-1",
    responseFormat: "text"
)
let response = try await openAIService.createTranscriptionRequest(body: requestBody)
```

This patch skips the use of Decodable and instead instantiates the `OpenAICreateTranscriptionResponseBody` directly using the http response body.

Thanks to Pierre for reporting!