### PR TITLE
Allow subclassing of AIProxyCertificatePinningDelegate

### DIFF
--- a/Sources/AIProxy/AIProxyCertificatePinning.swift
+++ b/Sources/AIProxy/AIProxyCertificatePinning.swift
@@ -49,9 +49,9 @@ import Foundation
 ///
 /// If you encounter other calls in the wild that do not invoke `urlSession:didReceiveChallenge:` on this class,
 /// please report them to me.
-final class AIProxyCertificatePinningDelegate: NSObject, URLSessionDelegate, URLSessionTaskDelegate {
+open class AIProxyCertificatePinningDelegate: NSObject, URLSessionDelegate, URLSessionTaskDelegate {
 
-   func urlSession(
+   public func urlSession(
       _ session: URLSession,
       task: URLSessionTask,
       didReceive challenge: URLAuthenticationChallenge
@@ -59,7 +59,7 @@ final class AIProxyCertificatePinningDelegate: NSObject, URLSessionDelegate, URL
       return self.answerChallenge(challenge)
    }
 
-   func urlSession(
+   public func urlSession(
       _ session: URLSession,
       didReceive challenge: URLAuthenticationChallenge
    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {

--- a/Sources/AIProxy/AIProxyURLSession.swift
+++ b/Sources/AIProxy/AIProxyURLSession.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct AIProxyURLSession {
-    private static let delegate = AIProxyCertificatePinningDelegate()
+public struct AIProxyURLSession {
+    public static var delegate = AIProxyCertificatePinningDelegate()
 
     /// Creates a URLSession that is configured for communication with aiproxy.pro
     static func create() -> URLSession {


### PR DESCRIPTION
This allows us to create a subclass of the session delegate, to override functions for tracking progress (whilst still maintaining certificate pinning) such as:
```swift
func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64)
```
and
```swift
func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data)
```

We can use it by simply overriding the delegate:
```swift
final class ProgressMonitoringSessionDelegate: AIProxyCertificatePinningDelegate {
...
}

AIProxyURLSession.delegate = ProgressMonitoringSessionDelegate()
```