### PR TITLE
Add support for Anthropic streaming messages and tool calls

### DIFF
--- a/Sources/AIProxy/Anthropic/AnthropicAsyncChunks.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicAsyncChunks.swift
@@ -1,0 +1,78 @@
+//
+//  AnthropicAsyncChunks.swift
+//
+//
+//  Created by Lou Zell on 10/7/24.
+//
+
+import Foundation
+
+/// Iterate the streaming chunks using the following pattern:
+///
+///     let stream = try await anthropicService.streamingMessageRequest(...)
+///
+///     for try await chunk in stream {
+///         switch chunk {
+///         case .text(let text):
+///             print(text)
+///         case .toolUse(name: let toolName, input: let toolInput):
+///             print("Claude wants to call tool \(toolName) with input \(toolInput)")
+///         }
+///     }
+public struct AnthropicAsyncChunks: AsyncSequence {
+    public typealias Element = AnthropicMessageStreamingChunk
+    private let asyncLines: AsyncLineSequence<URLSession.AsyncBytes>
+
+    internal init(asyncLines: AsyncLineSequence<URLSession.AsyncBytes>) {
+        self.asyncLines = asyncLines
+    }
+
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        var asyncBytesIterator: AsyncLineSequence<URLSession.AsyncBytes>.AsyncIterator
+
+        /// This buffers up any tool calls that are part of the streaming response before
+        /// emitting the next streaming chunk. That is, tool calls are not emitted to the
+        /// caller as partial values. I see no value in a partial tool call, as we don't have
+        /// enough context to form the full local function call (we don't have the arguments!)
+        /// until the full tool call is buffered in. If you have a use case where partial tool
+        /// calls are necessary, please reach out to me.
+        ///
+        /// Text chunks are immediately emitted.
+        mutating public func next() async throws -> AnthropicMessageStreamingChunk? {
+            var toolUseAccumulator = ""
+            var toolName: String? = nil
+            while true {
+                guard let value = try await self.asyncBytesIterator.next() else {
+                    return nil // No more streaming lines to consume
+                }
+                if value.starts(with: #"data: {"type":"content_block_start""#) {
+                    if let blockStart = try AnthropicMessageStreamingContentBlockStart.from(line: value) {
+                        if case .toolUse(name: let name) = blockStart.contentBlock {
+                            toolName = name
+                        }
+                    }
+                }
+                if value.starts(with: #"data: {"type":"content_block_stop""#) {
+                    if let toolName = toolName {
+                        return .toolUse(
+                            name: toolName,
+                            input: try [String: AIProxyJSONValue].deserialize(from: toolUseAccumulator).untypedDictionary
+                        )
+                    }
+                }
+                if let block = AnthropicMessageStreamingDeltaBlock.from(line: value) {
+                    switch block.delta {
+                    case .text(let string):
+                        return .text(string)
+                    case .toolUse(let string):
+                        toolUseAccumulator += string
+                    }
+                }
+            }
+        }
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        return AsyncIterator(asyncBytesIterator: asyncLines.makeAsyncIterator())
+    }
+}

--- a/Sources/AIProxy/Anthropic/AnthropicMessageStreamingChunk.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicMessageStreamingChunk.swift
@@ -1,0 +1,21 @@
+//
+//  AnthropicMessageStreamingChunk.swift
+//
+//
+//  Created by Lou Zell on 10/7/24.
+//
+
+import Foundation
+
+
+public enum AnthropicMessageStreamingChunk {
+    /// The `String` argument is the chat completion response text "delta", meaning the new bit
+    /// of text that just became available. It is not the full message.
+    case text(String)
+
+    /// The name of the tool that Claude wants to call, and a buffered input to the function.
+    /// The input argument is not a "delta". Internally to this lib, we accumulate the tool
+    /// call deltas and map them to `[String: Any]` once all tool call deltas have been
+    /// received.
+    case toolUse(name: String, input: [String: Any])
+}

