### PR TITLE
Increase polling attempts for image generation on Fal

### DIFF
--- a/Sources/AIProxy/Fal/FalService.swift
+++ b/Sources/AIProxy/Fal/FalService.swift
@@ -224,8 +224,8 @@ public final class FalService {
     /// - Returns: A queue response with the status of `.completed`
     public func pollForInferenceComplete(
         statusURL: URL,
-        pollAttempts: Int = 30,
-        secondsBetweenPollAttempts: UInt64 = 1
+        pollAttempts: Int = 60,
+        secondsBetweenPollAttempts: UInt64 = 2
     ) async throws -> FalQueueResponseBody {
         return try await self.actorPollForInferenceCompletion(
             url: statusURL,


### PR DESCRIPTION
Video generation takes longer than images (~ >30s) so the number of polling needed is higher. his bumps the attempts to 30 and the seconds between attempts to 2 seconds.