### PR TITLE
Added support for watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
     platforms: [
          .iOS(.v15),
          .macOS(.v13),
-         .visionOS(.v1)
+         .visionOS(.v1),
+         .watchOS(.v9)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Sources/AIProxy/AIProxyIdentifier.swift
+++ b/Sources/AIProxy/AIProxyIdentifier.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-#if canImport(UIKit)
+#if os(watchOS)
+import WatchKit
+#elseif canImport(UIKit)
 import UIKit
 #elseif canImport(IOKit)
 import IOKit
@@ -17,7 +19,9 @@ struct AIProxyIdentifier {
     /// Generates a clientID for this device.
     /// - Returns: a UIDevice ID on iOS, an IOKit ID on macOS
     internal static func getClientID() -> String? {
-#if canImport(UIKit)
+#if os(watchOS)
+        return WKInterfaceDevice.current().identifierForVendor?.uuidString
+#elseif canImport(UIKit)
         return UIDevice.current.identifierForVendor?.uuidString
 #elseif canImport(IOKit)
         return getIdentifierFromIOKit()


### PR DESCRIPTION
This PR adds support for watchOS. Only a handful of changes were required:

- Using the correct device identifier
- Made sure the Package targets watchOS 9 or newer (required for `DCDevice` to work)