### PR TITLE
Add Anthropic pdf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1138,6 +1138,114 @@ Use `UIImage` in place of `NSImage` for iOS apps:
     }
 
 
+## How to use Anthropic's pdf support in a buffered chat completion
+
+This snippet includes a pdf `mydocument.pdf` in the Anthropic request. Adjust the filename to
+match the pdf included in your Xcode project. The snippet expects the pdf in the app bundle.
+
+    ```swift
+    import AIProxy
+
+    /* Uncomment for BYOK use cases */
+    // let anthropicService = AIProxy.anthropicDirectService(
+    //     unprotectedAPIKey: "your-anthropic-key"
+    // )
+
+    /* Uncomment for all other production use cases */
+    // let anthropicService = AIProxy.anthropicService(
+    //     partialKey: "partial-key-from-your-developer-dashboard",
+    //     serviceURL: "service-url-from-your-developer-dashboard"
+    // )
+
+    guard let pdfFileURL = Bundle.main.url(forResource: "mydocument", withExtension: "pdf"),
+          let pdfData = try? Data(contentsOf: pdfFileURL)
+    else {
+        print("""
+              Drop mydocument.pdf file into your Xcode project first.
+              """)
+        return
+    }
+
+    do {
+        let response = try await anthropicService.messageRequest(body: AnthropicMessageRequestBody(
+            maxTokens: 1024,
+            messages: [
+                AnthropicInputMessage(content: [.pdf(data: pdfData.base64EncodedString())], role: .user),
+                AnthropicInputMessage(content: [.text("Summarize this")], role: .user)
+            ],
+            model: "claude-3-5-sonnet-20241022"
+        ))
+        for content in response.content {
+            switch content {
+            case .text(let message):
+                print("Claude sent a message: \(message)")
+            case .toolUse(id: _, name: let toolName, input: let toolInput):
+                print("Claude used a tool \(toolName) with input: \(toolInput)")
+            }
+        }
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
+    } catch {
+        print("Could not use Anthropic's buffered pdf support: \(error.localizedDescription)")
+    }
+    ```
+
+
+## How to use Anthropic's pdf support in a streaming chat completion
+
+This snippet includes a pdf `mydocument.pdf` in the Anthropic request. Adjust the filename to
+match the pdf included in your Xcode project. The snippet expects the pdf in the app bundle.
+
+    ```swift
+    import AIProxy
+
+    /* Uncomment for BYOK use cases */
+    // let anthropicService = AIProxy.anthropicDirectService(
+    //     unprotectedAPIKey: "your-anthropic-key"
+    // )
+
+    /* Uncomment for all other production use cases */
+    // let anthropicService = AIProxy.anthropicService(
+    //     partialKey: "partial-key-from-your-developer-dashboard",
+    //     serviceURL: "service-url-from-your-developer-dashboard"
+    // )
+
+    guard let pdfFileURL = Bundle.main.url(forResource: "mydocument", withExtension: "pdf"),
+          let pdfData = try? Data(contentsOf: pdfFileURL)
+    else {
+        print("""
+              Drop mydocument.pdf file into your Xcode project first.
+              """)
+        return
+    }
+
+    do {
+        let stream = try await anthropicService.streamingMessageRequest(body: AnthropicMessageRequestBody(
+            maxTokens: 1024,
+            messages: [
+                AnthropicInputMessage(content: [.pdf(data: pdfData.base64EncodedString())], role: .user),
+                AnthropicInputMessage(content: [.text("Summarize this")], role: .user)
+            ],
+            model: "claude-3-5-sonnet-20241022"
+        ))
+        for try await chunk in stream {
+            switch chunk {
+            case .text(let text):
+                print(text)
+            case .toolUse(name: let toolName, input: let toolInput):
+                print("Claude wants to call tool \(toolName) with input \(toolInput)")
+            }
+        }
+        print("Done with stream")
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
+    } catch {
+        print("Could not use Anthropic's streaming pdf support: \(error.localizedDescription)")
+    }
+
+    ```
+
+
 ***
 
 

--- a/README.md
+++ b/README.md
@@ -1242,7 +1242,6 @@ match the pdf included in your Xcode project. The snippet expects the pdf in the
     } catch {
         print("Could not use Anthropic's streaming pdf support: \(error.localizedDescription)")
     }