--- a/Sources/AIProxy/Anthropic/AnthropicMessageStreamingContentBlockStart.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicMessageStreamingContentBlockStart.swift
@@ -1,0 +1,58 @@
+//
+//  AnthropicMessageStreamingContentBlockStart.swift
+//
+//
+//  Created by Lou Zell on 10/7/24.
+//
+
+import Foundation
+
+internal struct AnthropicMessageStreamingContentBlockStart: Decodable {
+    let contentBlock: ContentBlock
+
+    static func from(line: String) -> Self? {
+        guard line.hasPrefix(#"data: {"type":"content_block_start""#) else {
+            return nil
+        }
+        guard let chunkJSON = line.dropFirst(6).data(using: .utf8),
+              let chunk = try? JSONDecoder().decode(Self.self, from: chunkJSON) else
+        {
+            aiproxyLogger.warning("Received unexpected JSON from Anthropic: \(line)")
+            return nil
+        }
+        return chunk
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case contentBlock = "content_block"
+    }
+}
+
+extension AnthropicMessageStreamingContentBlockStart {
+    enum ContentBlock: Decodable {
+        case text(String)
+        case toolUse(name: String)
+
+        private enum CodingKeys: String, CodingKey {
+            case name
+            case text
+            case type
+        }
+
+        private enum PossibleTypes: String, Decodable {
+            case text = "text"
+            case toolUse = "tool_use"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let type = try container.decode(PossibleTypes.self, forKey: .type)
+            switch type {
+            case PossibleTypes.text:
+                self = .text(try container.decode(String.self, forKey: CodingKeys.text))
+            case PossibleTypes.toolUse:
+                self = .toolUse(name: try container.decode(String.self, forKey: CodingKeys.name))
+            }
+        }
+    }
+}

--- a/Sources/AIProxy/Anthropic/AnthropicMessageStreamingDeltaBlock.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicMessageStreamingDeltaBlock.swift
@@ -1,0 +1,58 @@
+//
+//  AnthropicMessageStreamingDeltaBlock.swift
+//
+//
+//  Created by Lou Zell on 10/7/24.
+//
+
+import Foundation
+
+internal struct AnthropicMessageStreamingDeltaBlock: Decodable {
+    /// We do not vend this type. See AnthropicMessageStreamingChunk for the final product that
+    /// we vend to the client.
+    let delta: Delta
+
+    static func from(line: String) -> Self? {
+        guard line.hasPrefix(#"data: {"type":"content_block_delta""#) else {
+            return nil
+        }
+        guard let chunkJSON = line.dropFirst(6).data(using: .utf8),
+              let chunk = try? JSONDecoder().decode(Self.self, from: chunkJSON) else
+        {
+            aiproxyLogger.warning("Received unexpected JSON from Anthropic: \(line)")
+            return nil
+        }
+        return chunk
+    }
+}
+
+extension AnthropicMessageStreamingDeltaBlock {
+    enum Delta: Decodable {
+        case text(String)
+        case toolUse(String)
+
+        private enum CodingKeys: String, CodingKey {
+            case partialJSON = "partial_json"
+            case text
+            case type
+        }
+
+        private enum PossibleTypes: String, Decodable {
+            case textDelta = "text_delta"
+            case inputJSONDelta = "input_json_delta"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let type = try container.decode(PossibleTypes.self, forKey: .type)
+            switch type {
+            case .textDelta:
+                self = .text(try container.decode(String.self, forKey: .text))
+            case .inputJSONDelta:
+                self = .toolUse(try container.decode(String.self, forKey: .partialJSON))
+            }
+        }
+    }
+}
+
+

--- a/Sources/AIProxy/Anthropic/AnthropicService.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicService.swift
@@ -23,9 +23,9 @@ public final class AnthropicService {
     /// Initiates a non-streaming request to /v1/messages.
     ///
     /// - Parameters:
-    ///   - messageRequestBody: The request body to send to aiproxy and anthropic. See this reference:
+    ///   - body: The message request body. See this reference:
     ///                         https://docs.anthropic.com/en/api/messages
-    /// - Returns: The message response, See this reference:
+    /// - Returns: The message response body, See this reference:
     ///            https://platform.openai.com/docs/api-reference/chat/object
     public func messageRequest(
         body: AnthropicMessageRequestBody
@@ -53,7 +53,48 @@ public final class AnthropicService {
                 responseBody: String(data: data, encoding: .utf8) ?? ""
             )
         }
-    
+
         return try AnthropicMessageResponseBody.deserialize(from: data)
+    }
+
+    /// Initiates a streaming request to /v1/messages.
+    ///
+    /// - Parameters:
+    ///   - body: The message request body. See this reference:
+    ///                         https://docs.anthropic.com/en/api/messages
+    /// - Returns: The message response body, See this reference:
+    ///            https://platform.openai.com/docs/api-reference/chat/object
+    public func streamingMessageRequest(
+        body: AnthropicMessageRequestBody
+    ) async throws -> AnthropicAsyncChunks {
+        var body = body
+        body.stream = true
+        let session = AIProxyURLSession.create()
+        let request = try await AIProxyURLRequest.create(
+            partialKey: self.partialKey,
+            serviceURL: self.serviceURL,
+            clientID: self.clientID,
+            proxyPath: "/v1/messages",
+            body: try body.serialize(),
+            verb: .post,
+            contentType: "application/json"
+        )
+
+        let (asyncBytes, res) = try await session.bytes(for: request)
+
+        guard let httpResponse = res as? HTTPURLResponse else {
+            throw AIProxyError.assertion("Network response is not an http response")
+        }
+
+        if (httpResponse.statusCode > 299) {
+            let responseBody = try await asyncBytes.lines.reduce(into: "") { $0 += $1 }
+            throw AIProxyError.unsuccessfulRequest(
+                statusCode: httpResponse.statusCode,
+                responseBody: responseBody
+            )
+        }
+
+
+        return AnthropicAsyncChunks(asyncLines: asyncBytes.lines)
     }
 }

