### PR TITLE
Add support for OpenAI's text to speech API

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,41 @@ It asks ChatGPT to call a function with the correct arguments to look up a busin
     }
     ```
 
+### How to use OpenAI text-to-speech
+
+    ```swift
+    import AIProxy
+
+    let openAIService = AIProxy.openAIService(
+        partialKey: "partial-key-from-your-developer-dashboard",
+        serviceURL: "service-url-from-your-developer-dashboard"
+    )
+
+    do {
+        let requestBody = OpenAITextToSpeechRequestBody(
+            input: "Hello world",
+            voice: .nova
+        )
+        
+        let mpegData = try await openAIService.createTextToSpeechRequest(body: requestBody)
+
+        // Do not use a local `let` or `var` for AVAudioPlayer.
+        // You need the lifecycle of the player to live beyond the scope of this function.
+        // Instead, use file scope or set the player as a member of a reference type with long life.
+        // For example, at the top of this file you may define:
+        //
+        //   fileprivate var audioPlayer: AVAudioPlayer? = nil
+        //
+        // And then use the code below to play the TTS result:
+        audioPlayer = try AVAudioPlayer(data: mpegData)
+        audioPlayer?.prepareToPlay()
+        audioPlayer?.play()
+    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received \(statusCode) status code with response body: \(responseBody)")
+    } catch {
+        print("Could not create ElevenLabs TTS audio: \(error.localizedDescription)")
+    }
+    ```
 
 ### How to use OpenAI through an Azure deployment
 

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -196,7 +196,7 @@ public final class OpenAIService {
     ///            https://platform.openai.com/docs/api-reference/audio/createSpeech
     public func createTextToSpeechRequest(
         body: OpenAITextToSpeechRequestBody
-    ) async throws -> String {
+    ) async throws -> URL {
         let session = AIProxyURLSession.create()
         let boundary = UUID().uuidString
         let request = try await AIProxyURLRequest.create(
@@ -209,7 +209,7 @@ public final class OpenAIService {
             contentType: "application/json"
         )
 
-        let (data, res) = try await session.data(for: request)
+        let (url, res) = try await session.download(for: request)
         guard let httpResponse = res as? HTTPURLResponse else {
             throw AIProxyError.assertion("Network response is not an http response")
         }
@@ -217,11 +217,11 @@ public final class OpenAIService {
         if (httpResponse.statusCode > 299) {
             throw AIProxyError.unsuccessfulRequest(
                 statusCode: httpResponse.statusCode,
-                responseBody: String(data: data, encoding: .utf8) ?? ""
+                responseBody: String(data: Data(), encoding: .utf8) ?? ""
             )
         }
         
-        return try JSONDecoder().decode(String.self, from: data)
+        return url
     }
 
     private func resolvedPath(_ common: String) -> String {

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -203,7 +203,7 @@ public final class OpenAIService {
             serviceURL: self.serviceURL ?? legacyURL,
             clientID: self.clientID,
             proxyPath: self.resolvedPath("audio/speech"),
-            body:  try JSONEncoder().encode(body),
+            body:  try body.serialize(),
             verb: .post,
             contentType: "application/json"
         )

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -196,9 +196,8 @@ public final class OpenAIService {
     ///            https://platform.openai.com/docs/api-reference/audio/createSpeech
     public func createTextToSpeechRequest(
         body: OpenAITextToSpeechRequestBody
-    ) async throws -> URL {
+    ) async throws -> Data {
         let session = AIProxyURLSession.create()
-        let boundary = UUID().uuidString
         let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL ?? legacyURL,
@@ -209,7 +208,7 @@ public final class OpenAIService {
             contentType: "application/json"
         )
 
-        let (url, res) = try await session.download(for: request)
+        let (data, res) = try await session.data(for: request)
         guard let httpResponse = res as? HTTPURLResponse else {
             throw AIProxyError.assertion("Network response is not an http response")
         }
@@ -221,7 +220,7 @@ public final class OpenAIService {
             )
         }
         
-        return url
+        return data
     }
 
     private func resolvedPath(_ common: String) -> String {

--- a/Sources/AIProxy/OpenAI/OpenAITextToSpeechCodables.swift
+++ b/Sources/AIProxy/OpenAI/OpenAITextToSpeechCodables.swift
@@ -1,0 +1,12 @@
+//
+//  
+//  File.swift
+//  
+//
+//  Created by Daniel Aditya Istyana on 10/9/24.
+//
+
+
+import Foundation
+
+

--- a/Sources/AIProxy/OpenAI/OpenAITextToSpeechCodables.swift
+++ b/Sources/AIProxy/OpenAI/OpenAITextToSpeechCodables.swift
@@ -1,7 +1,7 @@
 //
 //  
-//  File.swift
-//  
+//  OpenAITextToSpeechCodables.swift
+//
 //
 //  Created by Daniel Aditya Istyana on 10/9/24.
 //
@@ -9,4 +9,45 @@
 
 import Foundation
 
+public struct OpenAITextToSpeechRequestBody: Encodable {
 
+    // Required
+    /// The text to generate audio for. The maximum length is 4096 characters.
+    public let input: String
+
+    // Required
+    /// One of the available TTS models: `tts-1` or `tts-1-hd`, default to `tts-1`
+    public let model: String
+
+    // Required
+    /// The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`.
+    public let voice: Voice
+
+    /// The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`.
+    public let responseFormat: ResponseFormat
+
+    /// The speed of the generated audio. Select a value from 0.25 to 4.0. 1.0 is the default.
+    public let speed: Float
+    
+    public enum Voice: String, Encodable {
+        case alloy, echo, fable, onyx, nova, shimmer
+    }
+    
+    public enum ResponseFormat: String, Encodable {
+        case mp3, opus, aac, flac, wav, pcm
+    }
+    
+    public init(
+        input: String,
+        model: String = "tts-1",
+        voice: OpenAITextToSpeechRequestBody.Voice,
+        responseFormat: OpenAITextToSpeechRequestBody.ResponseFormat = .mp3,
+        speed: Float = 1.0
+    ) {
+        self.input = input
+        self.model = model
+        self.voice = voice
+        self.responseFormat = responseFormat
+        self.speed = speed
+    }
+}