-
     ```
 
 

--- a/Sources/AIProxy/Anthropic/AnthropicDirectService.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicDirectService.swift
@@ -28,16 +28,20 @@ open class AnthropicDirectService: AnthropicService, DirectService {
     ) async throws -> AnthropicMessageResponseBody {
         var body = body
         body.stream = false
+        var additionalHeaders = [
+            "x-api-key": self.unprotectedAPIKey,
+            "anthropic-version": "2023-06-01",
+        ]
+        if body.needsPDFBeta {
+            additionalHeaders["anthropic-beta"] = "pdfs-2024-09-25"
+        }
         let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.anthropic.com",
             path: "/v1/messages",
             body: try body.serialize(),
             verb: .post,
             contentType: "application/json",
-            additionalHeaders: [
-                "x-api-key": self.unprotectedAPIKey,
-                "anthropic-version": "2023-06-01",
-            ]
+            additionalHeaders: additionalHeaders
         )
         return try await self.makeRequestAndDeserializeResponse(request)
     }
@@ -54,16 +58,20 @@ open class AnthropicDirectService: AnthropicService, DirectService {
     ) async throws -> AnthropicAsyncChunks {
         var body = body
         body.stream = true
+        var additionalHeaders = [
+            "x-api-key": self.unprotectedAPIKey,
+            "anthropic-version": "2023-06-01",
+        ]
+        if body.needsPDFBeta {
+            additionalHeaders["anthropic-beta"] = "pdfs-2024-09-25"
+        }
         let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.anthropic.com",
             path: "/v1/messages",
             body: try body.serialize(),
             verb: .post,
             contentType: "application/json",
-            additionalHeaders: [
-                "x-api-key": self.unprotectedAPIKey,
-                "anthropic-version": "2023-06-01",
-            ]
+            additionalHeaders: additionalHeaders
         )
         let (asyncBytes, _) = try await BackgroundNetworker.makeRequestAndWaitForAsyncBytes(self.urlSession, request)
         return AnthropicAsyncChunks(asyncLines: asyncBytes.lines)

--- a/Sources/AIProxy/Anthropic/AnthropicProxiedService.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicProxiedService.swift
@@ -32,6 +32,12 @@ open class AnthropicProxiedService: AnthropicService, ProxiedService {
     ) async throws -> AnthropicMessageResponseBody {
         var body = body
         body.stream = false
+        var additionalHeaders = [
+            "anthropic-version": "2023-06-01",
+        ]
+        if body.needsPDFBeta {
+            additionalHeaders["anthropic-beta"] = "pdfs-2024-09-25"
+        }
         let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
@@ -39,7 +45,8 @@ open class AnthropicProxiedService: AnthropicService, ProxiedService {
             proxyPath: "/v1/messages",
             body: try body.serialize(),
             verb: .post,
-            contentType: "application/json"
+            contentType: "application/json",
+            additionalHeaders: additionalHeaders
         )
         return try await self.makeRequestAndDeserializeResponse(request)
     }
@@ -56,6 +63,12 @@ open class AnthropicProxiedService: AnthropicService, ProxiedService {
     ) async throws -> AnthropicAsyncChunks {
         var body = body
         body.stream = true
+        var additionalHeaders = [
+            "anthropic-version": "2023-06-01",
+        ]
+        if body.needsPDFBeta {
+            additionalHeaders["anthropic-beta"] = "pdfs-2024-09-25"
+        }
         let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
@@ -63,7 +76,8 @@ open class AnthropicProxiedService: AnthropicService, ProxiedService {
             proxyPath: "/v1/messages",
             body: try body.serialize(),
             verb: .post,
-            contentType: "application/json"
+            contentType: "application/json",
+            additionalHeaders: additionalHeaders
         )
         let (asyncBytes, _) = try await BackgroundNetworker.makeRequestAndWaitForAsyncBytes(self.urlSession, request)
         return AnthropicAsyncChunks(asyncLines: asyncBytes.lines)


### PR DESCRIPTION
- PDFs can be included in chat completion requests to Anthropic.
- The README includes two examples:
  1. pdf summarization with a buffered response
  2. pdf summarization with a streaming response