### PR TITLE
Add privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,14 @@ let package = Package(
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "AIProxy"),
+            name: "AIProxy",
+            resources: [
+                .process("Resources/PrivacyInfo.xcprivacy")
+            ]
+        ),
         .testTarget(
             name: "AIProxyTests",
-            dependencies: ["AIProxy"]),
+            dependencies: ["AIProxy"]
+        ),
     ]
 )

--- a/Sources/AIProxy/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/AIProxy/Resources/PrivacyInfo.xcprivacy
@@ -13,7 +13,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>AI functionality usage limits</string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>
@@ -26,7 +26,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>AI functionality usage limits</string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/Sources/AIProxy/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/AIProxy/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>IP Address</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Added privacy manifest, which is used to generate the privacy "nutrition label" of the package.

AIProxy does not use any collected data for tracking, nor do we sell any data. The pieces of data we collect (IP address and DeviceID) are used for applying request rate limits, and for display in the 'Request History' tab of the developer dashboard. Our nutrition label looks like this:

![Screenshot 2024-10-17 at 19 54 04](https://github.com/user-attachments/assets/5aaeeb7c-c4ea-4f95-bd3c-6fd0d8129936)

According to [Apple](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/adding_a_privacy_manifest_to_your_app_or_third-party_sdk):
> Starting November 12, 2024, apps that don’t include a required privacy manifest can’t be submitted for review in App Store Connect

Closes: https://github.com/lzell/AIProxySwift/issues/28