### PR TITLE
Add support for Azure deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ in its response:
             "additionalProperties": false
         ]
         let requestBody = OpenAIChatCompletionRequestBody(
-            model: "gpt-4o",
+            model: "gpt-4o-2024-08-06",
             messages: [
                 .system(content: .text("Return valid JSON only")),
                 .user(content: .text("Return a peaches and cream color palette"))
@@ -334,7 +334,7 @@ It asks ChatGPT to call a function with the correct arguments to look up a busin
     }
 
 
-### How to get word-level timestamps in an audio transcription
+### How to get Whisper word-level timestamps in an audio transcription
 
 1. Record an audio file in quicktime and save it as "helloworld.m4a"
 2. Add the audio file to your Xcode project. Make sure it's included in your target: select your audio file in the project tree, type `cmd-opt-0` to open the inspect panel, and view `Target Membership`
@@ -367,6 +367,18 @@ It asks ChatGPT to call a function with the correct arguments to look up a busin
         print("Could not get word-level timestamps from OpenAI: \(error.localizedDescription)")
     }
     ```
+
+
+### How to use OpenAI through an Azure deployment
+
+You can use all of the OpenAI snippets aboves with one change. Initialize the OpenAI service with:
+
+    import AIProxy
+    let openAIService = AIProxy.openAIService(
+        partialKey: "partial-key-from-your-developer-dashboard",
+        serviceURL: "service-url-from-your-developer-dashboard",
+        requestFormat: .azureDeployment(apiVersion: "2024-06-01")
+    )
 
 
 ### How to send an Anthropic message request

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -78,16 +78,21 @@ public struct AIProxy {
     ///     persistent on macOS and can be accurately used to attribute all requests to the same device. The default UUIDs
     ///     on iOS are pesistent until the end user chooses to rotate their vendor identification number.
     ///
+    ///   - requestFormat: If you are sending requests to your own Azure deployment, set this to `.azureDeployment`.
+    ///                    Otherwise, you may leave this set to its default value of `.standard`.
+    ///
     /// - Returns: An instance of OpenAIService configured and ready to make requests
     public static func openAIService(
         partialKey: String,
         serviceURL: String? = nil,
-        clientID: String? = nil
+        clientID: String? = nil,
+        requestFormat: OpenAIRequestFormat = .standard
     ) -> OpenAIService {
         return OpenAIService(
             partialKey: partialKey,
             serviceURL: serviceURL,
-            clientID: clientID
+            clientID: clientID,
+            requestFormat: requestFormat
         )
     }
 

--- a/Sources/AIProxy/OpenAI/OpenAIRequestFormat.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRequestFormat.swift
@@ -1,0 +1,16 @@
+//
+//  OpenAIRequestFormat.swift
+//
+//
+//  Created by Lou Zell on 9/18/24.
+//
+
+import Foundation
+
+public enum OpenAIRequestFormat {
+    /// Requests are formatted for use with OpenAI
+    case standard
+
+    /// Requests are formatted for use with your own Azure deployment
+    case azureDeployment(apiVersion: String)
+}

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -38,7 +38,7 @@ public final class OpenAIService {
             partialKey: self.partialKey,
             serviceURL: self.serviceURL ?? legacyURL,
             clientID: self.clientID,
-            proxyPath: "/v1/chat/completions",
+            proxyPath: "/chat/completions?api-version=2023-03-15-preview",
             body:  try JSONEncoder().encode(body),
             verb: .post,
             contentType: "application/json"
@@ -77,7 +77,7 @@ public final class OpenAIService {
             partialKey: self.partialKey,
             serviceURL: self.serviceURL ?? legacyURL,
             clientID: self.clientID,
-            proxyPath: "/v1/chat/completions",
+            proxyPath: "/chat/completions?api-version=2023-03-15-preview",
             body:  try JSONEncoder().encode(body),
             verb: .post,
             contentType: "application/json"

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -11,13 +11,20 @@ public final class OpenAIService {
     private let partialKey: String
     private let serviceURL: String?
     private let clientID: String?
+    private let requestFormat: OpenAIRequestFormat
 
     /// Creates an instance of OpenAIService. Note that the initializer is not public.
     /// Customers are expected to use the factory `AIProxy.openAIService` defined in AIProxy.swift
-    internal init(partialKey: String, serviceURL: String?, clientID: String?) {
+    internal init(
+        partialKey: String,
+        serviceURL: String?,
+        clientID: String?,
+        requestFormat: OpenAIRequestFormat = .standard
+    ) {
         self.partialKey = partialKey
         self.serviceURL = serviceURL
         self.clientID = clientID
+        self.requestFormat = requestFormat
     }
 
     /// Initiates a non-streaming chat completion request to /v1/chat/completions.
@@ -38,7 +45,7 @@ public final class OpenAIService {
             partialKey: self.partialKey,
             serviceURL: self.serviceURL ?? legacyURL,
             clientID: self.clientID,
-            proxyPath: "/chat/completions?api-version=2023-03-15-preview",
+            proxyPath: self.resolvedPath("chat/completions"),
             body:  try JSONEncoder().encode(body),
             verb: .post,
             contentType: "application/json"
@@ -77,7 +84,7 @@ public final class OpenAIService {
             partialKey: self.partialKey,
             serviceURL: self.serviceURL ?? legacyURL,
             clientID: self.clientID,
-            proxyPath: "/chat/completions?api-version=2023-03-15-preview",
+            proxyPath: self.resolvedPath("chat/completions"),
             body:  try JSONEncoder().encode(body),
             verb: .post,
             contentType: "application/json"
@@ -115,7 +122,7 @@ public final class OpenAIService {
             partialKey: self.partialKey,
             serviceURL: self.serviceURL ?? legacyURL,
             clientID: self.clientID,
-            proxyPath: "/v1/images/generations",
+            proxyPath: self.resolvedPath("images/generations"),
             body:  try JSONEncoder().encode(body),
             verb: .post,
             contentType: "application/json"
@@ -152,7 +159,7 @@ public final class OpenAIService {
             partialKey: self.partialKey,
             serviceURL: self.serviceURL ?? legacyURL,
             clientID: self.clientID,
-            proxyPath: "/v1/audio/transcriptions",
+            proxyPath: self.resolvedPath("audio/transcriptions"),
             body: formEncode(body, boundary),
             verb: .post,
             contentType: "multipart/form-data; boundary=\(boundary)"
@@ -178,5 +185,15 @@ public final class OpenAIService {
         }
 
         return try JSONDecoder().decode(OpenAICreateTranscriptionResponseBody.self, from: data)
+    }
+
+    private func resolvedPath(_ common: String) -> String {
+        assert(common[common.startIndex] != "/")
+        switch self.requestFormat {
+        case .standard:
+            return "/v1/\(common)"
+        case .azureDeployment(let apiVersion):
+            return "/\(common)?api-version=\(apiVersion)"
+        }
     }
 }


### PR DESCRIPTION
### How to use OpenAI through an Azure deployment

You can use all of the OpenAI snippets in this project's README with one change. Initialize the OpenAI service with:

    import AIProxy
    let openAIService = AIProxy.openAIService(
        partialKey: "partial-key-from-your-developer-dashboard",
        serviceURL: "service-url-from-your-developer-dashboard",
        requestFormat: .azureDeployment(apiVersion: "2024-06-01")
    )


