### PR TITLE
Add option to set content type and headers when creating custom request

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -34,6 +34,10 @@ public struct AIProxy {
     ///   - verb: The HTTP verb to use for this request. If you leave the default selection of 'automatic', then requests that
     ///     contain a body will default to `POST` while requests with no body will default to `GET`
     ///
+    ///   - contentType: The optional content type of the request body.
+    ///
+    ///   - headers: An optional set of additional headers to include in the request.
+    ///
     /// - Returns: A request containing all headers that AIProxy expects. The request is ready to be used with a url session
     ///            that you create with `AIProxy.session()`
     public static func request(
@@ -42,7 +46,9 @@ public struct AIProxy {
         clientID: String? = nil,
         proxyPath: String,
         body: Data? = nil,
-        verb: AIProxyHTTPVerb = .automatic
+        verb: AIProxyHTTPVerb = .automatic,
+        contentType: String? = nil,
+        headers: [String: String] = [:]
     ) async throws -> URLRequest {
         return try await AIProxyURLRequest.create(
             partialKey: partialKey,
@@ -50,7 +56,9 @@ public struct AIProxy {
             clientID: clientID,
             proxyPath: proxyPath,
             body: body,
-            verb: verb
+            verb: verb,
+            contentType: contentType,
+            headers: headers
         )
     }
 

--- a/Sources/AIProxy/AIProxyURLRequest.swift
+++ b/Sources/AIProxy/AIProxyURLRequest.swift
@@ -17,7 +17,8 @@ struct AIProxyURLRequest {
         proxyPath: String,
         body: Data?,
         verb: AIProxyHTTPVerb,
-        contentType: String? = nil
+        contentType: String? = nil,
+        headers: [String: String] = [:]
     ) async throws -> URLRequest {
         let deviceCheckToken = await AIProxyDeviceCheck.getToken()
 
@@ -60,6 +61,10 @@ struct AIProxyURLRequest {
 
         if let contentType = contentType {
             request.addValue(contentType, forHTTPHeaderField: "Content-Type")
+        }
+
+        for (headerField, value) in headers {
+            request.addValue(value, forHTTPHeaderField: headerField)
         }
 
         return request

--- a/Sources/AIProxy/Gemini/GeminiService.swift
+++ b/Sources/AIProxy/Gemini/GeminiService.swift
@@ -77,17 +77,16 @@ public final class GeminiService {
     ) async throws -> GeminiFile {
         let body = GeminiFileUploadRequestBody(fileData: fileData, mimeType: mimeType)
         let boundary = UUID().uuidString
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: "/upload/v1beta/files",
             body: body.serialize(withBoundary: boundary),
             verb: .post,
-            contentType: "multipart/related; boundary=\(boundary)"
+            contentType: "multipart/related; boundary=\(boundary)",
+            headers: ["X-Goog-Upload-Protocol": "multipart"]
         )
-
-        request.addValue("multipart", forHTTPHeaderField: "X-Goog-Upload-Protocol")
 
         let (data, httpResponse) = try await BackgroundNetworker.send(request: request)
         if httpResponse.statusCode > 299 {

--- a/Sources/AIProxy/Replicate/ReplicateService.swift
+++ b/Sources/AIProxy/Replicate/ReplicateService.swift
@@ -663,16 +663,16 @@ public final class ReplicateService {
                 input: input
             )
         )
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: "/v1/models/\(modelOwner)/\(modelName)/predictions",
             body: body,
             verb: .post,
-            contentType: "application/json"
+            contentType: "application/json",
+            headers: ["Prefer": "wait=\(secondsToWait)"]
         )
-        request.addValue("wait=\(secondsToWait)", forHTTPHeaderField: "Prefer")
 
         let (data, httpResponse) = try await BackgroundNetworker.send(request: request)
 

--- a/Sources/AIProxy/StabilityAI/StabilityAIService.swift
+++ b/Sources/AIProxy/StabilityAI/StabilityAIService.swift
@@ -58,16 +58,16 @@ public final class StabilityAIService {
     ) async throws -> StabilityAIImageResponse {
         let session = AIProxyURLSession.create()
         let boundary = UUID().uuidString
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: path,
             body: formEncode(body, boundary),
             verb: .post,
-            contentType: "multipart/form-data; boundary=\(boundary)"
+            contentType: "multipart/form-data; boundary=\(boundary)",
+            headers: ["Accept": "image/*"]
         )
-        request.addValue("image/*", forHTTPHeaderField: "Accept")
 
         let (data, res) = try await session.data(for: request)
         guard let httpResponse = res as? HTTPURLResponse else {


### PR DESCRIPTION
I need to set the content type and an accept header in order for calls to api.neets.ai to succeed. 

When drafting this PR I found out I could of course also just do: 

```
var request = try await AIProxyType.request(...)
request.addValue("audio/wav", forHTTPHeaderField: "accept")
request.addValue("application/json", forHTTPHeaderField: "Content-Type")
```

Ah well.. feel free to close or merge this :D 