### PR TITLE
Support passing function call results back to OpenAI

### DIFF
--- a/Sources/AIProxy/AIProxyJSONValue.swift
+++ b/Sources/AIProxy/AIProxyJSONValue.swift
@@ -43,6 +43,7 @@ public enum AIProxyJSONValue: Codable {
     case array([AIProxyJSONValue])
     case object([String: AIProxyJSONValue])
 
+
     public func encode(to encoder: Encoder) throws {
          var container = encoder.singleValueContainer()
          switch self {
@@ -93,6 +94,14 @@ extension [String: AIProxyJSONValue] {
         return convertToUntypedDictionary(self)
     }
 }
+
+#if false
+extension [String: Any] {
+    public var jsonDictionary: [String: AIProxyJSONValue] {
+        return convertToTypedDictionary(self)
+    }
+}
+#endif
 
 extension AIProxyJSONValue: ExpressibleByNilLiteral {
   public init(nilLiteral: ()) {
@@ -177,3 +186,35 @@ private func convertToUntypedDictionary(
         }
     }
 }
+
+#if false
+private func convertToTyped(_ input: Any) -> AIProxyJSONValue {
+    switch input {
+    case is NSNull:
+        return .null(NSNull())
+    case let bool as Bool:
+        return .bool(bool)
+    case let int as Int:
+        return .int(int)
+    case let double as Double:
+        return .double(double)
+    case let string as String:
+        return .string(string)
+    case let array as [Any]:
+        return .array(array.map { convertToTyped($0) })
+    case let dictionary as [String: Any]:
+        return .object(convertToTypedDictionary(dictionary))
+    default:
+        return .string("\(input)")
+    }
+}
+
+private func convertToTypedDictionary(
+    _ input: [String: Any]
+) -> [String: AIProxyJSONValue] {
+    return input.mapValues { v in
+        return convertToTyped(v)
+    }
+}
+#endif
+

--- a/Sources/AIProxy/SingleOrPartsEncodable.swift
+++ b/Sources/AIProxy/SingleOrPartsEncodable.swift
@@ -1,0 +1,17 @@
+//
+//  SingleOrPartsEncodable.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 1/16/25.
+//
+
+protocol SingleOrPartsEncodable {
+    var encodableItem: any Encodable { get }
+}
+
+extension SingleOrPartsEncodable {
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.encodableItem)
+    }
+}

