### PR TITLE
Touch up Replicate convenience helpers

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -13,7 +13,7 @@ let aiproxyLogger = Logger(
 public struct AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.60.0"
+    public static let sdkVersion = "0.62.0"
 
     /// - Parameters:
     ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your provider's key.
@@ -786,7 +786,7 @@ public struct AIProxy {
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     public static func encodeImageAsJpeg(
         image: NSImage,
-        compressionQuality: CGFloat = 1.0
+        compressionQuality: CGFloat /* = 1.0 */
     ) -> Data? {
         return AIProxyUtils.encodeImageAsJpeg(image, compressionQuality)
     }
@@ -794,14 +794,14 @@ public struct AIProxy {
     @available(*, deprecated, message: "This function is deprecated. Use AIProxy.encodeImageAsURL instead.")
     public static func openAIEncodedImage(
         image: NSImage,
-        compressionQuality: CGFloat = 1.0
+        compressionQuality: CGFloat /* = 1.0 */
     ) -> URL? {
         return AIProxyUtils.encodeImageAsURL(image, compressionQuality)
     }
 
     public static func encodeImageAsURL(
         image: NSImage,
-        compressionQuality: CGFloat = 1.0
+        compressionQuality: CGFloat /* = 1.0 */
     ) -> URL? {
         return AIProxyUtils.encodeImageAsURL(image, compressionQuality)
     }
@@ -809,7 +809,7 @@ public struct AIProxy {
 #elseif canImport(UIKit)
     public static func encodeImageAsJpeg(
         image: UIImage,
-        compressionQuality: CGFloat = 1.0
+        compressionQuality: CGFloat /* = 1.0 */
     ) -> Data? {
         return AIProxyUtils.encodeImageAsJpeg(image, compressionQuality)
     }
@@ -817,14 +817,14 @@ public struct AIProxy {
     @available(*, deprecated, message: "This function is deprecated. Use AIProxy.encodeImageAsURL instead.")
     public static func openAIEncodedImage(
         image: UIImage,
-        compressionQuality: CGFloat = 1.0
+        compressionQuality: CGFloat /* = 1.0 */
     ) -> URL? {
         return AIProxyUtils.encodeImageAsURL(image, compressionQuality)
     }
 
     public static func encodeImageAsURL(
         image: UIImage,
-        compressionQuality: CGFloat = 1.0
+        compressionQuality: CGFloat /* = 1.0 */
     ) -> URL? {
         return AIProxyUtils.encodeImageAsURL(image, compressionQuality)
     }

--- a/Sources/AIProxy/Replicate/ReplicateError.swift
+++ b/Sources/AIProxy/Replicate/ReplicateError.swift
@@ -17,10 +17,7 @@ public enum ReplicateError: LocalizedError {
         case .predictionDidNotIncludeURL:
             return "A prediction was created, but replicate did not respond with a URL to poll"
         case .predictionFailed(let message):
-            if let message = message {
-                return "The prediction failed with error message: \(message)."
-            }
-            return "The prediction failed with an unspecificed error from replicate."
+            return message ?? "The prediction failed with an unspecificed error from replicate."
         case .missingModelURL:
             return "The replicate model does not contain a URL"
         case .reachedRetryLimit:

--- a/Sources/AIProxy/Replicate/ReplicateService+Convenience.swift
+++ b/Sources/AIProxy/Replicate/ReplicateService+Convenience.swift
@@ -55,18 +55,15 @@ extension ReplicateService {
     ///            `numOutputs` that you pass in the input schema.
     public func createFluxSchnellImageURLs(
         input: ReplicateFluxSchnellInputSchema,
-        secondsToWait: Int = 30
+        secondsToWait: Int /* = 30 */
     ) async throws -> [URL] {
-        let output: ReplicateSynchronousAPIOutput<[String]> = try await self.createSynchronousPredictionUsingOfficialModel(
+        let responseBody: ReplicateSynchronousResponseBody<[URL]> = try await self.createSynchronousPredictionUsingOfficialModel(
             modelOwner: "black-forest-labs",
             modelName: "flux-schnell",
             input: input,
             secondsToWait: secondsToWait
         )
-        if output.output == nil {
-            throw ReplicateError.predictionFailed("Reached wait limit of \(secondsToWait) seconds. You can adjust this.")
-        }
-        return try await self.mapPredictionResultURLToOutput(output.predictionResultURL)
+        return try await self.synchronousResponseBodyToOutput(responseBody)
     }
 
     /// Convenience method for creating an image through Black Forest Lab's Flux-Pro model:
@@ -115,18 +112,15 @@ extension ReplicateService {
     /// - Returns: The URL of the generated image
     public func createFluxProImageURL(
         input: ReplicateFluxProInputSchema,
-        secondsToWait: Int = 60
+        secondsToWait: Int /* = 60 */
     ) async throws -> URL {
-        let output: ReplicateSynchronousAPIOutput<String> = try await self.createSynchronousPredictionUsingOfficialModel(
+        let responseBody: ReplicateSynchronousAPIOutput<URL> = try await self.createSynchronousPredictionUsingOfficialModel(
             modelOwner: "black-forest-labs",
             modelName: "flux-pro",
             input: input,
             secondsToWait: secondsToWait
         )
-        if output.output == nil {
-            throw ReplicateError.predictionFailed("Reached wait limit of \(secondsToWait) seconds. You can adjust this.")
-        }
-        return try await self.mapPredictionResultURLToOutput(output.predictionResultURL)
+        return try await self.synchronousResponseBodyToOutput(responseBody)
     }
 
     /// Convenience method for creating an image through Black Forest Lab's Flux-Pro v1.1 model:
@@ -174,18 +168,15 @@ extension ReplicateService {
     /// - Returns: The URL of the generated image
     public func createFluxProImageURL_v1_1(
         input: ReplicateFluxProInputSchema_v1_1,
-        secondsToWait: Int = 60
+        secondsToWait: Int /* = 60 */
     ) async throws -> URL {
-        let output: ReplicateSynchronousAPIOutput<String> = try await self.createSynchronousPredictionUsingOfficialModel(
+        let responseBody: ReplicateSynchronousAPIOutput<URL> = try await self.createSynchronousPredictionUsingOfficialModel(
             modelOwner: "black-forest-labs",
             modelName: "flux-1.1-pro",
             input: input,
             secondsToWait: secondsToWait
         )
-        if output.output == nil {
-            throw ReplicateError.predictionFailed("Reached wait limit of \(secondsToWait) seconds. You can adjust this.")
-        }
-        return try await self.mapPredictionResultURLToOutput(output.predictionResultURL)
+        return try await self.synchronousResponseBodyToOutput(responseBody)
     }
 
     /// Convenience method for creating image URL through Black Forest Lab's Flux-Pro model.
@@ -200,18 +191,15 @@ extension ReplicateService {
     /// - Returns: The URL of the generated image
     public func createFluxProUltraImageURL_v1_1(
         input: ReplicateFluxProUltraInputSchema_v1_1,
-        secondsToWait: Int = 60
+        secondsToWait: Int /* = 60 */
     ) async throws -> URL {
-        let output: ReplicateSynchronousAPIOutput<String> = try await self.createSynchronousPredictionUsingOfficialModel(
+        let responseBody: ReplicateSynchronousAPIOutput<URL> = try await self.createSynchronousPredictionUsingOfficialModel(
             modelOwner: "black-forest-labs",
             modelName: "flux-1.1-pro-ultra",
             input: input,
             secondsToWait: secondsToWait
         )
-        if output.output == nil {
-            throw ReplicateError.predictionFailed("Reached wait limit of \(secondsToWait) seconds. You can adjust this.")
-        }
-        return try await self.mapPredictionResultURLToOutput(output.predictionResultURL)
+        return try await self.synchronousResponseBodyToOutput(responseBody)
     }
 
     /// Convenience method for creating an image through Black Forest Lab's Flux-Dev model:
@@ -260,18 +248,15 @@ extension ReplicateService {
     ///           `numOutputs` that you pass in the input schema.
     public func createFluxDevImageURLs(
         input: ReplicateFluxDevInputSchema,
-        secondsToWait: Int = 10
+        secondsToWait: Int /* = 10 */
     ) async throws -> [URL] {
-        let output: ReplicateSynchronousAPIOutput<[String]> = try await self.createSynchronousPredictionUsingOfficialModel(
+        let responseBody: ReplicateSynchronousAPIOutput<[URL]> = try await self.createSynchronousPredictionUsingOfficialModel(
             modelOwner: "black-forest-labs",
             modelName: "flux-dev",
             input: input,
             secondsToWait: secondsToWait
         )
-        if output.output == nil {
-            throw ReplicateError.predictionFailed("Reached wait limit of \(secondsToWait) seconds. You can adjust this.")
-        }
-        return try await self.mapPredictionResultURLToOutput(output.predictionResultURL)
+        return try await self.synchronousResponseBodyToOutput(responseBody)
     }
 
     /// Convenience method for creating an image using https://replicate.com/zsxkib/flux-pulid
@@ -345,17 +330,14 @@ extension ReplicateService {
     public func createSDXLImageURLs(
         input: ReplicateSDXLInputSchema,
         version: String = "7762fd07cf82c948538e41f63f77d685e02b063e37e496e96eefd46c929f9bdc",
-        secondsToWait: Int = 60
+        secondsToWait: Int /* = 60 */
     ) async throws -> [URL] {
-        let apiResult: ReplicateSynchronousAPIOutput<[URL]> = try await self.createSynchronousPredictionUsingVersion(
+        let responseBody: ReplicateSynchronousAPIOutput<[URL]> = try await self.createSynchronousPredictionUsingVersion(
             modelVersion: version,
             input: input,
             secondsToWait: secondsToWait
         )
-        guard let output = apiResult.output else {
-            throw ReplicateError.predictionDidNotIncludeOutput
-        }
-        return output
+        return try await self.synchronousResponseBodyToOutput(responseBody)
     }
 
     /// Convenience method for creating an image through fofr's fresh ink SDXL model
@@ -378,17 +360,14 @@ extension ReplicateService {
     public func createSDXLFreshInkImageURLs(
         input: ReplicateSDXLFreshInkInputSchema,
         version: String = "8515c238222fa529763ec99b4ba1fa9d32ab5d6ebc82b4281de99e4dbdcec943",
-        secondsToWait: Int = 60
+        secondsToWait: Int /* = 60 */
     ) async throws -> [URL] {
-        let apiResult: ReplicateSynchronousAPIOutput<[URL]> = try await self.createSynchronousPredictionUsingVersion(
+        let responseBody: ReplicateSynchronousAPIOutput<[URL]> = try await self.createSynchronousPredictionUsingVersion(
             modelVersion: version,
             input: input,
             secondsToWait: secondsToWait
         )
-        guard let output = apiResult.output else {
-            throw ReplicateError.predictionDidNotIncludeOutput
-        }
-        return output
+        return try await self.synchronousResponseBodyToOutput(responseBody)
     }
 
     /// Convenience method for creating an image using Flux-Dev ControlNet:

--- a/Sources/AIProxy/Replicate/ReplicateSynchronousAPIOutput.swift
+++ b/Sources/AIProxy/Replicate/ReplicateSynchronousAPIOutput.swift
@@ -7,14 +7,23 @@
 
 import Foundation
 
-public struct ReplicateSynchronousAPIOutput<T: Decodable>: Decodable {
+@available(*, deprecated, message: "Use ReplicateSynchronousResponseBody as a replacement")
+public typealias ReplicateSynchronousAPIOutput = ReplicateSynchronousResponseBody
+
+public struct ReplicateSynchronousResponseBody<T: Decodable>: Decodable {
+    public let error: String?
+
     public let output: T?
+
+    public let status: String?
 
     /// The location of a ReplicatePredictionResponseBody
     public let predictionResultURL: URL?
 
     private enum CodingKeys: String, CodingKey {
+        case error
         case output
+        case status
         case urls
     }
 
@@ -24,7 +33,9 @@ public struct ReplicateSynchronousAPIOutput<T: Decodable>: Decodable {
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.output = try container.decode(T?.self, forKey: .output)
+        self.error = try container.decodeIfPresent(String.self, forKey: .error)
+        self.status = try container.decodeIfPresent(String.self, forKey: .status)
+        self.output = try container.decodeIfPresent(T.self, forKey: .output)
         let nestedContainer = try container.nestedContainer(
             keyedBy: NestedKeys.self,
             forKey: .urls

--- a/Tests/AIProxyTests/OpenAIChatCompletionRequestTests.swift
+++ b/Tests/AIProxyTests/OpenAIChatCompletionRequestTests.swift
@@ -225,7 +225,7 @@ final class OpenAIChatCompletionRequestTests: XCTestCase {
             toolCalls: [
                 .init(
                     id: "abc",
-                    function: .init(name: "get_weather", arguments: ["location": "San Francisco, California"])
+                    function: .init(name: "get_weather", arguments: #"args"#)
                 )
             ]
         )
@@ -237,9 +237,7 @@ final class OpenAIChatCompletionRequestTests: XCTestCase {
               "tool_calls" : [
                 {
                   "function" : {
-                    "arguments" : {
-                      "location" : "San Francisco, California"
-                    },
+                    "arguments" : "args",
                     "name" : "get_weather"
                   },
                   "id" : "abc",

--- a/Tests/AIProxyTests/ReplicateSyncAPIResponseBodyTests.swift
+++ b/Tests/AIProxyTests/ReplicateSyncAPIResponseBodyTests.swift
@@ -1,0 +1,59 @@
+//
+//  ReplicateSyncAPIResponseTests.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 1/29/25.
+//
+
+import XCTest
+import Foundation
+@testable import AIProxy
+
+final class ReplicateSyncAPIResponseBodyTests: XCTestCase {
+    func testReplicateFluxProResponseIsDecodable() throws {
+        let responseBody = #"""
+        {
+          "id": "kwvnpcac8drj00cmpp48fvvgbr",
+          "model": "philz1337x/clarity-upscaler",
+          "version": "dfad41707589d68ecdccd1dfa600d55a208f9310748e44bfe35b4a6291453d5e",
+          "input": {
+            "creativity": 0.35,
+            "downscaling_resolution": 768,
+            "dynamic": 6,
+            "handfix": "disabled",
+            "image": "data:image/jpeg;base64,...",
+            "negative_prompt": "(worst quality, low quality, normal quality:2) JuggernautNegative-neg",
+            "num_inference_steps": 18,
+            "output_format": "png",
+            "prompt": "masterpiece, best quality, highres, <lora:more_details:0.5> <lora:SDXLrender_v2.0:1>",
+            "resemblance": 0.6,
+            "scale_factor": 122.5,
+            "scheduler": "DPM++ 3M SDE Karras",
+            "sd_model": "juggernaut_reborn.safetensors [338b85bc4f]",
+            "seed": 1337,
+            "tiling_height": 144,
+            "tiling_width": 112
+          },
+          "logs": "",
+          "output": null,
+          "data_removed": false,
+          "error": null,
+          "status": "starting",
+          "created_at": "2025-01-30T04:46:36.099Z",
+          "urls": {
+            "cancel": "https://api.replicate.com/v1/predictions/kwvnpcac8drj00cmpp48fvvgbr/cancel",
+            "get": "https://api.replicate.com/v1/predictions/kwvnpcac8drj00cmpp48fvvgbr",
+            "stream": "https://stream.replicate.com/v1/files/yswh-3iil5a2sisvp4yn2iahzihmbud3xzb6zaphn6265qbekothccx2a"
+          }
+        }
+        """#
+        let response = try ReplicateSynchronousAPIOutput<[String]>.deserialize(from: responseBody)
+        XCTAssertNil(response.output)
+        XCTAssertEqual(
+            "https://api.replicate.com/v1/predictions/kwvnpcac8drj00cmpp48fvvgbr",
+            response.predictionResultURL?.absoluteString
+        )
+    }
+}
+
+


### PR DESCRIPTION
- Enforce caller to supply the `secondsToWait` argument to communicate how the sync API works
- Rename `ReplicateSynchronousAPIOutput` to `ReplicateSynchronousResponseBody` (the old name will still compile)
- DRY the replicate convenience methods
- Expose `ReplicateService.synchronousResponseBodyToOutput`, which gets the inference result from the response body (or it transparently makes a subsequent request to Replicate if the inference result is not inline on the sync response body)