### PR TITLE
Runway Gen3 Alpha Support for Fal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,8 +1188,8 @@ See the full range of controls for generating an image by viewing `FalFastSDXLIn
     )
 
     let input = FalRunwayGen3AlphaInputSchema(
-        prompt: "A hot air balloon floating in the sky.",
-        imageUrl: "https://www.sonomacounty.com/wp-content/uploads/2023/09/activities_ballooning_Sonoma_Ballooning_Sonoma_County_900x675.png"
+        imageUrl: "https://www.sonomacounty.com/wp-content/uploads/2023/09/activities_ballooning_Sonoma_Ballooning_Sonoma_County_900x675.png",
+        prompt: "A hot air balloon floating in the sky."
     )
     do {
         let output = try await falService.createRunwayGen3AlphaVideo(input: input)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About
 
 Use this package to add [AIProxy](https://www.aiproxy.pro) support to your iOS and macOS apps.
-AIProxy lets you depend on AI APIs safely without building your own backend. 
+AIProxy lets you depend on AI APIs safely without building your own backend.
 Five levels of security are applied to keep your API key secure and your AI bill predictable:
 
 - Certificate pinning
@@ -47,7 +47,7 @@ See the FAQ for more details on the DeviceCheck bypass constant.
 
 - If you set the dependency rule to `main` in step 2 above, then you can ensure the package is
   up to date by right clicking on the package and selecting 'Update Package'
-  
+
   <img src="https://github.com/lzell/AIProxySwift/assets/35940/aeee0ab2-362b-4995-b9ca-ff4e1dd04f47" alt="Update package version" width="720">
 
 
@@ -1178,6 +1178,29 @@ model owner and model name in the string.
 
 See the full range of controls for generating an image by viewing `FalFastSDXLInputSchema.swift`
 
+### How to generate a Runway Gen3 Alpha video using Fal
+
+    import AIProxy
+
+    let falService = AIProxy.falService(
+        partialKey: "partial-key-from-your-developer-dashboard",
+        serviceURL: "service-url-from-your-developer-dashboard"
+    )
+
+    let input = FalRunwayGen3AlphaInputSchema(
+        prompt: "A hot air balloon floating in the sky.",
+        imageUrl: "https://www.sonomacounty.com/wp-content/uploads/2023/09/activities_ballooning_Sonoma_Ballooning_Sonoma_County_900x675.png"
+    )
+    do {
+        let output = try await falService.createRunwayGen3AlphaVideo(input: input)
+        print(output.video?.url?.absoluteString ?? "No video URL")
+    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
+    } catch {
+        print("Could not create Fal Runway Gen3 Alpha video: \(error.localizedDescription)")
+    }
+
+See the full range of controls for generating an image by viewing `FalRunwayGen3AlphaInputSchema.swift`
 
 ### How to train Flux on your own images using Fal
 
@@ -1407,11 +1430,11 @@ the package to Xcode using the [Installation steps](https://github.com/lzell/AIP
 Next, select your project in the Project Navigator (`cmd-1`), select your target, and scroll to
 the `Frameworks, Libraries, and Embedded Content` section. Tap on the plus icon:
 
-<img src="https://github.com/lzell/AIProxySwift/assets/35940/438e2bbb-688c-49bc-aa2a-ea85806818d5" alt="Add library dependency" width="820">  
+<img src="https://github.com/lzell/AIProxySwift/assets/35940/438e2bbb-688c-49bc-aa2a-ea85806818d5" alt="Add library dependency" width="820">
 
 And add the AIProxy library:
 
-<img src="https://github.com/lzell/AIProxySwift/assets/35940/f015a181-9591-435c-a37f-6fb0c8c5050c" alt="Select the AIProxy dependency" width="400">  
+<img src="https://github.com/lzell/AIProxySwift/assets/35940/f015a181-9591-435c-a37f-6fb0c8c5050c" alt="Select the AIProxy dependency" width="400">
 
 
 ## macOS network sandbox
@@ -1445,15 +1468,15 @@ consider a bug). Here is how to set it up:
   - Open the scheme editor at `Product > Scheme > Edit Scheme`
   - Select `Test`
   - Tap through to the test plan
-  
-    <img src="https://github.com/lzell/AIProxySwift/assets/35940/9a372244-f03e-4fe3-9361-ffc9d729b7d9" alt="Select test plan" width="720">  
-    
+
+    <img src="https://github.com/lzell/AIProxySwift/assets/35940/9a372244-f03e-4fe3-9361-ffc9d729b7d9" alt="Select test plan" width="720">
+
   - Select `Configurations > Environment Variables`
-    
+
     <img src="https://github.com/lzell/AIProxySwift/assets/35940/2e042957-2c40-4335-833d-70b2bf56c31a" alt="Select env variables" width="780">
-    
-  - Add the `AIPROXY_DEVICE_CHECK_BYPASS` env variable with your value  
-  
+
+  - Add the `AIPROXY_DEVICE_CHECK_BYPASS` env variable with your value
+
     <img src="https://github.com/lzell/AIProxySwift/assets/35940/e466097c-1700-401d-add6-07c14dd26ab8" alt="Enter env variable value" width="720">
 
 * **Important** Edit your test cases to forward on the env variable to the host simulator:

--- a/Sources/AIProxy/Fal/FalRunwalGen3AlphaInputSchema.swift
+++ b/Sources/AIProxy/Fal/FalRunwalGen3AlphaInputSchema.swift
@@ -1,0 +1,42 @@
+//
+//  FalRunwayGen3AlphaInputSchema.swift
+//
+//
+//  Created by Todd Hamilton on 10/4/24.
+//
+
+import Foundation
+
+/// Input schema for Runway Gen3 Alpha image-to-video model
+/// Docstrings from:
+/// https://fal.ai/models/fal-ai/runway-gen3/turbo/image-to-video/api
+public struct FalRunwayGen3AlphaInputSchema: Encodable {
+    // Required
+
+    /// The prompt to use for generating the video
+    public let prompt: String
+
+    /// The URL of the input image to be transformed into a video
+    public let imageUrl: String
+
+    // Optional
+
+    /// The duration of the generated video
+    public let duration: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case prompt
+        case imageUrl = "image_url"
+        case duration
+    }
+
+    public init(
+        prompt: String,
+        imageUrl: String,
+        duration: String? = nil
+    ) {
+        self.prompt = prompt
+        self.imageUrl = imageUrl
+        self.duration = duration
+    }
+}

--- a/Sources/AIProxy/Fal/FalRunwalGen3AlphaInputSchema.swift
+++ b/Sources/AIProxy/Fal/FalRunwalGen3AlphaInputSchema.swift
@@ -13,11 +13,11 @@ import Foundation
 public struct FalRunwayGen3AlphaInputSchema: Encodable {
     // Required
 
-    /// The prompt to use for generating the video
-    public let prompt: String
-
     /// The URL of the input image to be transformed into a video
     public let imageUrl: String
+
+    /// The prompt to use for generating the video
+    public let prompt: String
 
     // Optional
 
@@ -31,12 +31,12 @@ public struct FalRunwayGen3AlphaInputSchema: Encodable {
     }
 
     public init(
-        prompt: String,
         imageUrl: String,
+        prompt: String,
         duration: String? = nil
     ) {
-        self.prompt = prompt
         self.imageUrl = imageUrl
+        self.prompt = prompt
         self.duration = duration
     }
 }

--- a/Sources/AIProxy/Fal/FalRunwayGen3AlphaOutputSchema.swift
+++ b/Sources/AIProxy/Fal/FalRunwayGen3AlphaOutputSchema.swift
@@ -31,9 +31,9 @@ extension FalRunwayGen3AlphaOutputSchema {
 
         private enum CodingKeys: String, CodingKey {
             case contentType = "content_type"
-            case fileData
-            case fileName
-            case fileSize
+            case fileData = "file_data"
+            case fileName = "file_name"
+            case fileSize = "file_size"
             case url
         }
     }

--- a/Sources/AIProxy/Fal/FalRunwayGen3AlphaOutputSchema.swift
+++ b/Sources/AIProxy/Fal/FalRunwayGen3AlphaOutputSchema.swift
@@ -9,26 +9,32 @@ import Foundation
 
 public struct FalRunwayGen3AlphaOutputSchema: Decodable {
     public let video: Video?
-
-    private enum CodingKeys: String, CodingKey {
-        case video
-    }
 }
 
 extension FalRunwayGen3AlphaOutputSchema {
     public struct Video: Decodable {
-        public let url: URL?                // The URL where the file can be downloaded from.
-        public let contentType: String?     // The mime type of the file.
-        public let fileName: String?        // The name of the file. It will be auto-generated if not provided.
-        public let fileSize: Int?           // The size of the file in bytes.
-        public let fileData: String?           // File data
+
+        /// The mime type of the file.
+        public let contentType: String?
+
+        // File data
+        public let fileData: String?
+
+        /// The name of the file. It will be auto-generated if not provided.
+        public let fileName: String?
+
+        /// The size of the file in bytes.
+        public let fileSize: Int?
+
+        /// The URL where the file can be downloaded from.
+        public let url: URL?
 
         private enum CodingKeys: String, CodingKey {
-            case url
             case contentType = "content_type"
+            case fileData
             case fileName
             case fileSize
-            case fileData
+            case url
         }
     }
 }

--- a/Sources/AIProxy/Fal/FalRunwayGen3AlphaOutputSchema.swift
+++ b/Sources/AIProxy/Fal/FalRunwayGen3AlphaOutputSchema.swift
@@ -1,0 +1,34 @@
+//
+//  FalRunwayGen3AlphaOutputSchema.swift
+//
+//
+//  Created by Todd Hamilton on 10/4/24.
+//
+
+import Foundation
+
+public struct FalRunwayGen3AlphaOutputSchema: Decodable {
+    public let video: Video?
+
+    private enum CodingKeys: String, CodingKey {
+        case video
+    }
+}
+
+extension FalRunwayGen3AlphaOutputSchema {
+    public struct Video: Decodable {
+        public let url: URL?                // The URL where the file can be downloaded from.
+        public let contentType: String?     // The mime type of the file.
+        public let fileName: String?        // The name of the file. It will be auto-generated if not provided.
+        public let fileSize: Int?           // The size of the file in bytes.
+        public let fileData: String?           // File data
+
+        private enum CodingKeys: String, CodingKey {
+            case url
+            case contentType = "content_type"
+            case fileName
+            case fileSize
+            case fileData
+        }
+    }
+}

--- a/Sources/AIProxy/Fal/FalService.swift
+++ b/Sources/AIProxy/Fal/FalService.swift
@@ -72,11 +72,38 @@ public final class FalService {
         return try await self.getResponse(url: responseURL)
     }
 
+    /// Convenience method for running inference on your trained Flux LoRA
+    ///
+    /// - Parameter input: The input schema. See `FalFluxLoraInputSchema.swift` for the range of controls that you
+    ///                    can use to adjust the inference.
+    ///
+    /// - Returns: The inference output with URLs to all generated images
     public func createFluxLoRAImage(
         input: FalFluxLoRAInputSchema
     ) async throws -> FalFluxLoRAOutputSchema {
         let queueResponse = try await self.createInference(
             model: "fal-ai/flux-lora",
+            input: input
+        )
+        guard let statusURL = queueResponse.statusURL else {
+            throw FalError.missingStatusURL
+        }
+        let completedResponse = try await self.pollForInferenceComplete(statusURL: statusURL)
+
+        guard let responseURL = completedResponse.responseURL else {
+            throw FalError.missingResultURL
+        }
+        return try await self.getResponse(url: responseURL)
+    }
+
+
+    /// Convenience method for creating a `fal-ai/runway-gen3/turbo/image-to-video` video.
+    ///
+    public func createRunwayGen3AlphaVideo(
+        input: FalRunwayGen3AlphaInputSchema
+    ) async throws -> FalRunwayGen3AlphaOutputSchema {
+        let queueResponse = try await self.createInference(
+            model: "fal-ai/runway-gen3/turbo/image-to-video",
             input: input
         )
         guard let statusURL = queueResponse.statusURL else {

--- a/Sources/AIProxy/Fal/FalService.swift
+++ b/Sources/AIProxy/Fal/FalService.swift
@@ -99,6 +99,10 @@ public final class FalService {
 
     /// Convenience method for creating a `fal-ai/runway-gen3/turbo/image-to-video` video.
     ///
+    /// - Parameter input: The input schema. See `FalRunwayGen3AlphaInputSchema.swift` for the controls that you
+    ///                    can use to adjust the video generation.
+    ///
+    /// - Returns: The inference result. The `video` property of the returned value has a `url` that you can use to fetch the video contents.
     public func createRunwayGen3AlphaVideo(
         input: FalRunwayGen3AlphaInputSchema
     ) async throws -> FalRunwayGen3AlphaOutputSchema {


### PR DESCRIPTION
This PR adds Runway Gen3 Alpha (image to video) support on Fal. The request takes a prompt, image url, and optional duration.