--- a/Tests/AIProxyTests/OpenAIChatCompletionRequestTests.swift
+++ b/Tests/AIProxyTests/OpenAIChatCompletionRequestTests.swift
@@ -41,7 +41,7 @@ final class OpenAIChatCompletionRequestTests: XCTestCase {
     }
 
     func testTextChatContentPartIsEncodable() throws {
-        let chatContentPart: OpenAIChatCompletionRequestBody.Message.UserContent.Part = .text("abc")
+        let chatContentPart: OpenAIChatCompletionRequestBody.Message.ContentPart = .text("abc")
         XCTAssertEqual(
             """
             {
@@ -56,7 +56,7 @@ final class OpenAIChatCompletionRequestTests: XCTestCase {
     func testImageChatContentPartIsEncodable() throws {
         let image = createImage(width: 1, height: 1)
         let localURL = AIProxy.encodeImageAsURL(image: image)!
-        let chatContentPart: OpenAIChatCompletionRequestBody.Message.UserContent.Part = .imageURL(localURL)
+        let chatContentPart: OpenAIChatCompletionRequestBody.Message.ContentPart = .imageURL(localURL)
         XCTAssertEqual(
             #"""
             {
@@ -71,7 +71,7 @@ final class OpenAIChatCompletionRequestTests: XCTestCase {
     }
 
     func testChatContentOfMultipleTextIsEncodable() throws {
-        let chatContent: [OpenAIChatCompletionRequestBody.Message.UserContent.Part] = [
+        let chatContent: [OpenAIChatCompletionRequestBody.Message.ContentPart] = [
             .text("a"),
             .text("b")
         ]
@@ -95,7 +95,7 @@ final class OpenAIChatCompletionRequestTests: XCTestCase {
     func testChatContentContainingImageIsEncodable() throws {
         let image = createImage(width: 1, height: 1)
         let localURL = AIProxy.encodeImageAsURL(image: image)!
-        let chatContent: [OpenAIChatCompletionRequestBody.Message.UserContent.Part] = [
+        let chatContent: [OpenAIChatCompletionRequestBody.Message.ContentPart] = [
             .text("hello"),
             .imageURL(localURL)
         ]
@@ -188,6 +188,121 @@ final class OpenAIChatCompletionRequestTests: XCTestCase {
             }
             """#,
             try userMessage.serialize(pretty: true)
+        )
+    }
+
+    func testAssistantMessageWithTextContentIsEncodable() throws {
+        let assistantMessage: OpenAIChatCompletionRequestBody.Message = .assistant(content: .text("hello"))
+        XCTAssertEqual(
+            """
+            {
+              "content" : "hello",
+              "role" : "assistant"
+            }
+            """,
+            try assistantMessage.serialize(pretty: true)
+        )
+    }
+
+    func testAssistantMessageWithMultiplePartsIsEncodable() throws {
+        let assistantMessage: OpenAIChatCompletionRequestBody.Message = .assistant(content: .parts(["hello", "world"]))
+        XCTAssertEqual(
+            """
+            {
+              "content" : [
+                "hello",
+                "world"
+              ],
+              "role" : "assistant"
+            }
+            """,
+            try assistantMessage.serialize(pretty: true)
+        )
+    }
+
+    func testAssistantMessageWithToolCallIsEncodable() throws {
+        let assistantMessage: OpenAIChatCompletionRequestBody.Message = .assistant(
+            toolCalls: [
+                .init(
+                    id: "abc",
+                    function: .init(name: "get_weather", arguments: ["location": "San Francisco, California"])
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            """
+            {
+              "role" : "assistant",
+              "tool_calls" : [
+                {
+                  "function" : {
+                    "arguments" : {
+                      "location" : "San Francisco, California"
+                    },
+                    "name" : "get_weather"
+                  },
+                  "id" : "abc",
+                  "type" : "function"
+                }
+              ]
+            }
+            """,
+            try assistantMessage.serialize(pretty: true)
+        )
+    }
+
+    func testToolMessageIsEncodable() throws {
+        let toolMessage: OpenAIChatCompletionRequestBody.Message = .tool(
+            content: .text("Hello world"),
+            toolCallID: "abc"
+        )
+        XCTAssertEqual(
+            """
+            {
+              "content" : "Hello world",
+              "role" : "tool",
+              "tool_call_id" : "abc"
+            }
+            """,
+            try toolMessage.serialize(pretty: true)
+        )
+    }
+
+    func testDeveloperMessageWithTextContentIsEncodable() throws {
+        let developerMessage: OpenAIChatCompletionRequestBody.Message = .developer(
+            content: .text("hello"),
+            name: "alice"
+        )
+        XCTAssertEqual(
+            """
+            {
+              "content" : "hello",
+              "name" : "alice",
+              "role" : "developer"
+            }
+            """,
+            try developerMessage.serialize(pretty: true)
+        )
+    }
+
+    func testDeveloperMessageWithMultiplePartsIsEncodable() throws {
+        let developerMessage: OpenAIChatCompletionRequestBody.Message = .developer(
+            content: .parts(["hello", "world"]),
+            name: "alice"
+        )
+        XCTAssertEqual(
+            """
+            {
+              "content" : [
+                "hello",
+                "world"
+              ],
+              "name" : "alice",
+              "role" : "developer"
+            }
+            """,
+            try developerMessage.serialize(pretty: true)
         )
     }
 


### PR DESCRIPTION
- Added codables for passing function call information back to OpenAI
- See the guide on using [OpenAI function calls in swift](https://www.aiproxy.com/update/2025/01/17/OpenAI-function-calls-in-swift.html)
- Closes issue: https://github.com/lzell/AIProxySwift/issues/87