--- a/Sources/AIProxy/OpenAI/OpenAITextToSpeechRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAITextToSpeechRequestBody.swift
@@ -13,21 +13,25 @@ import Foundation
 public struct OpenAITextToSpeechRequestBody: Encodable {
 
     // Required
+    
     /// The text to generate audio for. The maximum length is 4096 characters.
     public let input: String
 
-    // Required
     /// One of the available TTS models: `tts-1` or `tts-1-hd`, default to `tts-1`
+    /// Default to `tts-1`
     public let model: Model
 
-    // Required
     /// The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`.
     public let voice: Voice
 
+    // Optional
+    
     /// The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`.
+    /// Default to `mp3`
     public let responseFormat: ResponseFormat?
 
-    /// The speed of the generated audio. Select a value from 0.25 to 4.0. 1.0 is the default.
+    /// The speed of the generated audio. Select a value from 0.25 to 4.0.
+    /// Default to `1.0`
     public let speed: Float?
 
     public init(
@@ -42,6 +46,14 @@ public struct OpenAITextToSpeechRequestBody: Encodable {
         self.voice = voice
         self.responseFormat = responseFormat
         self.speed = speed
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case input
+        case model
+        case voice
+        case responseFormat = "response_format"
+        case speed
     }
 }
 

--- a/Sources/AIProxy/OpenAI/OpenAITextToSpeechRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAITextToSpeechRequestBody.swift
@@ -17,7 +17,7 @@ public struct OpenAITextToSpeechRequestBody: Encodable {
 
     // Required
     /// One of the available TTS models: `tts-1` or `tts-1-hd`, default to `tts-1`
-    public let model: String
+    public let model: Model
 
     // Required
     /// The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`.
@@ -37,9 +37,14 @@ public struct OpenAITextToSpeechRequestBody: Encodable {
         case mp3, opus, aac, flac, wav, pcm
     }
     
+    public enum Model: String, Encodable {
+        case tts1 = "tts-1"
+        case tts1HD = "tts-1-hd"
+    }
+    
     public init(
         input: String,
-        model: String = "tts-1",
+        model: Model = .tts1,
         voice: OpenAITextToSpeechRequestBody.Voice,
         responseFormat: OpenAITextToSpeechRequestBody.ResponseFormat = .mp3,
         speed: Float = 1.0

--- a/Sources/AIProxy/OpenAI/OpenAITextToSpeechRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAITextToSpeechRequestBody.swift
@@ -1,6 +1,5 @@
 //
-//  
-//  OpenAITextToSpeechCodables.swift
+//  OpenAITextToSpeechRequestBody.swift
 //
 //
 //  Created by Daniel Aditya Istyana on 10/9/24.
@@ -9,6 +8,8 @@
 
 import Foundation
 
+/// Docstrings from 
+/// https://platform.openai.com/docs/api-reference/audio/createSpeech
 public struct OpenAITextToSpeechRequestBody: Encodable {
 
     // Required
@@ -24,35 +25,44 @@ public struct OpenAITextToSpeechRequestBody: Encodable {
     public let voice: Voice
 
     /// The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`.
-    public let responseFormat: ResponseFormat
+    public let responseFormat: ResponseFormat?
 
     /// The speed of the generated audio. Select a value from 0.25 to 4.0. 1.0 is the default.
-    public let speed: Float
-    
-    public enum Voice: String, Encodable {
-        case alloy, echo, fable, onyx, nova, shimmer
-    }
-    
-    public enum ResponseFormat: String, Encodable {
-        case mp3, opus, aac, flac, wav, pcm
-    }
-    
-    public enum Model: String, Encodable {
-        case tts1 = "tts-1"
-        case tts1HD = "tts-1-hd"
-    }
-    
+    public let speed: Float?
+
     public init(
         input: String,
         model: Model = .tts1,
         voice: OpenAITextToSpeechRequestBody.Voice,
-        responseFormat: OpenAITextToSpeechRequestBody.ResponseFormat = .mp3,
-        speed: Float = 1.0
+        responseFormat: OpenAITextToSpeechRequestBody.ResponseFormat? = .mp3,
+        speed: Float? = 1.0
     ) {
         self.input = input
         self.model = model
         self.voice = voice
         self.responseFormat = responseFormat
         self.speed = speed
+    }
+}
+
+// MARK: - OpenAITextToSpeechRequestBody.Model
+public extension OpenAITextToSpeechRequestBody {
+    enum Model: String, Encodable {
+        case tts1 = "tts-1"
+        case tts1HD = "tts-1-hd"
+    }
+}
+
+// MARK: - OpenAITextToSpeechRequestBody.ResponseFormat
+public extension OpenAITextToSpeechRequestBody {
+    enum ResponseFormat: String, Encodable {
+        case mp3, opus, aac, flac, wav, pcm
+    }
+}
+
+// MARK: - OpenAITextToSpeechRequestBody.Voice
+public extension OpenAITextToSpeechRequestBody {
+    enum Voice: String, Encodable {
+        case alloy, echo, fable, onyx, nova, shimmer
     }
 }


### PR DESCRIPTION
How to use OpenAI's text to speech API

```swift
import AIProxy

let openAIService = AIProxy.openAIService(
    partialKey: "partial-key-from-your-developer-dashboard",
    serviceURL: "service-url-from-your-developer-dashboard"
)

do {
    let requestBody = OpenAITextToSpeechRequestBody(
        input: "Hello world",
        voice: .nova
    )
    
    let mpegData = try await openAIService.createTextToSpeechRequest(body: requestBody)

    // Do not use a local `let` or `var` for AVAudioPlayer.
    // You need the lifecycle of the player to live beyond the scope of this function.
    // Instead, use file scope or set the player as a member of a reference type with long life.
    // For example, at the top of this file you may define:
    //
    //   fileprivate var audioPlayer: AVAudioPlayer? = nil
    //
    // And then use the code below to play the TTS result:
    audioPlayer = try AVAudioPlayer(data: mpegData)
    audioPlayer?.prepareToPlay()
    audioPlayer?.play()
}  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
    print("Received \(statusCode) status code with response body: \(responseBody)")
} catch {
    print("Could not create ElevenLabs TTS audio: \(error.localizedDescription)")
}

```