### PR TITLE
Add EachAI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ offer full demo apps to jump-start your development. Please see the [AIProxyBoot
 * [Groq](#groq)
 * [Perplexity](#perplexity)
 * [Mistral](#mistral)
+* [EachAI](#eachai)
 * [Advanced Settings](#advanced-settings)
 
 
@@ -2027,6 +2028,45 @@ Use `api.mistral.ai` as the proxy domain when creating your AIProxy service in t
 
 ***
 
+## EachAI
+
+### How to kick off an EachAI workflow
+
+Use `flows.eachlabs.ai` as the proxy domain when creating your AIProxy service in the developer dashboard.
+
+    import AIProxy
+
+    let eachAIService = AIProxy.eachAIService(
+        partialKey: "partial-key-from-your-developer-dashboard",
+        serviceURL: "service-url-from-your-developer-dashboard"
+    )
+
+    // Update the arguments here based on your eachlabs use case:
+    let workflowID = "your-workflow-id"
+    let requestBody = EachAITriggerWorkflowRequestBody(
+        parameters: [
+            "img": "https://storage.googleapis.com/magicpoint/models/women.png"
+        ]
+    )
+
+    do {
+        let triggerResponse = try await eachAIService.triggerWorkflow(
+            workflowID: workflowID,
+            body: requestBody
+        )
+        let executionResponse = try await eachAIService.pollForWorkflowExecutionComplete(
+            workflowID: workflowID,
+            triggerID: triggerResponse.triggerID
+        )
+        print("Workflow result is available at \(executionResponse.output ?? "output missing")")
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
+    } catch {
+        print("Could not execute EachAI workflow: \(error.localizedDescription)")
+    }
+
+
+***
 
 ## OpenMeteo
 

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -434,6 +434,35 @@ public struct AIProxy {
         )
     }
 
+    /// AIProxy's EachAI service
+    ///
+    /// - Parameters:
+    ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your EachAI key.
+    ///     AIProxy takes your EachAI key, encrypts it, and stores part of the result on our servers. The part that you include
+    ///     here is the other part. Both pieces are needed to decrypt your key and fulfill the request to EachAI.
+    ///
+    ///   - serviceURL: The service URL is displayed in the AIProxy dashboard when you submit your EachAI key.
+    ///
+    ///   - clientID: An optional clientID to attribute requests to specific users or devices. It is OK to leave this blank for
+    ///     most applications. You would set this if you already have an analytics system, and you'd like to annotate AIProxy
+    ///     requests with IDs that are known to other parts of your system.
+    ///
+    ///     If you do not supply your own clientID, the internals of this lib will generate UUIDs for you. The default UUIDs are
+    ///     persistent on macOS and can be accurately used to attribute all requests to the same device. The default UUIDs
+    ///     on iOS are pesistent until the end user chooses to rotate their vendor identification number.
+    ///
+    /// - Returns: An instance of EachAIService configured and ready to make requests
+    public static func eachAIService(
+        partialKey: String,
+        serviceURL: String,
+        clientID: String? = nil
+    ) -> EachAIService {
+        return EachAIService(
+            partialKey: partialKey,
+            serviceURL: serviceURL,
+            clientID: clientID
+        )
+    }
 
 #if canImport(AppKit)
     public static func encodeImageAsJpeg(

--- a/Sources/AIProxy/EachAI/EachAIError.swift
+++ b/Sources/AIProxy/EachAI/EachAIError.swift
@@ -1,0 +1,19 @@
+//
+//  EachAIError.swift
+//
+//
+//  Created by Lou Zell on 12/8/24.
+//
+
+import Foundation
+
+enum EachAIError: LocalizedError {
+    case reachedRetryLimit
+
+    var errorDescription: String? {
+        switch self {
+        case .reachedRetryLimit:
+            return "Reached EachAI polling retry limit"
+        }
+    }
+}

--- a/Sources/AIProxy/EachAI/EachAIService.swift
+++ b/Sources/AIProxy/EachAI/EachAIService.swift
@@ -1,0 +1,151 @@
+//
+//  EachAIService.swift
+//
+//
+//  Created by Lou Zell on 12/07/24.
+//
+
+import Foundation
+
+open class EachAIService {
+    private let partialKey: String
+    private let serviceURL: String
+    private let clientID: String?
+
+    /// Creates an instance of EachAIService. Note that the initializer is not public.
+    /// Customers are expected to use the factory `AIProxy.eachAIService` defined in AIProxy.swift
+    internal init(
+        partialKey: String,
+        serviceURL: String,
+        clientID: String?
+    ) {
+        self.partialKey = partialKey
+        self.serviceURL = serviceURL
+        self.clientID = clientID
+    }
+
+    /// Runs a workflow on EachAI
+    ///
+    /// - Parameters:
+    ///   - workflowID: The workflow ID to trigger. You can find your ID in the EachAI dashboard.
+    ///                 It will be included in the URL of the workflow that you are viewing, e.g.
+    ///                 https://console.eachlabs.ai/flow/<your-id>
+    ///
+    ///   - body: The workflow request body. See this reference:
+    ///           https://docs.eachlabs.ai/api-reference/flows/trigger-ai-workflow
+    ///
+    /// - Returns: A trigger workflow response, which contains a triggerID that you can use to
+    ///           poll for the result.
+    public func triggerWorkflow(
+        workflowID: String,
+        body: EachAITriggerWorkflowRequestBody
+    ) async throws -> EachAITriggerWorkflowResponseBody {
+        let session = AIProxyURLSession.create()
+        let request = try await AIProxyURLRequest.create(
+            partialKey: self.partialKey,
+            serviceURL: self.serviceURL,
+            clientID: self.clientID,
+            proxyPath: "/api/v1/\(workflowID)/trigger",
+            body: try body.serialize(),
+            verb: .post,
+            contentType: "application/json"
+        )
+
+        let (data, res) = try await session.data(for: request)
+        guard let httpResponse = res as? HTTPURLResponse else {
+            throw AIProxyError.assertion("Network response is not an http response")
+        }
+
+        if (httpResponse.statusCode > 299) {
+            throw AIProxyError.unsuccessfulRequest(
+                statusCode: httpResponse.statusCode,
+                responseBody: String(data: data, encoding: .utf8) ?? ""
+            )
+        }
+
+        return try EachAITriggerWorkflowResponseBody.deserialize(from: data)
+    }
+
+    /// Polls for the completion of a workflow. By default, the time between polls is 10 seconds.
+    /// If you have a workflow that completes quickly, consider dropping `secondsBetweenPollingAttempts`
+    ///
+    /// - Parameters:
+    ///   - workflowID: Workflow ID
+    ///
+    ///   - triggerID: Trigger ID. This is returned from the `triggerWorkflow` call
+    ///
+    ///   - pollAttempts: Number of polling attempts to make before raising EachAIError.reachedRetryLimit
+    ///
+    ///   - secondsBetweenPollAttempts: Number of seconds between polls. Choose this value such
+    ///   that `pollAttempts * secondsBetweenPollAttempts` is the total amount of time you want
+    ///   to wait for your workflow to complete.
+    ///
+    /// - Returns: A workflow execution response with `status` set to `succeeded` and the
+    ///            `output` set to the workflow execution result.
+    public func pollForWorkflowExecutionComplete(
+        workflowID: String,
+        triggerID: String,
+        pollAttempts: Int = 60,
+        secondsBetweenPollAttempts: UInt64 = 10
+    ) async throws -> EachAIWorkflowExecutionResponseBody {
+        return try await self.actorPollForWorkflowExecutionComplete(
+            workflowID: workflowID,
+            triggerID: triggerID,
+            numTries: pollAttempts,
+            nsBetweenPollAttempts: secondsBetweenPollAttempts * 1_000_000_000
+        )
+    }
+
+    @NetworkActor
+    private func actorPollForWorkflowExecutionComplete(
+        workflowID: String,
+        triggerID: String,
+        numTries: Int,
+        nsBetweenPollAttempts: UInt64
+    ) async throws -> EachAIWorkflowExecutionResponseBody {
+        try await Task.sleep(nanoseconds: nsBetweenPollAttempts)
+        for _ in 0..<numTries {
+            let response = try await self.actorGetWorkflowExecution(
+                workflowID: workflowID,
+                triggerID: triggerID
+            )
+            if response.status == "succeeded" {
+                return response
+            }
+            print("Status is \(response.status)")
+            try await Task.sleep(nanoseconds: nsBetweenPollAttempts)
+        }
+        throw EachAIError.reachedRetryLimit
+    }
+
+    /// https://docs.eachlabs.ai/api-reference/execution/get-flow-execution
+    @NetworkActor
+    private func actorGetWorkflowExecution(
+        workflowID: String,
+        triggerID: String
+    ) async throws -> EachAIWorkflowExecutionResponseBody {
+        let session = AIProxyURLSession.create()
+        let request = try await AIProxyURLRequest.create(
+            partialKey: self.partialKey,
+            serviceURL: self.serviceURL,
+            clientID: self.clientID,
+            proxyPath: "/api/v1/\(workflowID)/executions/\(triggerID)",
+            body: nil,
+            verb: .get
+        )
+
+        let (data, res) = try await session.data(for: request)
+        guard let httpResponse = res as? HTTPURLResponse else {
+            throw AIProxyError.assertion("Network response is not an http response")
+        }
+
+        if (httpResponse.statusCode > 299) {
+            throw AIProxyError.unsuccessfulRequest(
+                statusCode: httpResponse.statusCode,
+                responseBody: String(data: data, encoding: .utf8) ?? ""
+            )
+        }
+
+        return try EachAIWorkflowExecutionResponseBody.deserialize(from: data)
+    }
+}

--- a/Sources/AIProxy/EachAI/EachAITriggerWorkflowRequestBody.swift
+++ b/Sources/AIProxy/EachAI/EachAITriggerWorkflowRequestBody.swift
@@ -1,0 +1,19 @@
+//
+//  EachAITriggerWorkflowRequestBody.swift
+//
+//
+//  Created by Lou Zell on 12/7/24.
+//
+
+import Foundation
+
+/// See this reference: https://docs.eachlabs.ai/api-reference/flows/trigger-ai-workflow
+/// Note that the workflowID is not contained in the body. Rather, it is supplied as part of the path.
+public struct EachAITriggerWorkflowRequestBody: Encodable {
+    // Required
+    let parameters: [String: AIProxyJSONValue]
+
+    public init(parameters: [String : AIProxyJSONValue]) {
+        self.parameters = parameters
+    }
+}

--- a/Sources/AIProxy/EachAI/EachAITriggerWorkflowResponseBody.swift
+++ b/Sources/AIProxy/EachAI/EachAITriggerWorkflowResponseBody.swift
@@ -1,0 +1,20 @@
+//
+//  EachAITriggerWorkflowResponseBody.swift
+//
+//
+//  Created by Lou Zell on 12/7/24.
+//
+
+import Foundation
+
+public struct EachAITriggerWorkflowResponseBody: Decodable {
+    public let triggerID: String
+    public let message: String?
+    public let status: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case triggerID = "trigger_id"
+        case message
+        case status
+    }
+}

--- a/Sources/AIProxy/EachAI/EachAIWorkflowExecutionResponseBody.swift
+++ b/Sources/AIProxy/EachAI/EachAIWorkflowExecutionResponseBody.swift
@@ -1,0 +1,75 @@
+//
+//  EachAIWorkflowExecutionResponseBody.swift
+//
+//
+//  Created by Lou Zell on 12/8/24.
+//
+
+import Foundation
+
+/// https://docs.eachlabs.ai/api-reference/execution/get-flow-execution
+public struct EachAIWorkflowExecutionResponseBody: Decodable {
+    public let averagePercent: Double?
+    public let createdAt: String?
+    public let deletedAt: String?
+    public let endedAt: String?
+    public let executionId: String?
+    public let flowId: String?
+    public let flowName: String?
+    public let organizationId: String?
+    public let output: String?
+    public let outputJson: String?
+    public let sourceIpAddress: String?
+    public let startedAt: String?
+    public let status: String?
+    public let stepResults: [StepResult]?
+    public let updatedAt: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case averagePercent = "average_percent"
+        case createdAt = "created_at"
+        case deletedAt = "deleted_at"
+        case endedAt = "ended_at"
+        case executionId = "execution_id"
+        case flowId = "flow_id"
+        case flowName = "flow_name"
+        case organizationId = "organization_id"
+        case output
+        case outputJson = "output_json"
+        case sourceIpAddress = "source_ip_address"
+        case startedAt = "started_at"
+        case status
+        case stepResults = "step_results"
+        case updatedAt = "updated_at"
+    }
+}
+
+// MARK: - ResponseBody.StepResult
+extension EachAIWorkflowExecutionResponseBody {
+    public struct StepResult: Decodable {
+        public let endedAt: String?
+        public let input: String?
+        public let model: String?
+        public let output: String?
+        public let outputJson: String?
+        public let startedAt: String?
+        public let status: String?
+        public let stepId: String?
+        public let stepName: String?
+        public let version: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case endedAt = "ended_at"
+            case input
+            case model
+            case output
+            case outputJson = "output_json"
+            case startedAt = "started_at"
+            case status
+            case stepId = "step_id"
+            case stepName = "step_name"
+            case version
+        }
+    }
+}
+

--- a/Tests/AIProxyTests/EachAIWorkflowTests.swift
+++ b/Tests/AIProxyTests/EachAIWorkflowTests.swift
@@ -1,0 +1,166 @@
+//
+//  EachAIWorkflowTests.swift
+//
+//
+//  Created by Lou Zell on 12/7/24.
+//
+
+import XCTest
+import Foundation
+@testable import AIProxy
+
+final class EachAIWorkflowTests: XCTestCase {
+
+    func testTriggerWorkflowResponseIsDecodable() throws {
+        let sampleResponse = #"""
+        {
+          "status": "success",
+          "message": "Workflow triggered successfully",
+          "trigger_id": "mp0tnsxinwymncyio"
+        }
+        """#
+        let res = try EachAITriggerWorkflowResponseBody.deserialize(from: sampleResponse)
+        XCTAssertEqual("mp0tnsxinwymncyio", res.triggerID)
+        XCTAssertEqual("success", res.status)
+        XCTAssertEqual("Workflow triggered successfully", res.message)
+    }
+
+    func testFlowExecutionResponseIsDecodable() throws {
+        let sampleResponse = #"""
+        {
+          "flow_id": "bda5f7e3-d146-454d-bdb6-befb47adb2b1",
+          "average_percent": 100,
+          "flow_name": "1940's - Clone",
+          "organization_id": "1049",
+          "api_key": "MP1019YB1TSIBUCMOWNQL3V54NY2CC6GZGXM",
+          "execution_id": "mp53sjtsdgl83y2wm",
+          "source_ip_address": "",
+          "parameters": [
+            {
+              "name": "img",
+              "value": "https://storage.googleapis.com/magicpoint/models/women.png"
+            }
+          ],
+          "step_results": [
+            {
+              "step_id": "step1",
+              "step_name": "Face Analyzer",
+              "model": "1019-face-analyzer",
+              "version": "0.0.1",
+              "started_at": "2024-12-07T21:09:37Z",
+              "ended_at": "2024-12-07T21:09:45Z",
+              "status": "succeeded",
+              "output": "{\"age\":27,\"gender\":\"Woman\",\"race\":\"white\"}",
+              "output_json": null,
+              "input": "{\"image_url\":\"https://storage.googleapis.com/magicpoint/models/women.png\"}"
+            },
+            {
+              "step_id": "step2",
+              "step_name": "Image Generation",
+              "model": "photomaker",
+              "version": "0.0.1",
+              "started_at": "2024-12-07T21:09:59Z",
+              "ended_at": "2024-12-07T21:11:04Z",
+              "status": "succeeded",
+              "output": "\"https://storage.googleapis.com/1019uploads/output/1959357c-fba7-4c96-aada-0eb6c8a05474/0.png\"",
+              "output_json": null,
+              "input": "{\"guidance_scale\":5,\"input_image\":\"https://storage.googleapis.com/magicpoint/models/women.png\",\"negative_prompt\":\"nsfw, lowres, bad anatomy, hand, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry\",\"num_outputs\":1,\"num_steps\":20,\"prompt\":\" Vintage 1920s portrait of a flapper 27-year-old white {{step1.output.gender} img with a bob haircut, captured with a Graflex Speed Graphic camera, f/4.5 lens, 1/50 sec exposure, black and white, grainy, soft focus.\",\"style_name\":\"Photographic (Default)\",\"style_strength_ratio\":20}"
+            },
+            {
+              "step_id": "step3",
+              "step_name": "Face Swap",
+              "model": "face-swap-new",
+              "version": "0.0.1",
+              "started_at": "2024-12-07T21:11:13Z",
+              "ended_at": "2024-12-07T21:11:28Z",
+              "status": "succeeded",
+              "output": "\"https://storage.googleapis.com/1019uploads/output/af240bcd-e993-4479-9722-db9251564b08/0.jpeg\"",
+              "output_json": null,
+              "input": "{\"input_image\":\"https://storage.googleapis.com/1019uploads/output/1959357c-fba7-4c96-aada-0eb6c8a05474/0.png\",\"swap_image\":\"https://storage.googleapis.com/magicpoint/models/women.png\"}"
+            }
+          ],
+          "status": "succeeded",
+          "output": "\"https://storage.googleapis.com/1019uploads/output/af240bcd-e993-4479-9722-db9251564b08/0.jpeg\"",
+          "output_json": null,
+          "created_at": "2024-12-07T21:09:30Z",
+          "started_at": "2024-12-07T21:09:30Z",
+          "ended_at": "2024-12-07T21:11:28Z",
+          "updated_at": "",
+          "deleted_at": ""
+        }
+        """#
+        let res = try EachAIWorkflowExecutionResponseBody.deserialize(from: sampleResponse)
+        XCTAssertEqual("\"https://storage.googleapis.com/1019uploads/output/af240bcd-e993-4479-9722-db9251564b08/0.jpeg\"", res.output)
+        XCTAssertEqual("Face Swap", res.stepResults?.last?.stepName)
+    }
+
+    func testPendingFlowExecutionResponseIsDecodable() throws {
+        let sampleResponse = #"""
+        {
+          "flow_id": "bda5f7e3-d146-454d-bdb6-befb47adb2b1",
+          "average_percent": 9.816666666666666,
+          "flow_name": "1940's - Clone",
+          "organization_id": "1049",
+          "api_key": "MP1019YB1TSIBUCMOWNQL3V54NY2CC6GZGXM",
+          "execution_id": "mpzzednstsokliyjz",
+          "source_ip_address": "",
+          "parameters": [
+            {
+              "name": "img",
+              "value": "https://storage.googleapis.com/magicpoint/models/women.png"
+            }
+          ],
+          "step_results": [
+            {
+              "step_id": "step1",
+              "step_name": "Face Analyzer",
+              "model": "1019-face-analyzer",
+              "version": "0.0.1",
+              "started_at": "2024-12-08T09:50:34Z",
+              "ended_at": "2024-12-08T09:50:40Z",
+              "status": "succeeded",
+              "output": "{\"age\":27,\"gender\":\"Woman\",\"race\":\"white\"}",
+              "output_json": null,
+              "input": "{\"image_url\":\"https://storage.googleapis.com/magicpoint/models/women.png\"}"
+            },
+            {
+              "step_id": "step2",
+              "step_name": "Image Generation",
+              "model": "photomaker",
+              "version": "0.0.1",
+              "started_at": "",
+              "ended_at": "",
+              "status": "queued",
+              "output": "",
+              "output_json": null,
+              "input": ""
+            },
+            {
+              "step_id": "step3",
+              "step_name": "Face Swap",
+              "model": "face-swap-new",
+              "version": "0.0.1",
+              "started_at": "",
+              "ended_at": "",
+              "status": "queued",
+              "output": "",
+              "output_json": null,
+              "input": ""
+            }
+          ],
+          "status": "running",
+          "output": "",
+          "output_json": null,
+          "created_at": "2024-12-08T09:50:29Z",
+          "started_at": "2024-12-08T09:50:29Z",
+          "ended_at": "",
+          "updated_at": "",
+          "deleted_at": ""
+        }
+        """#
+        let res = try EachAIWorkflowExecutionResponseBody.deserialize(from: sampleResponse)
+
+
+    }
+}
+

--- a/Tests/AIProxyTests/OpenAIChatCompletionRequestTests.swift
+++ b/Tests/AIProxyTests/OpenAIChatCompletionRequestTests.swift
@@ -433,7 +433,7 @@ final class OpenAIChatCompletionRequestTests: XCTestCase {
 
     func testChatCompletionRequestBodyWithImageIsEncodableToJson() throws {
         let image = createImage(width: 1, height: 1)
-        let localURL = AIProxy.openAIEncodedImage(image: image)!
+        let localURL = AIProxy.encodeImageAsURL(image: image)!
         let requestBody = OpenAIChatCompletionRequestBody(
             model: "gpt-4o",
             messages: [

--- a/Tests/AIProxyTests/PerplexityChatCompletionResponseBodyTests.swift
+++ b/Tests/AIProxyTests/PerplexityChatCompletionResponseBodyTests.swift
@@ -45,7 +45,7 @@ final class PerplexityChatCompletionResponseBodyTests: XCTestCase {
         let res = try PerplexityChatCompletionResponseBody.deserialize(
             from: responseBody
         )
-        XCTAssertEqual("Hello world.", res.choices.first?.message.content)
-        XCTAssertEqual(.assistant, res.choices.first?.message.role)
+        XCTAssertEqual("Hello world.", res.choices.first?.message?.content)
+        XCTAssertEqual(.assistant, res.choices.first?.message?.role)
     }
 }


### PR DESCRIPTION
- Adds support for kicking off a workflow execution and polling for the result.
- The trigger request is documented here: https://docs.eachlabs.ai/api-reference/flows/trigger-ai-workflow
- The polling request is documented here: https://docs.eachlabs.ai/api-reference/execution/get-flow-execution
- Swift example for calling your own workflow:

```swift
    import AIProxy

    let eachAIService = AIProxy.eachAIService(
        partialKey: "partial-key-from-your-developer-dashboard",
        serviceURL: "service-url-from-your-developer-dashboard"
    )

    // Update the arguments here based on your eachlabs use case:
    let workflowID = "your-workflow-id"
    let requestBody = EachAITriggerWorkflowRequestBody(
        parameters: [
            "img": "https://storage.googleapis.com/magicpoint/models/women.png"
        ]
    )

    do {
        let triggerResponse = try await eachAIService.triggerWorkflow(
            workflowID: workflowID,
            body: requestBody
        )
        let executionResponse = try await eachAIService.pollForWorkflowExecutionComplete(
            workflowID: workflowID,
            triggerID: triggerResponse.triggerID
        )
        print("Workflow result is available at \(executionResponse.output ?? "output missing")")
    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
    } catch {
        print("Could not execute EachAI workflow: \(error.localizedDescription)")
    }
```