### PR TITLE
Add extended timeout for OpenAI requests to o1 and o3-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,49 @@ offer full demo apps to jump-start your development. Please see the [AIProxyBoot
     }
 ```
 
+### How to make a buffered chat completion to OpenAI with extended timeout
+
+This is useful for `o1` and `o3` models.
+
+```swift
+    import AIProxy
+
+    /* Uncomment for BYOK use cases */
+    // let openAIService = AIProxy.openAIDirectService(
+    //     unprotectedAPIKey: "your-openai-key"
+    // )
+
+    /* Uncomment for all other production use cases */
+    // let openAIService = AIProxy.openAIService(
+    //     partialKey: "partial-key-from-your-developer-dashboard",
+    //     serviceURL: "service-url-from-your-developer-dashboard"
+    // )
+
+    let requestBody = OpenAIChatCompletionRequestBody(
+        model: "o3-mini",
+        messages: [
+          .developer(content: .text("You are a coding assistant")),
+          .user(content: .text("Build a ruby service that writes latency stats to redis on each request"))
+        ]
+    )
+
+    do {
+        let response = try await openAIService.chatCompletionRequest(
+            body: requestBody,
+            secondsToWait: 300
+        )
+        print(response.choices.first?.message.content ?? "")
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
+    } catch let err as URLError where err.code == URLError.timedOut {
+        print("Request to OpenAI for a reasoning request timed out")
+    } catch let err as URLError where [.notConnectedToInternet, .networkConnectionLost].contains(err.code) {
+        print("Could not complete OpenAI reasoning request. Please check your internet connection")
+    } catch {
+        print("Could not complete OpenAI reasoning request: \(error.localizedDescription)")
+    }
+```
+
 
 ### Get a streaming chat completion from OpenAI:
 

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -13,7 +13,7 @@ let aiproxyLogger = Logger(
 public struct AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.67.0"
+    public static let sdkVersion = "0.68.0"
 
     /// - Parameters:
     ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your provider's key.

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -14,10 +14,12 @@ public protocol OpenAIService {
     /// - Parameters:
     ///   - body: The request body to send to aiproxy and openai. See this reference:
     ///           https://platform.openai.com/docs/api-reference/chat/create
+    ///   - secondsToWait: The amount of time to wait before `URLError.timedOut` is raised
     /// - Returns: A ChatCompletionResponse. See this reference:
     ///            https://platform.openai.com/docs/api-reference/chat/object
     func chatCompletionRequest(
-        body: OpenAIChatCompletionRequestBody
+        body: OpenAIChatCompletionRequestBody,
+        secondsToWait: Int
     ) async throws -> OpenAIChatCompletionResponseBody
     
     /// Initiates a streaming chat completion request to /v1/chat/completions.
@@ -25,10 +27,12 @@ public protocol OpenAIService {
     /// - Parameters:
     ///   - body: The request body to send to aiproxy and openai. See this reference:
     ///           https://platform.openai.com/docs/api-reference/chat/create
+    ///   - secondsToWait: The amount of time to wait before `URLError.timedOut` is raised
     /// - Returns: An async sequence of completion chunks. See this reference:
     ///            https://platform.openai.com/docs/api-reference/chat/streaming
     func streamingChatCompletionRequest(
-        body: OpenAIChatCompletionRequestBody
+        body: OpenAIChatCompletionRequestBody,
+        secondsToWait: Int
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk>
     
     /// Initiates a create image request to /v1/images/generations
@@ -74,4 +78,18 @@ public protocol OpenAIService {
     func moderationRequest(
         body: OpenAIModerationRequestBody
     ) async throws -> OpenAIModerationResponseBody
+}
+
+extension OpenAIService {
+    public func chatCompletionRequest(
+        body: OpenAIChatCompletionRequestBody
+    ) async throws -> OpenAIChatCompletionResponseBody {
+        return try await self.chatCompletionRequest(body: body, secondsToWait: 60)
+    }
+
+    public func streamingChatCompletionRequest(
+        body: OpenAIChatCompletionRequestBody
+    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk> {
+        return try await self.streamingChatCompletionRequest(body: body, secondsToWait: 60)
+    }
 }


### PR DESCRIPTION
- Added a `secondsToWait` parameter that holds off on raising `URLError.timedOut` until `secondsToWait` elapses
- Default timeout remains at 60 seconds, but the caller can customize how long they are willing to wait for their application.
- Added a README example using o3-mini
