### PR TITLE
Add a receipt validation service

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -11,6 +11,10 @@ let aiproxyLogger = Logger(
 )
 
 public struct AIProxy {
+
+    /// The current sdk version
+    public static let sdkVersion = "0.60.0"
+
     /// - Parameters:
     ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your provider's key.
     ///     AIProxy takes your key, encrypts it, and stores part of the result on our servers. The part that you include

--- a/Sources/AIProxy/AIProxyURLRequest.swift
+++ b/Sources/AIProxy/AIProxyURLRequest.swift
@@ -49,8 +49,9 @@ struct AIProxyURLRequest {
             request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
         }
 
-        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-            request.addValue("v1|\(appVersion)", forHTTPHeaderField: "aiproxy-metadata")
+        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as?  String,
+           let bundleID = Bundle.main.bundleIdentifier{
+            request.addValue("v2|\(bundleID)|\(appVersion)|\(AIProxy.sdkVersion)", forHTTPHeaderField: "aiproxy-metadata")
         }
 
     #if targetEnvironment(simulator)

--- a/Sources/AIProxy/ReceiptValidation/ReceiptValidationRequestBody.swift
+++ b/Sources/AIProxy/ReceiptValidation/ReceiptValidationRequestBody.swift
@@ -1,0 +1,70 @@
+//
+//  ReceiptValidationRequestBody.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 1/28/25.
+//
+
+/// Encapsulates the data from StoreKit's AppTransaction
+public struct ReceiptValidationRequestBody: Encodable {
+    /// The JSON representation of the transaction.
+    public let jsonRepresentationBase64: String
+
+    /// A number the App Store uses to uniquely identify the application.
+    public let appID: UInt64?
+
+    /// The application version the transaction is for.
+    public let appVersion: String
+
+    /// A number the App Store uses to uniquely identify the version of the application.
+    public let appVersionID: UInt64?
+
+    /// Identifies the application the transaction is for.
+    public let bundleID: String
+
+    /// The server environment this transaction was created in.
+    public let environment: String
+
+    /// The version of the app originally purchased.
+    public let originalAppVersion: String
+
+    /// The date this original app purchase occurred on.
+    public let originalPurchaseDate: Double
+
+    /// A SHA-384 hash of `AppStore.deviceVerificationID` appended after
+    /// `deviceVerificationNonce` (both lowercased UUID strings).
+    public let deviceVerificationBase64: String
+
+    /// The nonce used when computing `deviceVerification`.
+    /// - SeeAlso: `AppStore.deviceVerificationID`
+    public let deviceVerificationNonce: String
+
+    /// The date this transaction was generated and signed.
+    public let signedDate: Double
+
+    public init(
+        jsonRepresentationBase64: String,
+        appID: UInt64? = nil,
+        appVersion: String,
+        appVersionID: UInt64? = nil,
+        bundleID: String,
+        environment: String,
+        originalAppVersion: String,
+        originalPurchaseDate: Double,
+        deviceVerificationBase64: String,
+        deviceVerificationNonce: String,
+        signedDate: Double
+    ) {
+        self.jsonRepresentationBase64 = jsonRepresentationBase64
+        self.appID = appID
+        self.appVersion = appVersion
+        self.appVersionID = appVersionID
+        self.bundleID = bundleID
+        self.environment = environment
+        self.originalAppVersion = originalAppVersion
+        self.originalPurchaseDate = originalPurchaseDate
+        self.deviceVerificationBase64 = deviceVerificationBase64
+        self.deviceVerificationNonce = deviceVerificationNonce
+        self.signedDate = signedDate
+    }
+}

--- a/Sources/AIProxy/ReceiptValidation/ReceiptValidationResponseBody.swift
+++ b/Sources/AIProxy/ReceiptValidation/ReceiptValidationResponseBody.swift
@@ -1,0 +1,10 @@
+//
+//  ReceiptValidationResponseBody.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 1/28/25.
+//
+
+public struct ReceiptValidationResponseBody: Decodable {
+    public let isValid: Bool
+}

--- a/Sources/AIProxy/ReceiptValidation/ReceiptValidationService.swift
+++ b/Sources/AIProxy/ReceiptValidation/ReceiptValidationService.swift
@@ -1,0 +1,43 @@
+//
+//  ReceiptValidationService.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 1/28/25.
+//
+
+open class ReceiptValidationService: ProxiedService {
+
+    public let publishableKey: String
+    public let serviceURL: String
+    public let clientID: String?
+
+    public init(
+        publishableKey: String,
+        serviceURL: String,
+        clientID: String? = nil
+    ) {
+        self.publishableKey = publishableKey
+        self.serviceURL = serviceURL
+        self.clientID = clientID
+    }
+
+    /// Makes a request to validate the app purchase
+    ///
+    /// - Parameters:
+    ///   - body: The request body to send to aiproxy
+    /// - Returns: The validation result
+    public func validateReceipt(
+        body: ReceiptValidationRequestBody
+    ) async throws -> ReceiptValidationResponseBody {
+        let request = try await AIProxyURLRequest.create(
+            partialKey: self.publishableKey,
+            serviceURL: self.serviceURL,
+            clientID: self.clientID,
+            proxyPath: "/validate",
+            body: try body.serialize(),
+            verb: .post,
+            contentType: "application/json"
+        )
+        return try await self.makeRequestAndDeserializeResponse(request)
+    }
+}


### PR DESCRIPTION
- Sends the contents of AppTransaction up to AIProxy
  - Note that this does not happen automatically! Customers opt-in to use this service
- Adds the bundle ID and library version to metadata that goes up with all AIProxy requests
