### PR TITLE
Add support for anonymous accounts

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -830,6 +830,14 @@ public struct AIProxy {
     }
 #endif
 
+    public static func configure_BETA() async {
+        do {
+            try await AnonymousAccountStorage.sync()
+        } catch {
+            aiproxyLogger.critical("Could not configure an AIProxy anonymous account: \(error.localizedDescription)")
+        }
+    }
+
     private init() {
         fatalError("This type is not designed to be instantiated")
     }

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -13,7 +13,7 @@ let aiproxyLogger = Logger(
 public struct AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.63.0"
+    public static let sdkVersion = "0.64.0"
 
     /// - Parameters:
     ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your provider's key.

--- a/Sources/AIProxy/AnonymousAccount/AIProxyKeychain.swift
+++ b/Sources/AIProxy/AnonymousAccount/AIProxyKeychain.swift
@@ -1,0 +1,156 @@
+//
+//  AIProxyKeychain.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 1/30/25.
+//
+
+// ----------------------------------------------------------------
+// Usage Note:
+// Try the helpers in AIProxyStorage.swift before using these directly
+// ----------------------------------------------------------------
+
+import Foundation
+
+struct AIProxyKeychain {
+
+    enum Scope {
+        case local(keychainAccount: String)
+        case remote(keychainAccount: String)
+
+        var keychainAccount: String {
+            switch self {
+            case .local(let keychainAccount): return keychainAccount
+            case .remote(let keychainAccount): return keychainAccount
+            }
+        }
+    }
+
+    let keychainServiceName = (Bundle.main.bundleIdentifier ?? "com.example") + ".aiproxy-keychain"
+    let serialQueue = DispatchQueue(label: "aiproxy-keychain")
+
+    let secClass: NSCopying
+    let secAttrGeneric: NSCopying
+    let secAttrAccount: NSCopying
+    let secAttrService: NSCopying
+    let secAttrSynchronizable: NSCopying
+    let secMatchLimit: NSCopying
+    let secReturnData: NSCopying
+    let secValueData: NSCopying
+    let cfBooleanTrue: CFBoolean
+
+    init?() {
+        guard let secClass = kSecClass as? NSCopying,
+              let secAttrGeneric = kSecAttrGeneric as? NSCopying,
+              let secAttrAccount = kSecAttrAccount as? NSCopying,
+              let secAttrService = kSecAttrService as? NSCopying,
+              let secAttrSynchronizable = kSecAttrSynchronizable as? NSCopying,
+              let secMatchLimit = kSecMatchLimit as? NSCopying,
+              let secReturnData = kSecReturnData as? NSCopying,
+              let secValueData = kSecValueData as? NSCopying,
+              let cfBooleanTrue = kCFBooleanTrue
+        else {
+            return nil
+        }
+
+        self.secClass = secClass
+        self.secAttrGeneric = secAttrGeneric
+        self.secAttrAccount = secAttrAccount
+        self.secAttrService = secAttrService
+        self.secAttrSynchronizable = secAttrSynchronizable
+        self.secMatchLimit = secMatchLimit
+        self.secReturnData = secReturnData
+        self.secValueData = secValueData
+        self.cfBooleanTrue = cfBooleanTrue
+    }
+
+    func retrieve(scope: Scope) async -> Data? {
+        return await withCheckedContinuation { continuation in
+            self.serialQueue.async {
+                let data = self.searchKeychainCopyMatching(scope: scope)
+                DispatchQueue.main.async {
+                    continuation.resume(returning: data)
+                }
+            }
+        }
+    }
+
+    func create(data: Data, scope: Scope) async -> OSStatus {
+        return await withCheckedContinuation { continuation in
+            self.serialQueue.async {
+                let res = self.createKeychainValue(data: data, scope: scope)
+                DispatchQueue.main.async {
+                    continuation.resume(returning: res)
+                }
+            }
+        }
+    }
+
+    func update(data: Data, scope: Scope) async -> OSStatus {
+        return await withCheckedContinuation { continuation in
+            self.serialQueue.async {
+                let res = self.updateKeychainValue(data: data, scope: scope)
+                DispatchQueue.main.async {
+                    continuation.resume(returning: res)
+                }
+            }
+        }
+    }
+
+    func clear(scope: Scope) {
+        self.serialQueue.async {
+            self.deleteKeychainValue(scope: scope)
+        }
+    }
+
+    // MARK: - Private
+    private func newSearchDictionary(scope: Scope) -> NSMutableDictionary {
+        let searchDictionary = NSMutableDictionary()
+        searchDictionary.setObject(kSecClassGenericPassword, forKey: self.secClass)
+        searchDictionary.setObject(self.keychainServiceName, forKey: self.secAttrService)
+        searchDictionary.setObject(scope.keychainAccount, forKey: self.secAttrGeneric)
+        searchDictionary.setObject(scope.keychainAccount, forKey: self.secAttrAccount)
+        if case .remote = scope {
+            searchDictionary.setObject(self.cfBooleanTrue, forKey: self.secAttrSynchronizable)
+        }
+        return searchDictionary
+    }
+
+    private func searchKeychainCopyMatching(scope: Scope) -> Data? {
+        let searchDictionary = self.newSearchDictionary(scope: scope)
+        searchDictionary.setObject(kSecMatchLimitOne, forKey: self.secMatchLimit)
+        searchDictionary.setObject(self.cfBooleanTrue, forKey: self.secReturnData)
+        var queryResult: AnyObject?
+
+        var status: OSStatus = noErr
+        withUnsafeMutablePointer(to: &queryResult) {
+            status = SecItemCopyMatching(searchDictionary, UnsafeMutablePointer($0))
+        }
+        if status == errSecItemNotFound {
+            return nil
+        }
+        if status == noErr {
+            return queryResult as? Data
+        }
+        aiproxyLogger.error("Unexpected keychain error in searchKeychainCopyMatching: \(status)")
+        return nil
+    }
+
+    private func createKeychainValue(data: Data, scope: Scope) -> OSStatus {
+        let dictionary = self.newSearchDictionary(scope: scope)
+        dictionary.setObject(data, forKey:self.secValueData)
+        return SecItemAdd(dictionary, nil)
+    }
+
+    private func updateKeychainValue(data: Data, scope: Scope) -> OSStatus {
+        let searchDictionary = newSearchDictionary(scope: scope)
+        let updateDictionary = NSMutableDictionary()
+        updateDictionary.setObject(data, forKey: self.secValueData)
+        return SecItemUpdate(searchDictionary, updateDictionary)
+    }
+
+    private func deleteKeychainValue(scope: Scope) {
+      let searchDictionary = newSearchDictionary(scope: scope)
+      SecItemDelete(searchDictionary)
+    }
+}

--- a/Sources/AIProxy/AnonymousAccount/AIProxyStorage.swift
+++ b/Sources/AIProxy/AnonymousAccount/AIProxyStorage.swift
@@ -1,0 +1,111 @@
+//
+//  Storage.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 1/30/25.
+//
+
+import Foundation
+
+private let kAIProxyLocalAccount = "aiproxy-local"
+private let kAIProxyRemoteAccount = "aiproxy-remote"
+internal let kAIProxyUKVSAccount = "aiproxy-ukvs"
+
+
+public final class AIProxyStorage {
+
+    static private let keychain = AIProxyKeychain()
+    static private let ukvs = NSUbiquitousKeyValueStore.default
+
+    static func getLocalAccountChainFromKeychain() async throws -> [AnonymousAccount]? {
+        guard let keychain = self.keychain else {
+            throw AIProxyError.assertion("Keychain is not available")
+        }
+        if let data = await keychain.retrieve(scope: .local(keychainAccount: kAIProxyLocalAccount)) {
+            return try [AnonymousAccount].deserialize(from: data)
+        }
+        return nil
+    }
+
+    static func updateLocalAccountChainInKeychain(_ localAccountChain: [AnonymousAccount]) async throws -> OSStatus {
+        guard let keychain = self.keychain else {
+            throw AIProxyError.assertion("Keychain is not available")
+        }
+        return await keychain.update(
+            data: try localAccountChain.serialize(),
+            scope: .local(keychainAccount: kAIProxyLocalAccount)
+        )
+    }
+
+    static func updateRemoteAccountInKeychain(_ newAccount: AnonymousAccount) async throws -> OSStatus {
+        guard let keychain = self.keychain else {
+            throw AIProxyError.assertion("Keychain is not available")
+        }
+        return await keychain.update(
+            data: try newAccount.serialize(),
+            scope: .remote(keychainAccount: kAIProxyRemoteAccount)
+        )
+    }
+
+
+    static func writeNewLocalAccountChain() async throws -> [AnonymousAccount] {
+        guard let keychain = self.keychain else {
+            throw AIProxyError.assertion("Keychain is not available")
+        }
+        let accountChain = [AnonymousAccount(
+            uuid: UUID().uuidString,
+            timestamp: Date().timeIntervalSince1970
+        )]
+        let data: Data = try accountChain.serialize()
+        let createStatus = try await keychain.create(data: data, scope: .local(keychainAccount: kAIProxyLocalAccount))
+        if createStatus != noErr {
+            throw AIProxyError.assertion("Could not write a local account to keychain")
+        }
+        return accountChain
+    }
+
+    static func getRemoteAccountFromKeychain() async throws -> AnonymousAccount? {
+        guard let keychain = self.keychain else {
+            throw AIProxyError.assertion("Keychain is not available")
+        }
+        if let data = await keychain.retrieve(scope: .remote(keychainAccount: kAIProxyRemoteAccount)) {
+            return try AnonymousAccount.deserialize(from: data)
+        }
+        return nil
+    }
+
+
+    static func writeAccountToRemoteKeychain(_ account: AnonymousAccount) async throws -> OSStatus {
+        guard let keychain = self.keychain else {
+            throw AIProxyError.assertion("Keychain is not available")
+        }
+        let data: Data = try account.serialize()
+        return try await keychain.create(data: data, scope: .remote(keychainAccount: kAIProxyRemoteAccount))
+    }
+
+    static func clear() async throws {
+        guard let keychain = self.keychain else {
+            throw AIProxyError.assertion("Keychain is not available")
+        }
+        keychain.clear(scope: .local(keychainAccount: kAIProxyLocalAccount))
+        keychain.clear(scope: .remote(keychainAccount: kAIProxyRemoteAccount))
+        self.ukvs.removeObject(forKey: kAIProxyUKVSAccount)
+    }
+
+    static func ukvsAccountData() -> Data? {
+        return self.ukvs.data(forKey: kAIProxyUKVSAccount)
+    }
+
+    static func ukvsSync() -> Bool {
+        return self.ukvs.synchronize()
+    }
+
+    static func updateUKVS(_ account: AnonymousAccount) throws {
+        let accountData: Data = try account.serialize()
+        self.ukvs.set(accountData, forKey: kAIProxyUKVSAccount)
+    }
+}
+
+extension Notification.Name {
+    static let aiproxyResolvedAccountDidChange = Notification.Name("aiproxyResolvedAccountDidChange")
+}

--- a/Sources/AIProxy/AnonymousAccount/AnonymousAccount.swift
+++ b/Sources/AIProxy/AnonymousAccount/AnonymousAccount.swift
@@ -1,0 +1,15 @@
+//
+//  AnonymousAccount.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 2/2/25.
+//
+
+/// A best-effort anonymous ID that is stable across multiple devices of an iCloud account
+struct AnonymousAccount: Codable, Equatable {
+    /// UUID of the anonymous account
+    let uuid: String
+
+    /// Unix time that the UUID was created
+    let timestamp: Double
+}

--- a/Sources/AIProxy/AnonymousAccount/AnonymousAccountStorage.swift
+++ b/Sources/AIProxy/AnonymousAccount/AnonymousAccountStorage.swift
@@ -1,0 +1,203 @@
+//
+//  AnonymousAccountStorage.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 2/2/25.
+//
+
+import Foundation
+
+/// The purpose of this class is to set `resolvedAccount` to a stable identifier.
+///
+/// # Usage
+///
+/// - At app launch, call `Task.defer { AIProxy.configure }`, which internally will call `sync`.
+/// - Any requests through AIProxy will automatically include the UUID of `resolvedAccount` in the request headers.
+///
+final class AnonymousAccountStorage {
+    /// A best-effort anonymous ID that is stable across multiple devices of an iCloud account
+    static var resolvedAccount: AnonymousAccount? {
+        get {
+            return _resolvedAccountAccessQueue.sync {
+                return _resolvedAccount
+            }
+        }
+        set {
+            _resolvedAccountAccessQueue.async(flags: .barrier) {
+                _resolvedAccount = newValue
+            }
+        }
+    }
+    private static var _resolvedAccount: AnonymousAccount?
+    private static let _resolvedAccountAccessQueue = DispatchQueue(
+        label: "aiproxy-resolved-account-access-queue",
+        attributes: .concurrent
+    )
+
+    /// The account chain that lead to the current resolution.
+    private static var localAccountChain: [AnonymousAccount] = []
+
+    /// This is expected to be called as part of the application launch.
+    static func sync() async throws {
+        #if false
+        try await AIProxyStorage.clear()
+        #endif
+
+        // The first task is to populate self.localAccountChain.
+        // If we already have an account chain in keychain, great.
+        // Otherwise, create a new anonymous account and use that as the full chain.
+        //
+        // It's possible and likely that the local account chain will be updated later in this routine.
+        // That's fine, as the purpose of the local account chain is to hold history.
+        // That history shows when the stable identifier was able to be sync'd from the other device.
+        var _localAccountChain = try await AIProxyStorage.getLocalAccountChainFromKeychain()
+        if _localAccountChain == nil {
+            _localAccountChain = try await AIProxyStorage.writeNewLocalAccountChain()
+        }
+        guard var _localAccountChain = _localAccountChain,
+              var localAccount = _localAccountChain.last else {
+            throw AIProxyError.assertion("Broken invariant. localAccount must be populated with at least one element.")
+        }
+        self.localAccountChain = _localAccountChain
+
+
+        // Next we try to get any anonymous account that is already stored in NSUbiquitousKeyValueStore.
+        // We do not store a full chain there, it's intended to be used for the 'best account' of the chain,
+        // meaning the one that was created earliest. The design of this class is to eventually resolve out
+        // to the earliest account across multiple devices.
+        if !AIProxyStorage.ukvsSync() {
+            aiproxyLogger.error("Could not synchronize NSUbiquitousKeyValueStore. Please ensure you enabled the key/value store in Target > Signing & Capabilities > iCloud > Key-Value storage?")
+        }
+        if let ukvsAccountData = AIProxyStorage.ukvsAccountData() {
+            let ukvsAccount = try AnonymousAccount.deserialize(from: ukvsAccountData)
+            if ukvsAccount != localAccount {
+                // The account in UKVS is different from the local account.
+                // If the UKVS account was created earlier, update the local account.
+                // If the UKVS account was create dlater, update the UKVS account.
+                if ukvsAccount.timestamp <= localAccount.timestamp {
+                    localAccount = ukvsAccount
+                    self.localAccountChain.append(ukvsAccount)
+                    if try await AIProxyStorage.updateLocalAccountChainInKeychain(self.localAccountChain) != noErr {
+                        aiproxyLogger.warning("Could not update the local account chain")
+                    }
+                } else {
+                    try AIProxyStorage.updateUKVS(localAccount)
+                }
+            }
+        } else {
+            // There is no account in UKVS, so write one now
+            try AIProxyStorage.updateUKVS(localAccount)
+        }
+
+
+        // Next we try to get any anonymous account that is already stored in the iCloud-backed keychain.
+        // We do not store a full chain there, it's intended to be used for the 'best account' of the chain,
+        // meaning the one that was created earliest. The design of this class is to eventually resolve out
+        // to the earliest account across multiple devices.
+        //
+        // It's worth noting that the identifiers we use for the local keychain and iCloud-backed keychain
+        // are different. The local keychain does *not* try to sync to iCloud. We use that store as purely
+        // on-device authority.
+        if try await AIProxyStorage.writeAccountToRemoteKeychain(localAccount) == errSecDuplicateItem {
+            if let remoteAccount = try await AIProxyStorage.getRemoteAccountFromKeychain() {
+                if remoteAccount != localAccount {
+                    // The account in remote keychain is different from the local account.
+                    // If the remote keychain account was created earlier, update the local account *and* the UKVS account.
+                    // If the remote keychain account was created later, update the remote keychain account.
+                    if remoteAccount.timestamp <= localAccount.timestamp {
+                        localAccount = remoteAccount
+                        self.localAccountChain.append(remoteAccount)
+                        if try await AIProxyStorage.updateLocalAccountChainInKeychain(self.localAccountChain) != noErr {
+                            aiproxyLogger.warning("Could not update the local account chain")
+                        }
+                        try AIProxyStorage.updateUKVS(localAccount)
+                    } else {
+                        if try await AIProxyStorage.updateRemoteAccountInKeychain(localAccount) != noErr {
+                            aiproxyLogger.warning("Could not update the remote account")
+                        }
+                    }
+                }
+            } else {
+                aiproxyLogger.warning("Keychain cloud sync claims that there is a duplicate item, but we can't fetch it.")
+            }
+        }
+
+        // We are done resolving accounts at launch. Set the current resolved account, and listen for changes on NSUbiquitousKeyValueStore
+        self.resolvedAccount = localAccount
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(storeDidChange),
+                                               name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+                                               object: NSUbiquitousKeyValueStore.default)
+
+        #if false
+        aiproxyLogger.info("Local account chain is \(localAccountChain)")
+        aiproxyLogger.info("Anonymous account identifier is \(self.resolvedAccount!.uuid)")
+        #endif
+    }
+
+    /// Called when NSUbiquitousKeyValueStore was remotely updated.
+    /// See https://developer.apple.com/library/archive/documentation/General/Conceptual/iCloudDesignGuide/Chapters/DesigningForKey-ValueDataIniCloud.html#//apple_ref/doc/uid/TP40012094-CH7-SW6
+    //  See https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/UserDefaults/StoringPreferenceDatainiCloud/StoringPreferenceDatainiCloud.html
+    @objc
+    private static func storeDidChange(_ notification: Notification) {
+        guard let changedKeys = notification.userInfo?["NSUbiquitousKeyValueStoreChangedKeysKey"] as? [String],
+              changedKeys.contains(kAIProxyUKVSAccount) else {
+            return
+        }
+
+        guard var resolvedAccount = self.resolvedAccount else {
+            return
+        }
+
+        guard let changeReason = notification.userInfo?["NSUbiquitousKeyValueStoreChangeReasonKey"] as? NSNumber else {
+            return
+        }
+
+        switch changeReason.intValue {
+        case NSUbiquitousKeyValueStoreServerChange: aiproxyLogger.info("AIProxy account changed due to remote server change")
+        case NSUbiquitousKeyValueStoreInitialSyncChange: aiproxyLogger.info("AIProxy account changed due to initial sync change")
+        case NSUbiquitousKeyValueStoreQuotaViolationChange: aiproxyLogger.info("AIProxy account changed due to quota violation")
+        case NSUbiquitousKeyValueStoreAccountChange: aiproxyLogger.info("AIProxy account changed due to icloud account change")
+        default:
+            return
+        }
+
+        guard AIProxyStorage.ukvsSync() else {
+            return
+        }
+
+        guard let ukvsAccountData = AIProxyStorage.ukvsAccountData(),
+              let ukvsAccount = try? AnonymousAccount.deserialize(from: ukvsAccountData) else {
+            return
+        }
+
+        guard ukvsAccount != resolvedAccount else {
+            aiproxyLogger.info("UKVS remote sync is already up to date")
+            return
+        }
+
+        if ukvsAccount.timestamp <= resolvedAccount.timestamp {
+            aiproxyLogger.info("UKVS account is older than our existing resolved account. Switching to the older account.")
+            self.resolvedAccount = ukvsAccount
+            self.localAccountChain.append(ukvsAccount)
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .aiproxyResolvedAccountDidChange, object: nil, userInfo: [:])
+            }
+
+            Task.detached {
+                let updateLocal = try? await AIProxyStorage.updateLocalAccountChainInKeychain(self.localAccountChain)
+                if updateLocal == nil || updateLocal! != noErr {
+                    aiproxyLogger.warning("Could not update the local account chain")
+                }
+
+                let updateRemote = try? await AIProxyStorage.updateRemoteAccountInKeychain(ukvsAccount)
+                if updateRemote == nil || updateRemote! != noErr {
+                    aiproxyLogger.warning("Could not update the remote account")
+                }
+            }
+        } else {
+            aiproxyLogger.info("UKVS account is newer than our existing resolved account. Updating UKVS to use the older account.")
+            try? AIProxyStorage.updateUKVS(resolvedAccount)
+        }
+    }
+}


### PR DESCRIPTION
- Writes a local anonymous ID to keychain
- Attempts to sync a stable, anonymous ID across keychain backed by iCloud
- Attempts to sync a stable, anonymous ID across NSUbiquitousKeyValueStore
- Resolution logic picks the ID that was created earliest, and synchronizes the resolved identifier with the three sources

This gives us a best-effort anonymous ID that is stable across multiple devices of an iCloud account