### PR TITLE
Adopt replicate synchronous API for Flux generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,9 @@ This example is a Swift port of [this guide](https://docs.together.ai/docs/llama
 
 ### How to generate a Flux-Schnell image by Black Forest Labs, using Replicate
 
+You can get image data directly by switching the call from `createFluxSchnellImageURLs` to `createFluxSchnellImages`
+in the snippet below:
+
     import AIProxy
 
     let replicateService = AIProxy.replicateService(
@@ -962,7 +965,7 @@ This example is a Swift port of [this guide](https://docs.together.ai/docs/llama
         let input = ReplicateFluxSchnellInputSchema(
             prompt: "Monument valley, Utah"
         )
-        let output = try await replicateService.createFluxSchnellImage(
+        let output = try await replicateService.createFluxSchnellImageURLs(
             input: input
         )
         print("Done creating Flux-Schnell image: ", output.first ?? "")
@@ -978,6 +981,9 @@ See the full range of controls for generating an image by viewing `ReplicateFlux
 
 ### How to generate a Flux-Dev image by Black Forest Labs, using Replicate
 
+You can get image data directly by switching the call from `createFluxDevImageURLs` to `createFluxDevImages`
+in the snippet below:
+
     import AIProxy
 
     let replicateService = AIProxy.replicateService(
@@ -989,7 +995,7 @@ See the full range of controls for generating an image by viewing `ReplicateFlux
         let input = ReplicateFluxDevInputSchema(
             prompt: "Monument valley, Utah. High res"
         )
-        let output = try await replicateService.createFluxDevImage(
+        let output = try await replicateService.createFluxDevImageURLs(
             input: input
         )
         print("Done creating Flux-Dev image: ", output.first ?? "")
@@ -1004,6 +1010,9 @@ See the full range of controls for generating an image by viewing `ReplicateFlux
 
 
 ### How to generate a Flux-Pro image by Black Forest Labs, using Replicate
+
+You can get image data directly by switching the call from `createFluxProImageURL` to `createFluxProImage`
+in the snippet below.
 
 This snippet generates a version 1.1 image. If you would like to generate version 1, make the
 following substitutions:
@@ -1023,7 +1032,7 @@ following substitutions:
         let input = ReplicateFluxProInputSchema_v1_1(
             prompt: "Monument valley, Utah. High res"
         )
-        let output = try await replicateService.createFluxProImage_v1_1(
+        let output = try await replicateService.createFluxProImageURL_v1_1(
             input: input
         )
         print("Done creating Flux-Pro image: ", output)

--- a/Sources/AIProxy/Replicate/ReplicateSynchronousAPIOutput.swift
+++ b/Sources/AIProxy/Replicate/ReplicateSynchronousAPIOutput.swift
@@ -1,0 +1,34 @@
+//
+//  ReplicateSynchronousAPIOutput.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 10/19/24.
+//
+
+import Foundation
+
+public struct ReplicateSynchronousAPIOutput<T: Decodable>: Decodable {
+    public let output: T?
+
+    /// The location of a ReplicatePredictionResponseBody
+    public let predictionResultURL: URL?
+
+    private enum CodingKeys: String, CodingKey {
+        case output
+        case urls
+    }
+
+    private enum NestedKeys: String, CodingKey {
+        case get
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.output = try container.decode(T?.self, forKey: .output)
+        let nestedContainer = try container.nestedContainer(
+            keyedBy: NestedKeys.self,
+            forKey: .urls
+        )
+        self.predictionResultURL = try nestedContainer.decode(URL?.self, forKey: .get)
+    }
+}


### PR DESCRIPTION
- Added support for Replicate's synchronous API, [announced here](https://replicate.com/changelog/2024-10-09-synchronous-api)
- Added deprecation notices to existing Flux-Schnell, Flux-Dev, and Flux-Pro methods that use polling
- Created new methods that the deprecation notices point to. The new methods use http long polling, meaning connections remain open until the prediction result is available. This reduces the number of requests that are made to AIProxy. Results also arrive faster, as we don't have to worry about a coarse polling interval.