### PR TITLE
Add Fireworks AI support for DeepSeek

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -739,6 +739,50 @@ public struct AIProxy {
         )
     }
 
+    /// AIProxy's FireworksAI service
+    ///
+    /// - Parameters:
+    ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your FireworksAI key.
+    ///     AIProxy takes your FireworksAI key, encrypts it, and stores part of the result on our servers. The part that you include
+    ///     here is the other part. Both pieces are needed to decrypt your key and fulfill the request to FireworksAI.
+    ///
+    ///   - serviceURL: The service URL is displayed in the AIProxy dashboard when you submit your FireworksAI key.
+    ///
+    ///   - clientID: An optional clientID to attribute requests to specific users or devices. It is OK to leave this blank for
+    ///     most applications. You would set this if you already have an analytics system, and you'd like to annotate AIProxy
+    ///     requests with IDs that are known to other parts of your system.
+    ///
+    ///     If you do not supply your own clientID, the internals of this lib will generate UUIDs for you. The default UUIDs are
+    ///     persistent on macOS and can be accurately used to attribute all requests to the same device. The default UUIDs
+    ///     on iOS are pesistent until the end user chooses to rotate their vendor identification number.
+    ///
+    /// - Returns: An instance of FireworksAIService configured and ready to make requests
+    public static func fireworksAIService(
+        partialKey: String,
+        serviceURL: String,
+        clientID: String? = nil
+    ) -> FireworksAIService {
+        return FireworksAIProxiedService(
+            partialKey: partialKey,
+            serviceURL: serviceURL,
+            clientID: clientID
+        )
+    }
+
+    /// Service that makes request directly to FireworksAI. No protections are built-in for this service.
+    /// Please only use this for BYOK use cases.
+    ///
+    /// - Parameters:
+    ///   - unprotectedAPIKey: Your FireworksAI API key
+    /// - Returns: An instance of  FireworksAI configured and ready to make requests
+    public static func fireworksAIDirectService(
+        unprotectedAPIKey: String
+    ) -> FireworksAIService {
+        return FireworksAIDirectService(
+            unprotectedAPIKey: unprotectedAPIKey
+        )
+    }
+
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     public static func encodeImageAsJpeg(
         image: NSImage,

--- a/Sources/AIProxy/FireworksAI/FireworksAIDirectService.swift
+++ b/Sources/AIProxy/FireworksAI/FireworksAIDirectService.swift
@@ -1,0 +1,89 @@
+//
+//  FireworksAIDirectService.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 1/29/25.
+//
+
+import Foundation
+
+open class FireworksAIDirectService: FireworksAIService, DirectService {
+
+    private let unprotectedAPIKey: String
+
+    /// This initializer is not public on purpose.
+    /// Customers are expected to use the factory `AIProxy.directFireworksAIService` defined in AIProxy.swift
+    internal init(
+        unprotectedAPIKey: String
+    ) {
+        self.unprotectedAPIKey = unprotectedAPIKey
+    }
+
+    /// Initiates a non-streaming chat completion request to DeepSeek R1 at api.fireworks.ai/inference/v1/chat/completions
+    ///
+    /// - Parameters:
+    ///   - body: The request body to send to FireworksAI. See these references:
+    ///           https://fireworks.ai/models/fireworks/deepseek-r1
+    ///           https://api-docs.deepseek.com/api/create-chat-completion
+    ///   - secondsToWait: The number of seconds to wait before timing out
+    /// - Returns: The chat response. See this reference:
+    ///            https://api-docs.deepseek.com/api/create-chat-completion#responses
+    public func deepSeekR1Request(
+        body: DeepSeekChatCompletionRequestBody,
+        secondsToWait: Int
+    ) async throws -> DeepSeekChatCompletionResponseBody {
+        if body.model != "accounts/fireworks/models/deepseek-r1" {
+            aiproxyLogger.warning("Attempting to use deepSeekR1Request with an unknown model")
+        }
+        var body = body
+        body.stream = false
+        body.streamOptions = nil
+        var request = try AIProxyURLRequest.createDirect(
+            baseURL: "https://api.fireworks.ai",
+            path: "/inference/v1/chat/completions",
+            body: try body.serialize(),
+            verb: .post,
+            contentType: "application/json",
+            additionalHeaders: [
+                "Authorization": "Bearer \(self.unprotectedAPIKey)",
+                "Accept": "application/json"
+            ]
+        )
+        request.timeoutInterval = TimeInterval(secondsToWait)
+        return try await self.makeRequestAndDeserializeResponse(request)
+    }
+
+    /// Initiates a streaming chat completion request to DeepSeek R1 at api.fireworks.ai/inference/v1/chat/completions
+    ///
+    /// - Parameters:
+    ///   - body: The request body to send to FireworksAI.  See these references:
+    ///           https://fireworks.ai/models/fireworks/deepseek-r1
+    ///           https://api-docs.deepseek.com/api/create-chat-completion
+    ///   - secondsToWait: The number of seconds to wait before timing out
+    /// - Returns: An async sequence of completion chunks. See the 'Streaming' tab here:
+    ///           https://api-docs.deepseek.com/api/create-chat-completion#responses
+    public func streamingDeepSeekR1Request(
+        body: DeepSeekChatCompletionRequestBody,
+        secondsToWait: Int
+    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
+        if body.model != "accounts/fireworks/models/deepseek-r1" {
+            aiproxyLogger.warning("Attempting to use deepSeekR1Request with an unknown model")
+        }
+        var body = body
+        body.stream = true
+        body.streamOptions = .init(includeUsage: true)
+        var request = try AIProxyURLRequest.createDirect(
+            baseURL: "https://api.fireworks.ai",
+            path: "/inference/v1/chat/completions",
+            body: try body.serialize(),
+            verb: .post,
+            contentType: "application/json",
+            additionalHeaders: [
+                "Authorization": "Bearer \(self.unprotectedAPIKey)",
+                "Accept": "application/json"
+            ]
+        )
+        request.timeoutInterval = TimeInterval(secondsToWait)
+        return try await self.makeRequestAndDeserializeStreamingChunks(request)
+   }
+}

--- a/Sources/AIProxy/FireworksAI/FireworksAIProxiedService.swift
+++ b/Sources/AIProxy/FireworksAI/FireworksAIProxiedService.swift
@@ -1,0 +1,91 @@
+//
+//  FireworksAIProxiedService.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 1/29/25.
+//
+
+import Foundation
+
+open class FireworksAIProxiedService: FireworksAIService, ProxiedService {
+
+    private let partialKey: String
+    private let serviceURL: String
+    private let clientID: String?
+
+    /// This initializer is not public on purpose.
+    /// Customers are expected to use the factory `AIProxy.fireworksAIService` defined in AIProxy.swift
+    internal init(
+        partialKey: String,
+        serviceURL: String,
+        clientID: String?
+    ) {
+        self.partialKey = partialKey
+        self.serviceURL = serviceURL
+        self.clientID = clientID
+    }
+
+    /// Initiates a non-streaming chat completion request to DeepSeek R1 at api.fireworks.ai/inference/v1/chat/completions
+    ///
+    /// - Parameters:
+    ///   - body: The request body to send to FireworksAI. See these references:
+    ///           https://fireworks.ai/models/fireworks/deepseek-r1
+    ///           https://api-docs.deepseek.com/api/create-chat-completion
+    ///   - secondsToWait: The number of seconds to wait before timing out
+    /// - Returns: The chat response. See this reference:
+    ///            https://api-docs.deepseek.com/api/create-chat-completion#responses
+    public func deepSeekR1Request(
+        body: DeepSeekChatCompletionRequestBody,
+        secondsToWait: Int
+    ) async throws -> DeepSeekChatCompletionResponseBody {
+        if body.model != "accounts/fireworks/models/deepseek-r1" {
+            aiproxyLogger.warning("Attempting to use deepSeekR1Request with an unknown model")
+        }
+        var body = body
+        body.stream = false
+        body.streamOptions = nil
+        var request = try await AIProxyURLRequest.create(
+            partialKey: self.partialKey,
+            serviceURL: self.serviceURL,
+            clientID: self.clientID,
+            proxyPath: "/inference/v1/chat/completions",
+            body: try body.serialize(),
+            verb: .post,
+            contentType: "application/json"
+        )
+        request.timeoutInterval = TimeInterval(secondsToWait)
+        return try await self.makeRequestAndDeserializeResponse(request)
+    }
+
+    /// Initiates a streaming chat completion request to DeepSeek R1 at api.fireworks.ai/inference/v1/chat/completions
+    ///
+    /// - Parameters:
+    ///   - body: The request body to send to FireworksAI.  See these references:
+    ///           https://fireworks.ai/models/fireworks/deepseek-r1
+    ///           https://api-docs.deepseek.com/api/create-chat-completion
+    ///   - secondsToWait: The number of seconds to wait before timing out
+    /// - Returns: An async sequence of completion chunks. See the 'Streaming' tab here:
+    ///           https://api-docs.deepseek.com/api/create-chat-completion#responses
+    public func streamingDeepSeekR1Request(
+        body: DeepSeekChatCompletionRequestBody,
+        secondsToWait: Int
+    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
+        if body.model != "accounts/fireworks/models/deepseek-r1" {
+            aiproxyLogger.warning("Attempting to use deepSeekR1Request with an unknown model")
+        }
+        var body = body
+        body.stream = true
+        body.streamOptions = .init(includeUsage: true)
+        var request = try await AIProxyURLRequest.create(
+            partialKey: self.partialKey,
+            serviceURL: self.serviceURL,
+            clientID: self.clientID,
+            proxyPath: "/inference/v1/chat/completions",
+            body: try body.serialize(),
+            verb: .post,
+            contentType: "application/json"
+        )
+        request.timeoutInterval = TimeInterval(secondsToWait)
+        return try await self.makeRequestAndDeserializeStreamingChunks(request)
+    }
+}

--- a/Sources/AIProxy/FireworksAI/FireworksAIService.swift
+++ b/Sources/AIProxy/FireworksAI/FireworksAIService.swift
@@ -1,0 +1,39 @@
+//
+//  FireworksAIService.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 1/29/25.
+//
+
+import Foundation
+
+public protocol FireworksAIService {
+
+    /// Initiates a non-streaming chat completion request to DeepSeek R1 at api.fireworks.ai/inference/v1/chat/completions
+    ///
+    /// - Parameters:
+    ///   - body: The request body to send to FireworksAI. See these references:
+    ///           https://fireworks.ai/models/fireworks/deepseek-r1
+    ///           https://api-docs.deepseek.com/api/create-chat-completion
+    ///   - secondsToWait: The number of seconds to wait before timing out
+    /// - Returns: The chat response. See this reference:
+    ///            https://api-docs.deepseek.com/api/create-chat-completion#responses
+    func deepSeekR1Request(
+        body: DeepSeekChatCompletionRequestBody,
+        secondsToWait: Int
+    ) async throws -> DeepSeekChatCompletionResponseBody
+
+    /// Initiates a streaming chat completion request to DeepSeek R1 at api.fireworks.ai/inference/v1/chat/completions
+    ///
+    /// - Parameters:
+    ///   - body: The request body to send to FireworksAI.  See these references:
+    ///           https://fireworks.ai/models/fireworks/deepseek-r1
+    ///           https://api-docs.deepseek.com/api/create-chat-completion
+    ///   - secondsToWait: The number of seconds to wait before timing out
+    /// - Returns: An async sequence of completion chunks. See the 'Streaming' tab here:
+    ///           https://api-docs.deepseek.com/api/create-chat-completion#responses
+    func streamingDeepSeekR1Request(
+        body: DeepSeekChatCompletionRequestBody,
+        secondsToWait: Int
+    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk>
+}


### PR DESCRIPTION
- AIProxySwift can be used to make requests directly to Fireworks AI or protected through our backend.
  - Customers should configure their AIProxy service to use proxy domain `api.fireworks.ai`
- Added a readme example of streaming R1 use
- Added a readme example of buffered R1 use