--- a/Tests/AIProxyTests/AnthropicMessageStreamingChunkTests.swift
+++ b/Tests/AIProxyTests/AnthropicMessageStreamingChunkTests.swift
@@ -1,0 +1,37 @@
+//
+//  AnthropicMessageStreamingChunkTests.swift
+//
+//
+//  Created by Lou Zell on 10/7/24.
+//
+
+import XCTest
+import Foundation
+@testable import AIProxy
+
+
+final class AnthropicMessageStreamingChunkTests: XCTestCase {
+
+    func testDeltaBlockStartIsDecodable() {
+        let serializedChunk = #"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello! How"}   }"#
+        let deltaBlock = AnthropicMessageStreamingDeltaBlock.from(line: serializedChunk)
+        switch deltaBlock?.delta {
+        case .text(let txt):
+            XCTAssertEqual("Hello! How", txt)
+        default:
+            XCTFail()
+        }
+    }
+
+    func testContentBlockStartIsDecodable() {
+        let serializedChunk = #"data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01T1x1fJ34qAmk2tNTrN7Up6","name":"get_weather","input":{}}}"#
+        let contentBlockStart = AnthropicMessageStreamingContentBlockStart.from(line: serializedChunk)
+        switch contentBlockStart?.contentBlock {
+        case .toolUse(name: let name):
+            XCTAssertEqual("get_weather", name)
+        default:
+            XCTFail()
+        }
+    }
+}
+


### PR DESCRIPTION
### How to use streaming text messages with Anthropic

    import AIProxy

    let anthropicService = AIProxy.anthropicService(
        partialKey: "partial-key-from-your-developer-dashboard",
        serviceURL: "service-url-from-your-developer-dashboard"
    )
    do {
        let requestBody = AnthropicMessageRequestBody(
            maxTokens: 1024,
            messages: [
                .init(
                    content: [.text("hello world")],
                    role: .user
                )
            ],
            model: "claude-3-5-sonnet-20240620"
        )

        let stream = try await anthropicService.streamingMessageRequest(body: requestBody)
        for try await chunk in stream {
            switch chunk {
            case .text(let text):
                print(text)
            case .toolUse(name: let toolName, input: let toolInput):
                print("Claude wants to call tool \(toolName) with input \(toolInput)")
            }
        }
    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
    } catch {
        print("Could not use Anthropic's message stream: \(error.localizedDescription)")
    }


### How to use streaming tool calls with Anthropic

    import AIProxy

    let anthropicService = AIProxy.anthropicService(
        partialKey: "partial-key-from-your-developer-dashboard",
        serviceURL: "service-url-from-your-developer-dashboard"
    )

    do {
        let requestBody = AnthropicMessageRequestBody(
            maxTokens: 1024,
            messages: [
                .init(
                    content: [.text("What is nvidia's stock price?")],
                    role: .user
                )
            ],
            model: "claude-3-5-sonnet-20240620",
            tools: [
                .init(
                    description: "Call this function when the user wants a stock symbol",
                    inputSchema: [
                        "type": "object",
                        "properties": [
                            "ticker": [
                                "type": "string",
                                "description": "The stock ticker symbol, e.g. AAPL for Apple Inc."
                            ]
                        ],
                        "required": ["ticker"]
                    ],
                    name: "get_stock_symbol"
                )
            ]
        )

        let stream = try await anthropicService.streamingMessageRequest(body: requestBody)
        for try await chunk in stream {
            switch chunk {
            case .text(let text):
                print(text)
            case .toolUse(name: let toolName, input: let toolInput):
                print("Claude wants to call tool \(toolName) with input \(toolInput)")
            }
        }
        print("Done with stream")
    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
    } catch {
        print(error.localizedDescription)
    }