### PR TITLE
Add automatic fallback to polling API for replicate requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ This example it taken from OpenAI's [function calling guide](https://platform.op
         audioPlayer = try AVAudioPlayer(data: mpegData)
         audioPlayer?.prepareToPlay()
         audioPlayer?.play()
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create OpenAI TTS audio: \(error.localizedDescription)")
@@ -810,7 +810,7 @@ This example it taken from OpenAI's [function calling guide](https://platform.op
         //
         //     response.results.first?.categoryScores
         //
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not perform moderation request to OpenAI")
@@ -1227,7 +1227,7 @@ If you use a file like `my-movie.mp4`, change the mime type from `video/quicktim
               It will be available for 48 hours.
               Find it at \(geminiFile.uri.absoluteString)
               """)
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
         print("Could not upload file to Gemini: \(error.localizedDescription)")
@@ -1369,7 +1369,7 @@ Use the file URL returned from the snippet above.
                 print("Claude used a tool \(toolName) with input: \(toolInput)")
             }
         }
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create an Anthropic message: \(error.localizedDescription)")
@@ -1412,7 +1412,7 @@ Use the file URL returned from the snippet above.
                 print("Claude wants to call tool \(toolName) with input \(toolInput)")
             }
         }
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
         print("Could not use Anthropic's message stream: \(error.localizedDescription)")
@@ -1472,7 +1472,7 @@ Use the file URL returned from the snippet above.
             }
         }
         print("Done with stream")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
         print(error.localizedDescription)
@@ -1525,7 +1525,7 @@ On macOS, use `NSImage(named:)` in place of `UIImage(named:)`
                 print("Claude used a tool \(toolName) with input: \(toolInput)")
             }
         }
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not send a multi-modal message to Anthropic: \(error.localizedDescription)")
@@ -1583,7 +1583,7 @@ On macOS, use `NSImage(named:)` in place of `UIImage(named:)`
                 print("Claude used a tool \(toolName) with input: \(toolInput)")
             }
         }
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create Anthropic message with tool call: \(error.localizedDescription)")
@@ -1725,7 +1725,7 @@ For a SwiftUI example, see [this gist](https://gist.github.com/lzell/a878b787f24
         let response = try await service.ultraRequest(body: body)
         let image = NSImage(data: response.imageData)
         // Do something with `image`
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not generate an image with StabilityAI: \(error.localizedDescription)")
@@ -1754,7 +1754,7 @@ For a SwiftUI example, see [this gist](https://gist.github.com/lzell/a878b787f24
         let body = DeepLTranslateRequestBody(targetLang: "ES", text: ["hello world"])
         let response = try await service.translateRequest(body: body)
         // Do something with `response.translations`
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create DeepL translation: \(error.localizedDescription)")
@@ -1789,7 +1789,7 @@ options to pass as the `model` argument:
         )
         let response = try await togetherAIService.chatCompletionRequest(body: requestBody)
         print(response.choices.first?.message.content ?? "")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create TogetherAI chat completion: \(error.localizedDescription)")
@@ -1823,7 +1823,7 @@ options to pass as the `model` argument:
         for try await chunk in stream {
             print(chunk.choices.first?.delta.content ?? "")
         }
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create TogetherAI streaming chat completion: \(error.localizedDescription)")
@@ -1891,7 +1891,7 @@ support JSON mode. See [this guide](https://docs.together.ai/docs/json-mode) for
         )
         let response = try await togetherAIService.chatCompletionRequest(body: requestBody)
         print(response.choices.first?.message.content ?? "")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create TogetherAI JSON chat completion: \(error.localizedDescription)")
@@ -1976,7 +1976,7 @@ This example is a Swift port of [this guide](https://docs.together.ai/docs/llama
         )
         let response = try await togetherAIService.chatCompletionRequest(body: requestBody)
         print(response.choices.first?.message.content ?? "")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create TogetherAI llama 3.1 tool completion: \(error.localizedDescription)")
@@ -1990,6 +1990,7 @@ This example is a Swift port of [this guide](https://docs.together.ai/docs/llama
 
 ### How to generate a Flux-Schnell image by Black Forest Labs, using Replicate
 
+```swift
     import AIProxy
 
     /* Uncomment for BYOK use cases */
@@ -2007,15 +2008,20 @@ This example is a Swift port of [this guide](https://docs.together.ai/docs/llama
         let input = ReplicateFluxSchnellInputSchema(
             prompt: "Monument valley, Utah"
         )
-        let output = try await replicateService.createFluxSchnellImageURLs(
-            input: input
+        let urls = try await replicateService.createFluxSchnellImages(
+            input: input,
+            secondsToWait: 30
         )
-        print("Done creating Flux-Schnell image: ", output.first ?? "")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Done creating Flux-Schnell images: ", urls)
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
+        // You may want to catch additional Foundation errors and pop the appropriate UI
+        // to the user. See "How to catch Foundation errors for specific conditions" here:
+        // https://www.aiproxy.com/docs/integration-options.html
         print("Could not create Flux-Schnell image: \(error.localizedDescription)")
     }
+```
 
 
 See the full range of controls for generating an image by viewing `ReplicateFluxSchnellInputSchema.swift`
@@ -2023,6 +2029,7 @@ See the full range of controls for generating an image by viewing `ReplicateFlux
 
 ### How to generate a Flux-Dev image by Black Forest Labs, using Replicate
 
+```swift
     import AIProxy
 
     /* Uncomment for BYOK use cases */
@@ -2038,17 +2045,23 @@ See the full range of controls for generating an image by viewing `ReplicateFlux
 
     do {
         let input = ReplicateFluxDevInputSchema(
-            prompt: "Monument valley, Utah. High res"
+            prompt: "Monument valley, Utah. High res",
+            goFast: false
         )
-        let output = try await replicateService.createFluxDevImageURLs(
-            input: input
+        let urls = try await replicateService.createFluxDevImages(
+            input: input,
+            secondsToWait: 30
         )
-        print("Done creating Flux-Dev image: ", output.first ?? "")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
-        print("Received \(statusCode) status code with response body: \(responseBody)")
+        print("Done creating Flux-Dev images: ", urls)
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
+        // You may want to catch additional Foundation errors and pop the appropriate UI
+        // to the user. See "How to catch Foundation errors for specific conditions" here:
+        // https://www.aiproxy.com/docs/integration-options.html
         print("Could not create Flux-Dev image: \(error.localizedDescription)")
     }
+```
 
 
 See the full range of controls for generating an image by viewing `ReplicateFluxDevInputSchema.swift`
@@ -2062,7 +2075,7 @@ following substitutions:
 - `ReplicateFluxProInputSchema_v1_1` -> `ReplicateFluxProInputSchema`
 - `createFluxProImage_v1_1` -> `createFluxProImage`
 
-    ```
+```swift
     import AIProxy
 
     /* Uncomment for BYOK use cases */
@@ -2079,17 +2092,22 @@ following substitutions:
     do {
         let input = ReplicateFluxProInputSchema_v1_1(
             prompt: "Monument valley, Utah. High res"
+            promptUpsampling: true
         )
-        let output = try await replicateService.createFluxProImageURL_v1_1(
-            input: input
+        let url = try await replicateService.createFluxProImage_v1_1(
+            input: input,
+            secondsToWait: 60
         )
-        print("Done creating Flux-Pro image: ", output)
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Done creating Flux-Pro 1.1 image: ", url)
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
-        print("Could not create Flux-Pro image: \(error.localizedDescription)")
+        // You may want to catch additional Foundation errors and pop the appropriate UI
+        // to the user. See "How to catch Foundation errors for specific conditions" here:
+        // https://www.aiproxy.com/docs/integration-options.html
+        print("Could not create Flux-Pro 1.1 image: \(error.localizedDescription)")
     }
-    ```
+```
 
 See the full range of controls for generating an image by viewing `ReplicateFluxProInputSchema_v1_1.swift`
 
@@ -2098,6 +2116,7 @@ See the full range of controls for generating an image by viewing `ReplicateFlux
 
 On macOS, use `NSImage(named:)` in place of `UIImage(named:)`
 
+```swift
     import AIProxy
 
     /* Uncomment for BYOK use cases */
@@ -2111,12 +2130,15 @@ On macOS, use `NSImage(named:)` in place of `UIImage(named:)`
     //     serviceURL: "service-url-from-your-developer-dashboard"
     // )
 
-    guard let image = UIImage(named: "face") else {
+    guard let image = NSImage(named: "face") else {
         print("Could not find an image named 'face' in your app assets")
         return
     }
 
-    guard let imageURL = AIProxy.encodeImageAsURL(image: image, compressionQuality: 0.6) else {
+    guard let imageURL = AIProxy.encodeImageAsURL(
+        image: image,
+        compressionQuality: 0.8
+    ) else {
         print("Could not convert image to a local data URI")
         return
     }
@@ -2128,15 +2150,20 @@ On macOS, use `NSImage(named:)` in place of `UIImage(named:)`
             numOutputs: 1,
             startStep: 4
         )
-        let output = try await replicateService.createFluxPulidImage(
-            input: input
+        let urls = try await replicateService.createFluxPuLIDImages(
+            input: input,
+            secondsToWait: 60
         )
-        print("Done creating Flux-PuLID image: ", output)
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Done creating Flux-PuLID image: ", urls)
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
+        // You may want to catch additional Foundation errors and pop the appropriate UI
+        // to the user. See "How to catch Foundation errors for specific conditions" here:
+        // https://www.aiproxy.com/docs/integration-options.html
         print("Could not create Flux-Pulid images: \(error.localizedDescription)")
     }
+```
 
 
 See the full range of controls for generating an image by viewing `ReplicateFluxPulidInputSchema.swift`
@@ -2147,6 +2174,7 @@ See the full range of controls for generating an image by viewing `ReplicateFlux
 There are many controls to play with for this use case. Please see
 `ReplicateFluxDevControlNetInputSchema.swift` for the full range of controls.
 
+```swift
     import AIProxy
 
     /* Uncomment for BYOK use cases */
@@ -2166,19 +2194,25 @@ There are many controls to play with for this use case. Please see
             prompt: "a cyberpunk with natural greys and whites and browns",
             controlStrength: 0.4
         )
-        let output = try await replicateService.createFluxDevControlNetImage(
-            input: input
+        let output = try await replicateService.createFluxDevControlNetImages(
+            input: input,
+            secondsToWait: 60
         )
         print("Done creating Flux-ControlNet image: ", output)
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
+        // You may want to catch additional Foundation errors and pop the appropriate UI
+        // to the user. See "How to catch Foundation errors for specific conditions" here:
+        // https://www.aiproxy.com/docs/integration-options.html
         print("Could not create Flux-ControlNet image: \(error.localizedDescription)")
     }
+```
 
 
 ### How to generate an SDXL image by StabilityAI, using Replicate
 
+```swift
     import AIProxy
 
     /* Uncomment for BYOK use cases */
@@ -2196,21 +2230,27 @@ There are many controls to play with for this use case. Please see
         let input = ReplicateSDXLInputSchema(
             prompt: "Monument valley, Utah"
         )
-        let urls = try await replicateService.createSDXLImageURLs(
-            input: input
+        let urls = try await replicateService.createSDXLImages(
+            input: input,
+            secondsToWait: 2
         )
-        print("Done creating SDXL image: ", urls.first ?? "")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
-        print("Received \(statusCode) status code with response body: \(responseBody)")
+        print("Done creating SDXL images: ", urls)
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
+        // You may want to catch additional Foundation errors and pop the appropriate UI
+        // to the user. See "How to catch Foundation errors for specific conditions" here:
+        // https://www.aiproxy.com/docs/integration-options.html
         print("Could not create SDXL image: \(error.localizedDescription)")
     }
+```
 
 See the full range of controls for generating an image by viewing `ReplicateSDXLInputSchema.swift`
 
 
 ### How to generate an SDXL Fresh Ink image by fofr, using Replicate
 
+```swift
     import AIProxy
 
     /* Uncomment for BYOK use cases */
@@ -2229,15 +2269,20 @@ See the full range of controls for generating an image by viewing `ReplicateSDXL
             prompt: "A fresh ink TOK tattoo of monument valley, Utah",
             negativePrompt: "ugly, broken, distorted"
         )
-        let urls = try await replicateService.createSDXLFreshInkImageURLs(
-            input: input
+        let urls = try await replicateService.createSDXLFreshInkImages(
+            input: input,
+            secondsToWait: 60
         )
-        print("Done creating SDXL fresh ink image: ", urls.first ?? "")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
-        print("Received \(statusCode) status code with response body: \(responseBody)")
+        print("Done creating SDXL Fresh Ink images: ", urls)
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
-        print("Could not create SDXL fresh ink image: \(error.localizedDescription)")
+        // You may want to catch additional Foundation errors and pop the appropriate UI
+        // to the user. See "How to catch Foundation errors for specific conditions" here:
+        // https://www.aiproxy.com/docs/integration-options.html
+        print("Could not create SDXL Fresh Ink images: \(error.localizedDescription)")
     }
+```
 
 See the full range of controls for generating an image by viewing `ReplicateSDXLFreshInkInputSchema.swift`
 
@@ -2258,15 +2303,16 @@ Look in the `ReplicateService+Convenience.swift` file for inspiration on how to 
    string or an array of strings). Look at `ReplicateFluxOutputSchema.swift` for inspiration.
    If you need help doing this, please reach out.
 
-3. Call the `createSynchronousPredictionUsingVersion` or
-   `createSynchronousPredictionUsingOfficialModel` method and grab the `output` off the
-   response. See `createFaceSwapImage` in `ReplicateService+Convenience.swift` as an example.
+3. Call `replicateService.runOfficialModel` or `replicateService.runCommunityModel`. Community
+   models have a `version` while official models do not.
+
+4. Call `replicateService.getPredictionOutput` on the result from step 3.
 
 You'll need to change `YourInputSchema`, `YourOutputSchema` and `your-model-version` in this
 snippet:
 
 
-    ```
+```swift
     import AIProxy
 
     /* Uncomment for BYOK use cases */
@@ -2284,24 +2330,71 @@ snippet:
         let input = YourInputSchema(
             prompt: "Monument valley, Utah"
         )
-
-        let apiResult: ReplicateSynchronousAPIOutput<YourOutputSchema> = try await replicateService.createSynchronousPredictionUsingVersion(
+        let prediction: ReplicatePrediction<YourOutputSchema> = try await replicateService.runCommunityModel( /* or runOfficialModel */
             modelVersion: "your-model-version",
             input: input,
             secondsToWait: secondsToWait
         )
-
-        guard let output = apiResult.output else {
-            throw ReplicateError.predictionDidNotIncludeOutput
-        }
+        let output: YourOutputSchema = try await replicateService.getPredictionOutput(prediction)
 
         // Do something with output
+
     } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
-        print("Could not create replicate synchronous prediction: \(error.localizedDescription)")
+        // You may want to catch additional Foundation errors and pop the appropriate UI
+        // to the user. See "How to catch Foundation errors for specific conditions" here:
+        // https://www.aiproxy.com/docs/integration-options.html
+        print("Could not run replicate model: \(error.localizedDescription)")
     }
-    ```
+```
+
+### How to upload a file to Replicate's CDN
+
+```swift
+    import AIProxy
+
+    /* Uncomment for BYOK use cases */
+    // let replicateService = AIProxy.replicateDirectService(
+    //     unprotectedAPIKey: "your-replicate-key"
+    // )
+
+    /* Uncomment for all other production use cases */
+    // let replicateService = AIProxy.replicateService(
+    //     partialKey: "partial-key-from-your-developer-dashboard",
+    //     serviceURL: "service-url-from-your-developer-dashboard"
+    // )
+
+    guard let image = NSImage(named: "face") else {
+        print("Drop face.jpeg into Assets first")
+        return
+    }
+
+    guard let imageData = AIProxy.encodeImageAsJpeg(image: image, compressionQuality: 0.5) else {
+        print("Could not encode the image as jpeg")
+        return
+    }
+
+    do {
+        let fileUploadResponse = try await replicateService.uploadFile(
+            contents: imageData,
+            contentType: "image/jpeg",
+            name: "face.jpg"
+        )
+        print("""
+              Image uploaded. Find it at \(fileUploadResponse.urls.get)
+              You can use this file until \(fileUploadResponse.expiresAt ?? "")
+              """)
+
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
+    } catch {
+        // You may want to catch additional Foundation errors and pop the appropriate UI
+        // to the user. See "How to catch Foundation errors for specific conditions" here:
+        // https://www.aiproxy.com/docs/integration-options.html
+        print("Could not upload file to replicate: \(error.localizedDescription)")
+    }
+```
 
 ### How to create a replicate model for your own Flux fine tune
 
@@ -2329,7 +2422,7 @@ Replace `<your-account>`:
             visibility: .private
         )
         print("Your model is at \(modelURL)")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create replicate model: \(error.localizedDescription)")
@@ -2374,7 +2467,7 @@ for tips on what to include in the zip file. Then run:
               You you can train with this file until \(fileUploadResponse.expiresAt ?? "")
               """)
 
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not upload file to replicate: \(error.localizedDescription)")
@@ -2423,7 +2516,7 @@ Use the `<model-name>` that you used from the snippet above that.
             body: reqBody
         )
         print("Get training status at: \(training.urls?.get?.absoluteString ?? "unknown")")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create replicate training: \(error.localizedDescription)")
@@ -2450,7 +2543,7 @@ Use the `<url>` that is returned from the snippet above.
     let url = URL(string: "<url>")!
 
     do {
-        let training = try await replicateService.pollForTrainingComplete(
+        let training = try await replicateService.pollForTrainingCompletion(
             url: url,
             pollAttempts: 100,
             secondsBetweenPollAttempts: 10
@@ -2459,7 +2552,7 @@ Use the `<url>` that is returned from the snippet above.
               Flux training status: \(training.status?.rawValue ?? "unknown")
               Your model version is: \(training.output?.version ?? "unknown")
               """)
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not poll for the replicate training: \(error.localizedDescription)")
@@ -2494,7 +2587,7 @@ model owner and model name in the string.
         let predictionResponse = try await replicateService.createPrediction(
             version: "<version>",
             input: input,
-            output: ReplicatePredictionResponseBody<[URL]>.self
+            output: ReplicatePrediction<[URL]>.self
         )
 
         let predictionOutput: [URL] = try await replicateService.pollForPredictionOutput(
@@ -2503,7 +2596,7 @@ model owner and model name in the string.
             secondsBetweenPollAttempts: 5
         )
         print("Done creating predictionOutput: \(predictionOutput)")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print("Could not create replicate prediction: \(error.localizedDescription)")
@@ -2645,7 +2738,7 @@ model owner and model name in the string.
               The first output image is at \(output.images?.first?.url?.absoluteString ?? "")
               It took \(output.timings?.inference ?? Double.nan) seconds to generate.
               """)
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
         print("Could not create Fal SDXL image: \(error.localizedDescription)")
@@ -2737,7 +2830,7 @@ I do here), or construct the zip in memory:
             name: "training.zip"
         )
         print("Training file uploaded. Find it at \(url.absoluteString)")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
         print("Could not upload file to Fal: \(error.localizedDescription)")
@@ -2757,7 +2850,7 @@ Using the URL returned in the step above:
               Fal's Flux LoRA fast trainer is complete.
               Your weights are at: \(output.diffusersLoraFile?.url?.absoluteString ?? "")
               """)
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
         print("Could not create Fal Flux training: \(error.localizedDescription)")
@@ -2786,7 +2879,7 @@ Using the LoRA URL returned in the step above:
               Fal's Flux LoRA inference is complete.
               Your images are at: \(output.images?.compactMap {$0.url?.absoluteString} ?? [])
               """)
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
         print("Could not create Fal LoRA image: \(error.localizedDescription)")
@@ -2821,7 +2914,7 @@ See `FalFluxLoRAInputSchema.swift` for the full range of inference controls
             model: "mixtral-8x7b-32768"
         ))
         print(response.choices.first?.message.content ?? "")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
         print(error.localizedDescription)
@@ -2852,7 +2945,7 @@ See `FalFluxLoRAInputSchema.swift` for the full range of inference controls
         for try await chunk in stream {
             print(chunk.choices.first?.delta.content ?? "")
         }
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received \(statusCode) status code with response body: \(responseBody)")
     } catch {
         print(error.localizedDescription)
@@ -2889,7 +2982,7 @@ See `FalFluxLoRAInputSchema.swift` for the full range of inference controls
         let response = try await groqService.createTranscriptionRequest(body: requestBody)
         let transcript = response.text ?? "None"
         print("Groq transcribed: \(transcript)")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
         print("Could not get audio transcription from Groq: \(error.localizedDescription)")
@@ -3029,7 +3122,7 @@ Use `api.mistral.ai` as the proxy domain when creating your AIProxy service in t
                 """
             )
         }
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch {
         print("Could not create mistral chat completion: \(error.localizedDescription)")
@@ -3992,6 +4085,7 @@ Some errors may be more interesting to you, and worth their own error handler to
 your user. For example, to catch `NSURLErrorTimedOut`, `NSURLErrorNetworkConnectionLost` and
 `NSURLErrorNotConnectedToInternet`, you could use the following try/catch structure:
 
+```swift
     import AIProxy
 
     let openAIService = AIProxy.openAIService(
@@ -4005,7 +4099,7 @@ your user. For example, to catch `NSURLErrorTimedOut`, `NSURLErrorNetworkConnect
             messages: [.assistant(content: .text("hello world"))]
         ))
         print(response.choices.first?.message.content ?? "")
-    }  catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
         print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
     } catch let err as URLError where err.code == URLError.timedOut {
         print("Request for OpenAI buffered chat completion timed out")
@@ -4014,6 +4108,7 @@ your user. For example, to catch `NSURLErrorTimedOut`, `NSURLErrorNetworkConnect
     } catch {
         print("Could not get buffered chat completion: \(error.localizedDescription)")
     }
+```
 
 
 # Troubleshooting

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -13,7 +13,7 @@ let aiproxyLogger = Logger(
 public struct AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.69.0"
+    public static let sdkVersion = "0.70.0"
 
     /// - Parameters:
     ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your provider's key.

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -379,6 +379,7 @@ public struct AIProxy {
     /// - Parameters:
     ///   - unprotectedAPIKey: Your Replicate API key
     /// - Returns: An instance of ReplicateService configured and ready to make requests
+    #if false
     public static func replicateDirectService(
         unprotectedAPIKey: String
     ) -> ReplicateService {
@@ -386,6 +387,7 @@ public struct AIProxy {
             unprotectedAPIKey: unprotectedAPIKey
         )
     }
+    #endif
 
     /// AIProxy's ElevenLabs service
     ///

--- a/Sources/AIProxy/Replicate/ReplicateDirectService.swift
+++ b/Sources/AIProxy/Replicate/ReplicateDirectService.swift
@@ -10,6 +10,7 @@ import Foundation
 private let kTimeoutBufferForSyncAPIInSeconds: TimeInterval = 5
 
 open class ReplicateDirectService: ReplicateService, DirectService {
+
     private let unprotectedAPIKey: String
 
     /// This initializer is not public on purpose.
@@ -18,40 +19,43 @@ open class ReplicateDirectService: ReplicateService, DirectService {
         self.unprotectedAPIKey = unprotectedAPIKey
     }
 
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runOfficialModel`, which automatically handles waiting for the prediction to complete.
+    ///
+    /// This method will only succeed if the prediction completes within 60 seconds. By contrast, `runOfficialModel`
+    /// can wait longer, automatically switching from the sync API to the polling API if necessary.
+    ///
+    /// # Usage
+    ///
     /// This is the general purpose method for running official replicate models.
-    /// It is generic in the input and output, so it's up to you to pass appropriate types.
+    /// It is generic in the input and output, so it's up to you to pass the appropriate types.
+    ///
     /// To craft the appropriate types, look at the model's schema on replicate.
     /// You can find the schema by browsing to the model and tapping on `API` in the top nav and then `Schema` in the side nav.
-    /// If the output schema is a `URI`, for example, you can call this with:
+    /// If the output schema is a `URL`, for example, you can call this with (note the specialization of `<URL>` in the type annotation):
     ///
-    ///     let myPredictionResult: ReplicateSynchronousAPIOutput<URL> = replicateService.createSynchronousPredictionUsingOfficialModel(...)
-    ///     let myURL = myPredictionResult.output
+    ///     let predictionResponseBody: ReplicatePrediction<URL> = replicateService.createSynchronousPredictionUsingOfficialModel(...)
     ///
-    /// note the specialization of `<URL>` in the type annotation.
-    ///
-    /// There are convenience methods for running specific replicate models lower in this file, which are easier to call and
-    /// not generic. You can use those for guidance on how to call this general purpose method with your own model.
-    ///
-    /// Makes a POST request to the 'create a prediction using an official model' endpoint described here:
-    /// https://replicate.com/docs/reference/http#create-a-prediction-using-an-official-model
-    ///
-    /// Uses the synchronous API announced here: https://replicate.com/changelog/2024-10-09-synchronous-api
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#models.predictions.create
     ///
     /// - Parameters:
     ///
-    ///   - modelOwner: The owner of the model
+    ///   - modelOwner: The model owner. This is not your account name.
+    ///               The owner is displayed in the URL of the model you are trying to call
     ///
     ///   - modelName: The name of the model
     ///
     ///   - input: The input schema, for example `ReplicateFluxSchnellInputSchema`
     ///
-    /// - Returns: The inference results wrapped in ReplicateSynchronousAPIOutput
-    public func createSynchronousPredictionUsingOfficialModel<T: Encodable, U: Decodable>(
+    /// - Returns: The prediction response body
+    public func createSynchronousPredictionUsingOfficialModel<Input: Encodable, Output: Decodable>(
         modelOwner: String,
         modelName: String,
-        input: T,
-        secondsToWait: Int
-    )  async throws -> ReplicateSynchronousResponseBody<U> {
+        input: Input,
+        secondsToWait: UInt
+    )  async throws -> ReplicatePrediction<Output> {
+        let secondsToWait = self.safeSecondsToWait(secondsToWait, warn: true)
         let requestBody = ReplicatePredictionRequestBody(input: input)
         var request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.replicate.com",
@@ -68,21 +72,24 @@ open class ReplicateDirectService: ReplicateService, DirectService {
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
-    /// This is the general purpose method for running community replicate models.
-    /// It is generic in the input and output, so it's up to you to pass appropriate types.
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runCommunityModel`, which automatically handles waiting for the prediction to complete.
+    ///
+    /// This method will only succeed if the prediction completes within 60 seconds. By contrast, `runCommunityModel`
+    /// can wait longer, automatically switching from the sync API to the polling API if necessary.
+    ///
+    /// # Usage
+    /// This is the general purpose method for running official replicate models.
+    /// It is generic in the input and output, so it's up to you to pass the appropriate types.
+    ///
     /// To craft the appropriate types, look at the model's schema on replicate.
     /// You can find the schema by browsing to the model and tapping on `API` in the top nav and then `Schema` in the side nav.
-    /// If the output schema is a `URI`, for example, you can call this with:
+    /// If the output schema is a `URL`, for example, you can call this with (note the specialization of `<URL>` in the type annotation):
     ///
-    ///     let myPredictionResult: ReplicateSynchronousAPIOutput<URL> = replicateService.createSynchronousPredictionUsingVersion(...)
-    ///     let myURL = myPredictionResult.output
+    ///     let predictionResponseBody: ReplicatePrediction<URL> = replicateService.createSynchronousPredictionUsingVersion(...)
     ///
-    /// note the specialization of `<URL>` in the type annotation.
-    ///
-    /// Makes a POST request to the 'create a prediction using community model' endpoint described here:
-    /// https://replicate.com/docs/reference/http#predictions.create
-    ///
-    /// Uses the synchronous API announced here: https://replicate.com/changelog/2024-10-09-synchronous-api
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#predictions.create
     ///
     /// - Parameters:
     ///
@@ -90,12 +97,13 @@ open class ReplicateDirectService: ReplicateService, DirectService {
     ///
     ///   - input: The input schema, for example `ReplicateFluxSchnellInputSchema`
     ///
-    /// - Returns: The inference results wrapped in ReplicateSynchronousAPIOutput
-    public func createSynchronousPredictionUsingVersion<T: Encodable, U: Decodable>(
+    /// - Returns: The prediction response body
+    public func createSynchronousPredictionUsingCommunityModel<Input: Encodable, Output: Decodable>(
         modelVersion: String,
-        input: T,
-        secondsToWait: Int
-    )  async throws -> ReplicateSynchronousResponseBody<U> {
+        input: Input,
+        secondsToWait: UInt
+    ) async throws -> ReplicatePrediction<Output> {
+        let secondsToWait = self.safeSecondsToWait(secondsToWait, warn: true)
         let requestBody = ReplicatePredictionRequestBody(
             input: input,
             version: modelVersion
@@ -115,10 +123,17 @@ open class ReplicateDirectService: ReplicateService, DirectService {
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
-    /// Prefer `createSynchronousPredictionUsingOfficialModel` to this method.
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runOfficialModel`, which automatically handles waiting for the prediction result.
     ///
-    /// Makes a POST request to the 'create a prediction using an official model' endpoint described here:
-    /// https://replicate.com/docs/reference/http#create-a-prediction-using-an-official-model
+    /// This method kicks off the prediction, but does not wait for completion. It is intended to be used in
+    /// combination with `pollForPredictionCompletion`
+    ///
+    /// By contrast, `runOfficialModel` will use the sync API to wait for the prediction result, automatically
+    /// switching from the sync API to the polling API if necessary.
+    ///
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#models.predictions.create
     ///
     /// - Parameters:
     ///
@@ -128,16 +143,13 @@ open class ReplicateDirectService: ReplicateService, DirectService {
     ///
     ///   - input: The input schema, for example `ReplicateFluxSchnellInputSchema`
     ///
-    ///   - output: The output schema, for example `ReplicateFluxSchnellOutputSchema`
-    ///
-    /// - Returns: A prediction object that contains a `url` that can be queried using the
-    ///            `getPredictionResult` method or `pollForPredictionResult` method.
-    public func createPredictionUsingOfficialModel<T: Encodable, U: Decodable>(
+    /// - Returns: A prediction object specialized by the `Output`, e.g. `ReplicateFluxSchnellOutputSchema`.
+    ///            The prediction object contains a `url` that can be queried using `getPrediction` or `pollForPredictionCompletion`.
+    public func createPredictionUsingOfficialModel<Input: Encodable, Output: Decodable>(
         modelOwner: String,
         modelName: String,
-        input: T,
-        output: U.Type
-    )  async throws -> U {
+        input: Input
+    ) async throws -> ReplicatePrediction<Output> {
         let requestBody = ReplicatePredictionRequestBody(input: input)
         let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.replicate.com",
@@ -149,34 +161,33 @@ open class ReplicateDirectService: ReplicateService, DirectService {
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
         )
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
-            self.urlSession,
-            request
-        )
-        return try output.deserialize(from: data)
+        return try await self.makeRequestAndDeserializeResponse(request)
     }
 
-
-    /// Prefer `createSynchronousPredictionUsingVersion` to this method.
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runCommunityModel`, which automatically handles waiting for the prediction result.
     ///
-    /// Makes a POST request to the 'create a prediction' endpoint described here:
-    /// https://replicate.com/docs/reference/http#create-a-prediction
+    /// This method kicks off the prediction, but does not wait for completion. It is intended to be used in
+    /// combination with `pollForPredictionCompletion`
+    ///
+    /// By contrast, `runCommunityModel` will use the sync API to wait for the prediction result, automatically
+    /// switching from the sync API to the polling API if necessary.
+    ///
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#predictions.create
     ///
     /// - Parameters:
     ///
-    ///   - version: The version of the model that you would like to create a prediction
+    ///   - version: The version of the community model that you would like to create a prediction
     ///
     ///   - input: The input schema, for example `ReplicateSDXLInputSchema`
     ///
-    ///   - output: The output schema, for example `ReplicateSDXLOutputSchema`
-    ///
-    /// - Returns: A prediction object that contains a `url` that can be queried using the
-    ///            `getPredictionResult` method or `pollForPredictionResult` method.
-    public func createPrediction<T: Encodable, U: Decodable>(
+    /// - Returns: A prediction object specialized by the `Output`, e.g. `ReplicateSDXLOutputSchema`.
+    ///            The prediction object contains a `url` that can be queried using `getPrediction` or `pollForPredictionCompletion`.
+    public func createPredictionUsingCommunityModel<Input: Encodable, Output: Decodable>(
         version: String,
-        input: T,
-        output: U.Type
-    )  async throws -> U {
+        input: Input
+    ) async throws -> ReplicatePrediction<Output> {
         let requestBody = ReplicatePredictionRequestBody(
             input: input,
             version: version
@@ -191,27 +202,23 @@ open class ReplicateDirectService: ReplicateService, DirectService {
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
         )
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
-            self.urlSession,
-            request
-        )
-        return try output.deserialize(from: data)
+        return try await self.makeRequestAndDeserializeResponse(request)
     }
 
-    /// Queries for a prediction result a single time.
+    /// Get the current state of a prediction.
+    ///
+    /// If you need to poll for the prediction to complete, see `pollForPredictionCompletion` defined below.
+    ///
+    /// # References
+    /// - https://replicate.com/docs/reference/http#predictions.get
     ///
     /// - Parameters:
+    ///   - url: The prediction URL returned as part of a `createPrediction` request
     ///
-    ///   - url: The polling URL returned as part of a `createPrediction` request
-    ///
-    ///   - output: The decodable to map the returned response to. This is likely a
-    ///             ReplicatePredictionResponseBody specialized by the output schema of your model,
-    ///             e.g. ReplicatePredictionResponseBody<ReplicateSDXLOutputSchema>
-    /// - Returns: The prediction response body
-    public func getPredictionResult<U: Decodable>(
-        url: URL,
-        output: U.Type
-    ) async throws -> U {
+    /// - Returns: The prediction response body specialized by `Output`, which must be a decodable that matches the output schema of this model
+    public func getPrediction<Output: Decodable>(
+        url: URL
+    ) async throws -> ReplicatePrediction<Output> {
         guard let scheme = url.scheme,
               let host = url.host else {
             throw AIProxyError.assertion("No host available for replicate poll request")
@@ -225,11 +232,7 @@ open class ReplicateDirectService: ReplicateService, DirectService {
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
         )
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
-            self.urlSession,
-            request
-        )
-        return try output.deserialize(from: data)
+        return try await self.makeRequestAndDeserializeResponse(request)
     }
 
     /// Adds a new public or private model to your replicate account.
@@ -295,38 +298,6 @@ open class ReplicateDirectService: ReplicateService, DirectService {
         return url
     }
 
-    /// Uploads a zip file to replicate for use in training Flux fine-tunes.
-    /// For instructions on what to place in the zip file, see the "prepare your training data"
-    /// of this guide: https://replicate.com/blog/fine-tune-flux
-    ///
-    /// - Parameters:
-    ///
-    ///   - zipData: The binary contents of your zip file. If you've added your zip file to xcassets, you
-    ///              can access the file's data with `NSDataAsset(name: "myfile").data`
-    ///
-    ///   - name: The name of the zip file, e.g. `myfile.zip`
-    ///
-    /// - Returns: The file upload response body, which contains a URL for where your zip file lives on
-    ///            replicate's network. You can pass this URL to training jobs.
-    public func uploadTrainingZipFile(
-        zipData: Data,
-        name: String
-    ) async throws -> ReplicateFileUploadResponseBody {
-        let body = ReplicateFileUploadRequestBody(fileData: zipData, fileName: name)
-        let boundary = UUID().uuidString
-        let request = try AIProxyURLRequest.createDirect(
-            baseURL: "https://api.replicate.com",
-            path: "/v1/files",
-            body: formEncode(body, boundary),
-            verb: .post,
-            contentType: "multipart/form-data; boundary=\(boundary)",
-            additionalHeaders: [
-                "Authorization": "Bearer \(self.unprotectedAPIKey)"
-            ]
-        )
-        return try await self.makeRequestAndDeserializeResponse(request)
-    }
-
     /// Train a model
     ///
     /// - Parameters:
@@ -352,6 +323,67 @@ open class ReplicateDirectService: ReplicateService, DirectService {
             body: body.serialize(),
             verb: .post,
             contentType: "application/json",
+            additionalHeaders: [
+                "Authorization": "Bearer \(self.unprotectedAPIKey)"
+            ]
+        )
+        return try await self.makeRequestAndDeserializeResponse(request)
+    }
+
+    /// Get the current state of a training.
+    ///
+    /// If you need to poll for the training to complete, see `pollForTrainingResult` defined below.
+    ///
+    /// - Parameters:
+    ///   - url: The URL returned as part of a `createTraining` request
+    ///
+    /// - Returns: The training response body
+    public func getTraining(
+        url: URL
+    ) async throws -> ReplicateTrainingResponseBody {
+        guard let scheme = url.scheme,
+              let host = url.host else {
+            throw AIProxyError.assertion("No host available for replicate poll request")
+        }
+        let request = try AIProxyURLRequest.createDirect(
+            baseURL: "\(scheme)://\(host)",
+            path: url.path,
+            body: nil,
+            verb: .get,
+            additionalHeaders: [
+                "Authorization": "Bearer \(self.unprotectedAPIKey)"
+            ]
+        )
+        return try await self.makeRequestAndDeserializeResponse(request)
+    }
+
+    /// Uploads a file to replicate's CDN.
+    ///
+    /// - Parameters:
+    ///   - contents: The binary contents of your file. If you've added your file to xcassets, you
+    ///               can access the file's data with `NSDataAsset(name: "myfile").data`
+    ///   - contentType: The mime type of the file, e.g. "application/zip"
+    ///   - name: The name of the file, e.g. `myfile.zip`
+    ///
+    /// - Returns: The file upload response body, which contains the file's URL on Replicate's network.
+    ///            You can pass this URL to subsequent inference and training jobs.
+    public func uploadFile(
+        contents: Data,
+        contentType: String,
+        name: String
+    ) async throws -> ReplicateFileUploadResponseBody {
+        let body = ReplicateFileUploadRequestBody(
+            contents: contents,
+            contentType: contentType,
+            fileName: name
+        )
+        let boundary = UUID().uuidString
+        let request = try AIProxyURLRequest.createDirect(
+            baseURL: "https://api.replicate.com",
+            path: "/v1/files",
+            body: formEncode(body, boundary),
+            verb: .post,
+            contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]

--- a/Sources/AIProxy/Replicate/ReplicateError.swift
+++ b/Sources/AIProxy/Replicate/ReplicateError.swift
@@ -21,7 +21,7 @@ public enum ReplicateError: LocalizedError {
         case .missingModelURL:
             return "The replicate model does not contain a URL"
         case .reachedRetryLimit:
-            return "Reached replicate polling retry limit"
+            return "Reached secondsToWait without the prediction completing"
         }
     }
 }

--- a/Sources/AIProxy/Replicate/ReplicateFileUploadRequestBody.swift
+++ b/Sources/AIProxy/Replicate/ReplicateFileUploadRequestBody.swift
@@ -7,17 +7,23 @@
 
 import Foundation
 
-struct ReplicateFileUploadRequestBody: MultipartFormEncodable {
+internal struct ReplicateFileUploadRequestBody: MultipartFormEncodable {
 
-    let fileData: Data
+    /// The binary contents of the file
+    let contents: Data
+
+    /// The file mime type
+    let contentType: String
+
+    /// The name of the file. I believe this does not get preserved on replicate's CDN. Can it be removed?
     let fileName: String
 
     var formFields: [FormField] {
         return [
             .fileField(
                 name: "content",
-                content: self.fileData,
-                contentType: "application/zip",
+                content: self.contents,
+                contentType: self.contentType,
                 filename: self.fileName
             )
         ]

--- a/Sources/AIProxy/Replicate/ReplicatePredictionRequestBody.swift
+++ b/Sources/AIProxy/Replicate/ReplicatePredictionRequestBody.swift
@@ -7,13 +7,21 @@
 
 import Foundation
 
-/// The request body for creating a Replicate prediction:
-/// https://replicate.com/docs/reference/http#create-a-prediction
+/// The request body for creating a Replicate prediction.
+///
+/// This type is used for both community models and official models.
+/// When using with an official model, the `version` property can remain `nil`.
+///
+/// Community model reference: https://replicate.com/docs/reference/http#predictions.create
+/// Official model reference: https://replicate.com/docs/reference/http#models.predictions.create
 public struct ReplicatePredictionRequestBody: Encodable {
+
     /// The replicate input schema, for example ReplicateSDXLInputSchema
+    /// TThe input schema depends on what model you are running. To see the available inputs, click the "API" tab on the model you are running or get the model version and look at its `openapi_schema` property. For example, `stability-ai/sdxl` takes `prompt` as an input.
     public let input: Encodable
 
-    /// The version of the model to run
+    /// You do not need to set this field if you are using an official model.
+    /// For community models, set it to the ID of the model version that you want to run.
     public let version: String?
 
     public init(

--- a/Sources/AIProxy/Replicate/ReplicateProxiedService.swift
+++ b/Sources/AIProxy/Replicate/ReplicateProxiedService.swift
@@ -21,40 +21,43 @@ open class ReplicateProxiedService: ReplicateService, ProxiedService {
         self.clientID = clientID
     }
 
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runOfficialModel`, which automatically handles waiting for the prediction to complete.
+    ///
+    /// This method will only succeed if the prediction completes within 60 seconds. By contrast, `runOfficialModel`
+    /// can wait longer, automatically switching from the sync API to the polling API if necessary.
+    ///
+    /// # Usage
+    ///
     /// This is the general purpose method for running official replicate models.
-    /// It is generic in the input and output, so it's up to you to pass appropriate types.
+    /// It is generic in the input and output, so it's up to you to pass the appropriate types.
+    ///
     /// To craft the appropriate types, look at the model's schema on replicate.
     /// You can find the schema by browsing to the model and tapping on `API` in the top nav and then `Schema` in the side nav.
-    /// If the output schema is a `URI`, for example, you can call this with:
+    /// If the output schema is a `URL`, for example, you can call this with (note the specialization of `<URL>` in the type annotation):
     ///
-    ///     let myPredictionResult: ReplicateSynchronousAPIOutput<URL> = replicateService.createSynchronousPredictionUsingOfficialModel(...)
-    ///     let myURL = myPredictionResult.output
+    ///     let predictionResponseBody: ReplicatePrediction<URL> = replicateService.createSynchronousPredictionUsingOfficialModel(...)
     ///
-    /// note the specialization of `<URL>` in the type annotation.
-    ///
-    /// There are convenience methods for running specific replicate models lower in this file, which are easier to call and
-    /// not generic. You can use those for guidance on how to call this general purpose method with your own model.
-    ///
-    /// Makes a POST request to the 'create a prediction using an official model' endpoint described here:
-    /// https://replicate.com/docs/reference/http#create-a-prediction-using-an-official-model
-    ///
-    /// Uses the synchronous API announced here: https://replicate.com/changelog/2024-10-09-synchronous-api
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#models.predictions.create
     ///
     /// - Parameters:
     ///
-    ///   - modelOwner: The owner of the model
+    ///   - modelOwner: The model owner. This is not your account name.
+    ///               The owner is displayed in the URL of the model you are trying to call
     ///
     ///   - modelName: The name of the model
     ///
     ///   - input: The input schema, for example `ReplicateFluxSchnellInputSchema`
     ///
-    /// - Returns: The inference results wrapped in ReplicateSynchronousAPIOutput
-    public func createSynchronousPredictionUsingOfficialModel<T: Encodable, U: Decodable>(
+    /// - Returns: The prediction response body
+    public func createSynchronousPredictionUsingOfficialModel<Input: Encodable, Output: Decodable>(
         modelOwner: String,
         modelName: String,
-        input: T,
-        secondsToWait: Int
-    )  async throws -> ReplicateSynchronousResponseBody<U> {
+        input: Input,
+        secondsToWait: UInt
+    )  async throws -> ReplicatePrediction<Output> {
+        let secondsToWait = self.safeSecondsToWait(secondsToWait, warn: true)
         let requestBody = ReplicatePredictionRequestBody(input: input)
         var request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
@@ -64,27 +67,30 @@ open class ReplicateProxiedService: ReplicateService, ProxiedService {
             body: requestBody.serialize(),
             verb: .post,
             contentType: "application/json",
-            additionalHeaders: ["Prefer": "wait=\(secondsToWait)"]
+            additionalHeaders: ["Prefer": "wait=\(min(secondsToWait, 60))"]
         )
         request.timeoutInterval = TimeInterval(secondsToWait) + kTimeoutBufferForSyncAPIInSeconds
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
-    /// This is the general purpose method for running community replicate models.
-    /// It is generic in the input and output, so it's up to you to pass appropriate types.
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runCommunityModel`, which automatically handles waiting for the prediction to complete.
+    ///
+    /// This method will only succeed if the prediction completes within 60 seconds. By contrast, `runCommunityModel`
+    /// can wait longer, automatically switching from the sync API to the polling API if necessary.
+    ///
+    /// # Usage
+    /// This is the general purpose method for running official replicate models.
+    /// It is generic in the input and output, so it's up to you to pass the appropriate types.
+    ///
     /// To craft the appropriate types, look at the model's schema on replicate.
     /// You can find the schema by browsing to the model and tapping on `API` in the top nav and then `Schema` in the side nav.
-    /// If the output schema is a `URI`, for example, you can call this with:
+    /// If the output schema is a `URL`, for example, you can call this with (note the specialization of `<URL>` in the type annotation):
     ///
-    ///     let myPredictionResult: ReplicateSynchronousAPIOutput<URL> = replicateService.createSynchronousPredictionUsingVersion(...)
-    ///     let myURL = myPredictionResult.output
+    ///     let predictionResponseBody: ReplicatePrediction<URL> = replicateService.createSynchronousPredictionUsingVersion(...)
     ///
-    /// note the specialization of `<URL>` in the type annotation.
-    ///
-    /// Makes a POST request to the 'create a prediction using community model' endpoint described here:
-    /// https://replicate.com/docs/reference/http#predictions.create
-    ///
-    /// Uses the synchronous API announced here: https://replicate.com/changelog/2024-10-09-synchronous-api
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#predictions.create
     ///
     /// - Parameters:
     ///
@@ -92,12 +98,13 @@ open class ReplicateProxiedService: ReplicateService, ProxiedService {
     ///
     ///   - input: The input schema, for example `ReplicateFluxSchnellInputSchema`
     ///
-    /// - Returns: The inference results wrapped in ReplicateSynchronousAPIOutput
-    public func createSynchronousPredictionUsingVersion<T: Encodable, U: Decodable>(
+    /// - Returns: The prediction response body
+    public func createSynchronousPredictionUsingCommunityModel<Input: Encodable, Output: Decodable>(
         modelVersion: String,
-        input: T,
-        secondsToWait: Int
-    )  async throws -> ReplicateSynchronousResponseBody<U> {
+        input: Input,
+        secondsToWait: UInt
+    ) async throws -> ReplicatePrediction<Output> {
+        let secondsToWait = self.safeSecondsToWait(secondsToWait, warn: true)
         let requestBody = ReplicatePredictionRequestBody(
             input: input,
             version: modelVersion
@@ -116,10 +123,17 @@ open class ReplicateProxiedService: ReplicateService, ProxiedService {
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
-    /// Prefer `createSynchronousPredictionUsingOfficialModel` to this method.
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runOfficialModel`, which automatically handles waiting for the prediction result.
     ///
-    /// Makes a POST request to the 'create a prediction using an official model' endpoint described here:
-    /// https://replicate.com/docs/reference/http#create-a-prediction-using-an-official-model
+    /// This method kicks off the prediction, but does not wait for completion. It is intended to be used in
+    /// combination with `pollForPredictionCompletion`
+    ///
+    /// By contrast, `runOfficialModel` will use the sync API to wait for the prediction result, automatically
+    /// switching from the sync API to the polling API if necessary.
+    ///
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#models.predictions.create
     ///
     /// - Parameters:
     ///
@@ -129,16 +143,13 @@ open class ReplicateProxiedService: ReplicateService, ProxiedService {
     ///
     ///   - input: The input schema, for example `ReplicateFluxSchnellInputSchema`
     ///
-    ///   - output: The output schema, for example `ReplicateFluxSchnellOutputSchema`
-    ///
-    /// - Returns: A prediction object that contains a `url` that can be queried using the
-    ///            `getPredictionResult` method or `pollForPredictionResult` method.
-    public func createPredictionUsingOfficialModel<T: Encodable, U: Decodable>(
+    /// - Returns: A prediction object specialized by the `Output`, e.g. `ReplicateFluxSchnellOutputSchema`.
+    ///            The prediction object contains a `url` that can be queried using `getPrediction` or `pollForPredictionCompletion`.
+    public func createPredictionUsingOfficialModel<Input: Encodable, Output: Decodable>(
         modelOwner: String,
         modelName: String,
-        input: T,
-        output: U.Type
-    )  async throws -> U {
+        input: Input
+    ) async throws -> ReplicatePrediction<Output> {
         let requestBody = ReplicatePredictionRequestBody(input: input)
         let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
@@ -149,34 +160,33 @@ open class ReplicateProxiedService: ReplicateService, ProxiedService {
             verb: .post,
             contentType: "application/json"
         )
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
-            self.urlSession,
-            request
-        )
-        return try output.deserialize(from: data)
+        return try await self.makeRequestAndDeserializeResponse(request)
     }
 
-
-    /// Prefer `createSynchronousPredictionUsingVersion` to this method.
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runCommunityModel`, which automatically handles waiting for the prediction result.
     ///
-    /// Makes a POST request to the 'create a prediction' endpoint described here:
-    /// https://replicate.com/docs/reference/http#create-a-prediction
+    /// This method kicks off the prediction, but does not wait for completion. It is intended to be used in
+    /// combination with `pollForPredictionCompletion`
+    ///
+    /// By contrast, `runCommunityModel` will use the sync API to wait for the prediction result, automatically
+    /// switching from the sync API to the polling API if necessary.
+    ///
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#predictions.create
     ///
     /// - Parameters:
     ///
-    ///   - version: The version of the model that you would like to create a prediction
+    ///   - version: The version of the community model that you would like to create a prediction
     ///
     ///   - input: The input schema, for example `ReplicateSDXLInputSchema`
     ///
-    ///   - output: The output schema, for example `ReplicateSDXLOutputSchema`
-    ///
-    /// - Returns: A prediction object that contains a `url` that can be queried using the
-    ///            `getPredictionResult` method or `pollForPredictionResult` method.
-    public func createPrediction<T: Encodable, U: Decodable>(
+    /// - Returns: A prediction object specialized by the `Output`, e.g. `ReplicateSDXLOutputSchema`.
+    ///            The prediction object contains a `url` that can be queried using `getPrediction` or `pollForPredictionCompletion`.
+    public func createPredictionUsingCommunityModel<Input: Encodable, Output: Decodable>(
         version: String,
-        input: T,
-        output: U.Type
-    )  async throws -> U {
+        input: Input
+    ) async throws -> ReplicatePrediction<Output> {
         let requestBody = ReplicatePredictionRequestBody(
             input: input,
             version: version
@@ -190,27 +200,23 @@ open class ReplicateProxiedService: ReplicateService, ProxiedService {
             verb: .post,
             contentType: "application/json"
         )
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
-            self.urlSession,
-            request
-        )
-        return try output.deserialize(from: data)
+        return try await self.makeRequestAndDeserializeResponse(request)
     }
 
-    /// Queries for a prediction result a single time.
+    /// Get the current state of a prediction.
+    ///
+    /// If you need to poll for the prediction to complete, see `pollForPredictionCompletion` defined below.
+    ///
+    /// # References
+    /// - https://replicate.com/docs/reference/http#predictions.get
     ///
     /// - Parameters:
+    ///   - url: The prediction URL returned as part of a `createPrediction` request
     ///
-    ///   - url: The polling URL returned as part of a `createPrediction` request
-    ///
-    ///   - output: The decodable to map the returned response to. This is likely a
-    ///             ReplicatePredictionResponseBody specialized by the output schema of your model,
-    ///             e.g. ReplicatePredictionResponseBody<ReplicateSDXLOutputSchema>
-    /// - Returns: The prediction response body
-    public func getPredictionResult<U: Decodable>(
-        url: URL,
-        output: U.Type
-    ) async throws -> U {
+    /// - Returns: The prediction response body specialized by `Output`, which must be a decodable that matches the output schema of this model
+    public func getPrediction<Output: Decodable>(
+        url: URL
+    ) async throws -> ReplicatePrediction<Output> {
         guard url.host == "api.replicate.com" else {
             throw AIProxyError.assertion("Replicate has changed the poll domain")
         }
@@ -222,11 +228,7 @@ open class ReplicateProxiedService: ReplicateService, ProxiedService {
             body: nil,
             verb: .get
         )
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
-            self.urlSession,
-            request
-        )
-        return try output.deserialize(from: data)
+        return try await self.makeRequestAndDeserializeResponse(request)
     }
 
     /// Adds a new public or private model to your replicate account.
@@ -295,41 +297,6 @@ open class ReplicateProxiedService: ReplicateService, ProxiedService {
         return url
     }
 
-    /// Uploads a zip file to replicate for use in training Flux fine-tunes.
-    /// For instructions on what to place in the zip file, see the "prepare your training data"
-    /// of this guide: https://replicate.com/blog/fine-tune-flux
-    ///
-    /// - Parameters:
-    ///
-    ///   - zipData: The binary contents of your zip file. If you've added your zip file to xcassets, you
-    ///              can access the file's data with `NSDataAsset(name: "myfile").data`
-    ///
-    ///   - name: The name of the zip file, e.g. `myfile.zip`
-    ///
-    /// - Returns: The file upload response body, which contains a URL for where your zip file lives on
-    ///            replicate's network. You can pass this URL to training jobs.
-    public func uploadTrainingZipFile(
-        zipData: Data,
-        name: String
-    ) async throws -> ReplicateFileUploadResponseBody {
-        let body = ReplicateFileUploadRequestBody(fileData: zipData, fileName: name)
-        let boundary = UUID().uuidString
-        let request = try await AIProxyURLRequest.create(
-            partialKey: self.partialKey,
-            serviceURL: self.serviceURL,
-            clientID: self.clientID,
-            proxyPath: "/v1/files",
-            body: formEncode(body, boundary),
-            verb: .post,
-            contentType: "multipart/form-data; boundary=\(boundary)"
-        )
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
-            self.urlSession,
-            request
-        )
-        return try ReplicateFileUploadResponseBody.deserialize(from: data)
-    }
-
     /// Train a model
     ///
     /// - Parameters:
@@ -363,6 +330,64 @@ open class ReplicateProxiedService: ReplicateService, ProxiedService {
             request
         )
         return try ReplicateTrainingResponseBody.deserialize(from: data)
+    }
+
+    /// Get the current state of a training.
+    ///
+    /// If you need to poll for the training to complete, see `pollForTrainingResult` defined below.
+    ///
+    /// - Parameters:
+    ///   - url: The URL returned as part of a `createTraining` request
+    ///
+    /// - Returns: The training response body
+    public func getTraining(
+        url: URL
+    ) async throws -> ReplicateTrainingResponseBody {
+        guard url.host == "api.replicate.com" else {
+            throw AIProxyError.assertion("Replicate has changed the poll domain")
+        }
+        let request = try await AIProxyURLRequest.create(
+            partialKey: self.partialKey,
+            serviceURL: self.serviceURL,
+            clientID: self.clientID,
+            proxyPath: url.path,
+            body: nil,
+            verb: .get
+        )
+        return try await self.makeRequestAndDeserializeResponse(request)
+    }
+
+    /// Uploads a file to replicate's CDN.
+    ///
+    /// - Parameters:
+    ///   - contents: The binary contents of your file. If you've added your file to xcassets, you
+    ///               can access the file's data with `NSDataAsset(name: "myfile").data`
+    ///   - contentType: The mime type of the file, e.g. "application/zip"
+    ///   - name: The name of the file, e.g. `myfile.zip`
+    ///
+    /// - Returns: The file upload response body, which contains the file's URL on Replicate's network.
+    ///            You can pass this URL to subsequent inference and training jobs.
+    public func uploadFile(
+        contents: Data,
+        contentType: String,
+        name: String
+    ) async throws -> ReplicateFileUploadResponseBody {
+        let body = ReplicateFileUploadRequestBody(
+            contents: contents,
+            contentType: contentType,
+            fileName: name
+        )
+        let boundary = UUID().uuidString
+        let request = try await AIProxyURLRequest.create(
+            partialKey: self.partialKey,
+            serviceURL: self.serviceURL,
+            clientID: self.clientID,
+            proxyPath: "/v1/files",
+            body: formEncode(body, boundary),
+            verb: .post,
+            contentType: "multipart/form-data; boundary=\(boundary)"
+        )
+        return try await self.makeRequestAndDeserializeResponse(request)
     }
 }
 

--- a/Sources/AIProxy/Replicate/ReplicateService+Convenience.swift
+++ b/Sources/AIProxy/Replicate/ReplicateService+Convenience.swift
@@ -9,335 +9,151 @@ import Foundation
 
 /// Convenience methods for ReplicateService
 extension ReplicateService {
+
     /// Convenience method for creating an image through Black Forest Lab's Flux-Schnell model:
     /// https://replicate.com/black-forest-labs/flux-schnell
     ///
     /// - Parameters:
-    ///
-    ///   - input: The input specification of the image you'd like to generate. See ReplicateFluxSchnellInputSchema.swift
-    ///
-    ///   - pollAttempts: The number of attempts to poll for the resulting image. If the result
-    ///   is not available within `pollAttempts`, `ReplicateError.reachedRetryLimit` is thrown.
-    ///
-    ///   - secondsBetweenPollAttempts: The number of seconds between poll attempts. The total
-    ///   amount of time that this method will wait for a result is `pollAttempts *
-    ///   secondsBetweenPollAttempts`
-    ///
-    /// - Returns: An array of image URLs
-    @available(*, deprecated, message: """
-        Use the following method as a replacement:
-          - ReplicateService.createFluxschnellImageURLs(input:secondsToWait:)
-        """)
-    public func createFluxSchnellImage(
-        input: ReplicateFluxSchnellInputSchema,
-        pollAttempts: Int = 30,
-        secondsBetweenPollAttempts: UInt64 = 1
-    ) async throws -> [URL] {
-        return try await self.predictAndPollUsingOfficialModel(
-            modelOwner: "black-forest-labs",
-            modelName: "flux-schnell",
-            input: input,
-            pollAttempts: pollAttempts,
-            secondsBetweenPollAttempts: secondsBetweenPollAttempts
-        )
-    }
-
-    /// Convenience method for creating image URLs through Black Forest Lab's Flux-Schnell model.
-    /// https://replicate.com/black-forest-labs/flux-schnell
-    ///
-    /// - Parameters:
-    ///
     ///   - input: The input specification of the images you'd like to generate. See ReplicateFluxSchnellInputSchema.swift
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
     ///
-    ///   - secondsToWait: Seconds to wait before failing
-    ///
-    /// - Returns: An array of URLs. The number of urls in the result will be equal to
-    ///            `numOutputs` that you pass in the input schema.
-    public func createFluxSchnellImageURLs(
+    /// - Returns: The URLs of the generated images. The number of urls in the result is equal to `numOutputs` of the input schema.
+    public func createFluxSchnellImages(
         input: ReplicateFluxSchnellInputSchema,
-        secondsToWait: Int /* = 30 */
+        secondsToWait: UInt
     ) async throws -> [URL] {
-        let responseBody: ReplicateSynchronousResponseBody<[URL]> = try await self.createSynchronousPredictionUsingOfficialModel(
+        let prediction: ReplicatePrediction<[URL]> = try await self.runOfficialModel(
             modelOwner: "black-forest-labs",
             modelName: "flux-schnell",
             input: input,
             secondsToWait: secondsToWait
         )
-        return try await self.synchronousResponseBodyToOutput(responseBody)
+        return try await self.getPredictionOutput(prediction)
     }
 
     /// Convenience method for creating an image through Black Forest Lab's Flux-Pro model:
     /// https://replicate.com/black-forest-labs/flux-pro
     ///
     /// - Parameters:
-    ///
     ///   - input: The input specification of the image you'd like to generate. See ReplicateFluxProInputSchema.swift
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
     ///
-    ///   - pollAttempts: The number of attempts to poll for the resulting image. If the result
-    ///   is not available within `pollAttempts`, `ReplicateError.reachedRetryLimit` is thrown.
-    ///
-    ///   - secondsBetweenPollAttempts: The number of seconds between poll attempts. The total
-    ///   amount of time that this method will wait for a result is `pollAttempts *
-    ///   secondsBetweenPollAttempts`
-    ///
-    /// - Returns: An image URL
-    ///
-    @available(*, deprecated, message: """
-        Use the following method as a replacement:
-          - ReplicateService.createFluxProImageURL(input:secondsToWait:)
-        """)
+    /// - Returns: The URL of the generated Flux Pro image
     public func createFluxProImage(
         input: ReplicateFluxProInputSchema,
-        pollAttempts: Int = 60,
-        secondsBetweenPollAttempts: UInt64 = 2
+        secondsToWait: UInt
     ) async throws -> URL {
-        return try await self.predictAndPollUsingOfficialModel(
-            modelOwner: "black-forest-labs",
-            modelName: "flux-pro",
-            input: input,
-            pollAttempts: pollAttempts,
-            secondsBetweenPollAttempts: secondsBetweenPollAttempts
-        )
-    }
-
-    /// Convenience method for creating image URL through Black Forest Lab's Flux-Pro model.
-    /// https://replicate.com/black-forest-labs/flux-pro
-    ///
-    /// - Parameters:
-    ///
-    ///   - input: The input specification of the images you'd like to generate. See ReplicateFluxProInputSchema.swift
-    ///
-    ///   - secondsToWait: Seconds to wait before failing
-    ///
-    /// - Returns: The URL of the generated image
-    public func createFluxProImageURL(
-        input: ReplicateFluxProInputSchema,
-        secondsToWait: Int /* = 60 */
-    ) async throws -> URL {
-        let responseBody: ReplicateSynchronousResponseBody<URL> = try await self.createSynchronousPredictionUsingOfficialModel(
+        let prediction: ReplicatePrediction<URL> = try await self.runOfficialModel(
             modelOwner: "black-forest-labs",
             modelName: "flux-pro",
             input: input,
             secondsToWait: secondsToWait
         )
-        return try await self.synchronousResponseBodyToOutput(responseBody)
+        return try await self.getPredictionOutput(prediction)
     }
 
     /// Convenience method for creating an image through Black Forest Lab's Flux-Pro v1.1 model:
     /// https://replicate.com/black-forest-labs/flux-1.1-pro
     ///
     /// - Parameters:
-    ///
     ///   - input: The input specification of the image you'd like to generate.
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
     ///
-    ///   - pollAttempts: The number of attempts to poll for the resulting image. If the result
-    ///   is not available within `pollAttempts`, `ReplicateError.reachedRetryLimit` is thrown.
-    ///
-    ///   - secondsBetweenPollAttempts: The number of seconds between poll attempts. The total
-    ///   amount of time that this method will wait for a result is `pollAttempts *
-    ///   secondsBetweenPollAttempts`
-    ///
-    /// - Returns: An image URL
-    @available(*, deprecated, message: """
-        Use one of the following methods as a replacement:
-          - ReplicateService.createFluxProImageURL_v1_1(input:secondsToWait:)
-        """)
+    /// - Returns: The URL of the generated Flux 1.1 Pro image
     public func createFluxProImage_v1_1(
         input: ReplicateFluxProInputSchema_v1_1,
-        pollAttempts: Int = 30,
-        secondsBetweenPollAttempts: UInt64 = 2
+        secondsToWait: UInt
     ) async throws -> URL {
-        return try await self.predictAndPollUsingOfficialModel(
-            modelOwner: "black-forest-labs",
-            modelName: "flux-1.1-pro",
-            input: input,
-            pollAttempts: pollAttempts,
-            secondsBetweenPollAttempts: secondsBetweenPollAttempts
-        )
-    }
-
-    /// Convenience method for creating image URL through Black Forest Lab's Flux-Pro model.
-    /// https://replicate.com/black-forest-labs/flux-1.1-pro
-    ///
-    /// - Parameters:
-    ///
-    ///   - input: The input specification of the images you'd like to generate. See `ReplicateFluxProInputSchema_v1_1.swift`
-    ///
-    ///   - secondsToWait: Seconds to wait before failing
-    ///
-    /// - Returns: The URL of the generated image
-    public func createFluxProImageURL_v1_1(
-        input: ReplicateFluxProInputSchema_v1_1,
-        secondsToWait: Int /* = 60 */
-    ) async throws -> URL {
-        let responseBody: ReplicateSynchronousResponseBody<URL> = try await self.createSynchronousPredictionUsingOfficialModel(
+        let prediction: ReplicatePrediction<URL> = try await self.runOfficialModel(
             modelOwner: "black-forest-labs",
             modelName: "flux-1.1-pro",
             input: input,
             secondsToWait: secondsToWait
         )
-        return try await self.synchronousResponseBodyToOutput(responseBody)
+        return try await self.getPredictionOutput(prediction)
     }
 
-    /// Convenience method for creating image URL through Black Forest Lab's Flux-Pro model.
+    /// Convenience method for creating image URL through Black Forest Lab's Flux-Pro Ultra model.
     /// https://replicate.com/black-forest-labs/flux-1.1-pro-ultra
     ///
     /// - Parameters:
-    ///
-    ///   - input: The input specification of the images you'd like to generate. See `ReplicateFluxProInputSchema_v1_1.swift`
-    ///
-    ///   - secondsToWait: Seconds to wait before failing
+    ///   - input: The input specification of the images you'd like to generate. See `ReplicateFluxProUltraInputSchema_v1_1.swift`
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
     ///
     /// - Returns: The URL of the generated image
-    public func createFluxProUltraImageURL_v1_1(
+    public func createFluxProUltraImage_v1_1(
         input: ReplicateFluxProUltraInputSchema_v1_1,
-        secondsToWait: Int /* = 60 */
+        secondsToWait: UInt
     ) async throws -> URL {
-        let responseBody: ReplicateSynchronousResponseBody<URL> = try await self.createSynchronousPredictionUsingOfficialModel(
+        let prediction: ReplicatePrediction<URL> = try await self.runOfficialModel(
             modelOwner: "black-forest-labs",
             modelName: "flux-1.1-pro-ultra",
             input: input,
             secondsToWait: secondsToWait
         )
-        return try await self.synchronousResponseBodyToOutput(responseBody)
-    }
-
-    /// Convenience method for creating an image through Black Forest Lab's Flux-Dev model:
-    /// https://replicate.com/black-forest-labs/flux-dev
-    ///
-    /// - Parameters:
-    ///
-    ///   - input: The input specification of the image you'd like to generate. See ReplicateFluxDevInputSchema.swift
-    ///
-    ///   - pollAttempts: The number of attempts to poll for the resulting image. If the result
-    ///   is not available within `pollAttempts`, `ReplicateError.reachedRetryLimit` is thrown.
-    ///
-    ///   - secondsBetweenPollAttempts: The number of seconds between poll attempts. The total
-    ///   amount of time that this method will wait for a result is `pollAttempts *
-    ///   secondsBetweenPollAttempts`
-    ///
-    /// - Returns: An array of image URLs
-    @available(*, deprecated, message: """
-    Use the following method as a replacement:
-      - ReplicateService.createFluxDevImageURLs(input:secondsToWait:)
-    """)
-    public func createFluxDevImage(
-        input: ReplicateFluxDevInputSchema,
-        pollAttempts: Int = 30,
-        secondsBetweenPollAttempts: UInt64 = 1
-    ) async throws -> [URL] {
-        return try await self.predictAndPollUsingOfficialModel(
-            modelOwner: "black-forest-labs",
-            modelName: "flux-dev",
-            input: input,
-            pollAttempts: pollAttempts,
-            secondsBetweenPollAttempts: secondsBetweenPollAttempts
-        )
+        return try await self.getPredictionOutput(prediction)
     }
 
     /// Convenience method for creating image URLs through Black Forest Lab's Flux-Dev model.
     /// https://replicate.com/black-forest-labs/flux-dev
     ///
     /// - Parameters:
-    ///
     ///   - input: The input specification of the images you'd like to generate. See ReplicateFluxDevInputSchema.swift
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
     ///
-    ///   - secondsToWait: Seconds to wait before failing
-    ///
-    /// - Returns: An array of URLs. The number of urls in the result will be equal to
-    ///           `numOutputs` that you pass in the input schema.
-    public func createFluxDevImageURLs(
+    /// - Returns: The URLs of the generated images. The number of urls in the result is equal to `numOutputs` of the input schema.
+    public func createFluxDevImages(
         input: ReplicateFluxDevInputSchema,
-        secondsToWait: Int /* = 10 */
+        secondsToWait: UInt
     ) async throws -> [URL] {
-        let responseBody: ReplicateSynchronousResponseBody<[URL]> = try await self.createSynchronousPredictionUsingOfficialModel(
+        let prediction: ReplicatePrediction<[URL]> = try await self.runOfficialModel(
             modelOwner: "black-forest-labs",
             modelName: "flux-dev",
             input: input,
             secondsToWait: secondsToWait
         )
-        return try await self.synchronousResponseBodyToOutput(responseBody)
+        return try await self.getPredictionOutput(prediction)
     }
 
     /// Convenience method for creating an image using https://replicate.com/zsxkib/flux-pulid
     ///
     /// - Parameters:
-    ///
     ///   - input: The input specification of the image you'd like to generate. See ReplicateFluxPuLIDInputSchema.swift
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
     ///
-    ///   - pollAttempts: The number of attempts to poll for the resulting image. If the result
-    ///   is not available within `pollAttempts`, `ReplicateError.reachedRetryLimit` is thrown.
-    ///
-    ///   - secondsBetweenPollAttempts: The number of seconds between poll attempts. The total
-    ///   amount of time that this method will wait for a result is `pollAttempts *
-    ///   secondsBetweenPollAttempts`
-    ///
-    /// - Returns: An array of image URLs
-    public func createFluxPulidImage(
-        input: ReplicateFluxPulidInputSchema,
+    /// - Returns: The URLs of the generated images. The number of urls in the result is equal to `numOutputs` of the input schema.
+    public func createFluxPuLIDImages(
         version: String = "8baa7ef2255075b46f4d91cd238c21d31181b3e6a864463f967960bb0112525b",
-        pollAttempts: Int = 30,
-        secondsBetweenPollAttempts: UInt64 = 2
+        input: ReplicateFluxPulidInputSchema,
+        secondsToWait: UInt
     ) async throws -> [URL] {
-        return try await self.predictAndPollUsingVersion(
+        let prediction: ReplicatePrediction<[URL]> = try await self.runCommunityModel(
             version: version,
-            input: input,
-            pollAttempts: pollAttempts,
-            secondsBetweenPollAttempts: secondsBetweenPollAttempts
-        )
-    }
-
-    /// Convenience method for creating an image through StabilityAI's SDXL model.
-    /// https://replicate.com/stability-ai/sdxl
-    ///
-    /// - Parameters:
-    ///
-    ///   - input: The input specification of the image you'd like to generate. See ReplicateSDXLInputSchema.swift
-    ///
-    ///   - pollAttempts: The number of attempts to poll for the resulting image. If the result
-    ///   is not available within `pollAttempts`, `ReplicateError.reachedRetryLimit` is thrown.
-    ///
-    ///   - secondsBetweenPollAttempts: The number of seconds between poll attempts. The total
-    ///   amount of time that this method will wait for a result is `pollAttempts *
-    ///   secondsBetweenPollAttempts`
-    ///
-    /// - Returns: An array of image URLs
-    @available(*, deprecated, message: """
-    Use the following method as a replacement:
-      - ReplicateService.createSDXLImageURLs(input:secondsToWait:)
-    """)
-    public func createSDXLImage(
-        input: ReplicateSDXLInputSchema,
-        version: String = "7762fd07cf82c948538e41f63f77d685e02b063e37e496e96eefd46c929f9bdc",
-        pollAttempts: Int = 60,
-        secondsBetweenPollAttempts: UInt64 = 1
-    ) async throws -> [URL] {
-        return try await self.predictAndPollUsingVersion(
-            version: version,
-            input: input,
-            pollAttempts: pollAttempts,
-            secondsBetweenPollAttempts: secondsBetweenPollAttempts
-        )
-    }
-
-    /// Convenience method for creating an image through StabilityAI's SDXL model.
-    /// https://replicate.com/stability-ai/sdxl
-    ///
-    /// - Parameters:
-    ///   - input: The input specification of the image you'd like to generate. See ReplicateSDXLInputSchema.swift
-    ///   - secondsToWait: The number of seconds to wait before raising `unsuccessfulRequest`
-    /// - Returns: An array of image URLs
-    public func createSDXLImageURLs(
-        input: ReplicateSDXLInputSchema,
-        version: String = "7762fd07cf82c948538e41f63f77d685e02b063e37e496e96eefd46c929f9bdc",
-        secondsToWait: Int /* = 60 */
-    ) async throws -> [URL] {
-        let responseBody: ReplicateSynchronousResponseBody<[URL]> = try await self.createSynchronousPredictionUsingVersion(
-            modelVersion: version,
             input: input,
             secondsToWait: secondsToWait
         )
-        return try await self.synchronousResponseBodyToOutput(responseBody)
+        return try await self.getPredictionOutput(prediction)
+    }
+
+    /// Convenience method for creating an image through StabilityAI's SDXL model.
+    /// https://replicate.com/stability-ai/sdxl
+    ///
+    /// - Parameters:
+    ///   - input: The input specification of the image you'd like to generate. See ReplicateSDXLInputSchema.swift
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
+    ///
+    /// - Returns: The URLs of the generated images. The number of urls in the result is equal to `numOutputs` of the input schema.
+    public func createSDXLImages(
+        input: ReplicateSDXLInputSchema,
+        version: String = "7762fd07cf82c948538e41f63f77d685e02b063e37e496e96eefd46c929f9bdc",
+        secondsToWait: UInt
+    ) async throws -> [URL] {
+        let prediction: ReplicatePrediction<[URL]> = try await self.runCommunityModel(
+            version: version,
+            input: input,
+            secondsToWait: secondsToWait
+        )
+        return try await self.getPredictionOutput(prediction)
     }
 
     /// Convenience method for creating an image through fofr's fresh ink SDXL model
@@ -349,25 +165,25 @@ extension ReplicateService {
     ///         prompt: "A fresh ink TOK tattoo of monument valley, Utah",
     ///         negativePrompt: "ugly, broken, distorted"
     ///     )
-    ///     let urls = try await replicateService.createSDXLFreshInkImageURLs(
+    ///     let urls = try await replicateService.createSDXLFreshInkImages(
     ///         input: input
     ///     )
     ///
     /// - Parameters:
     ///   - input: The input specification of the image you'd like to generate. See ReplicateSDXLFreshInkInputSchema.swift
-    ///   - secondsToWait: The number of seconds to wait before raising `unsuccessfulRequest`
-    /// - Returns: An array of image URLs
-    public func createSDXLFreshInkImageURLs(
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
+    /// - Returns: The URLs of the generated images. The number of urls in the result is equal to `numOutputs` of the input schema.
+    public func createSDXLFreshInkImages(
         input: ReplicateSDXLFreshInkInputSchema,
         version: String = "8515c238222fa529763ec99b4ba1fa9d32ab5d6ebc82b4281de99e4dbdcec943",
-        secondsToWait: Int /* = 60 */
+        secondsToWait: UInt
     ) async throws -> [URL] {
-        let responseBody: ReplicateSynchronousResponseBody<[URL]> = try await self.createSynchronousPredictionUsingVersion(
-            modelVersion: version,
+        let prediction: ReplicatePrediction<[URL]> = try await self.runCommunityModel(
+            version: version,
             input: input,
             secondsToWait: secondsToWait
         )
-        return try await self.synchronousResponseBodyToOutput(responseBody)
+        return try await self.getPredictionOutput(prediction)
     }
 
     /// Convenience method for creating an image using Flux-Dev ControlNet:
@@ -378,28 +194,115 @@ extension ReplicateService {
     /// - If the model is warm, generation takes 30-50 seconds
     ///
     /// - Parameters:
-    ///
     ///   - input: The input specification of the image you'd like to generate. See ReplicateFluxDevControlNetInputSchema.swift
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
     ///
-    ///   - pollAttempts: The number of attempts to poll for the resulting image. If the result
-    ///   is not available within `pollAttempts`, `ReplicateError.reachedRetryLimit` is thrown.
-    ///
-    ///   - secondsBetweenPollAttempts: The number of seconds between poll attempts. The total
-    ///   amount of time that this method will wait for a result is `pollAttempts *
-    ///   secondsBetweenPollAttempts`
-    ///
-    /// - Returns: An array of image URLs
+    /// - Returns: The URLs of the generated images. The number of urls in the result is equal to `numOutputs` of the input schema.
+    public func createFluxDevControlNetImages(
+        input: ReplicateFluxDevControlNetInputSchema,
+        version: String = "f2c31c31d81278a91b2447a304dae654c64a5d5a70340fba811bb1cbd41019a2",
+        secondsToWait: UInt
+    ) async throws -> [URL] {
+        let prediction: ReplicatePrediction<[URL]> = try await self.runCommunityModel(
+            version: version,
+            input: input,
+            secondsToWait: secondsToWait
+        )
+        return try await self.getPredictionOutput(prediction)
+    }
+
+    // MARK: - Deprecated
+    @available(*, deprecated, message: "Please use createFluxSchnellImages")
+    public func createFluxSchnellImageURLs(
+        input: ReplicateFluxSchnellInputSchema,
+        secondsToWait: UInt
+    ) async throws -> [URL] {
+        return try await self.createFluxSchnellImages(input: input, secondsToWait: secondsToWait)
+    }
+
+    @available(*, deprecated, message: "Please use createFluxProImage")
+    public func createFluxProImageURLs(
+        input: ReplicateFluxProInputSchema,
+        secondsToWait: UInt
+    ) async throws -> URL {
+        return try await self.createFluxProImage(input: input, secondsToWait: secondsToWait)
+    }
+
+    @available(*, deprecated, message: "Please use createFluxProImage")
+    public func createFluxProImageURL(
+        input: ReplicateFluxProInputSchema,
+        secondsToWait: UInt
+    ) async throws -> URL {
+        return try await self.createFluxProImage(input: input, secondsToWait: secondsToWait)
+    }
+
+    @available(*, deprecated, message: "Please use createFluxProImage_v1_1")
+    public func createFluxProImageURL_v1_1(
+        input: ReplicateFluxProInputSchema_v1_1,
+        secondsToWait: UInt
+    ) async throws -> URL {
+        return try await self.createFluxProImage_v1_1(input: input, secondsToWait: secondsToWait)
+    }
+
+    @available(*, deprecated, message: "Please use createFluxProUltraImage_v1_1")
+    public func createFluxProUltraImageURL_v1_1(
+        input: ReplicateFluxProUltraInputSchema_v1_1,
+        secondsToWait: UInt
+    ) async throws -> URL {
+        return try await self.createFluxProUltraImage_v1_1(input: input, secondsToWait: secondsToWait)
+    }
+
+    @available(*, deprecated, message: "Please use createFluxDevImages")
+    public func createFluxDevImageURLs(
+        input: ReplicateFluxDevInputSchema,
+        secondsToWait: UInt
+    ) async throws -> [URL] {
+        return try await self.createFluxDevImages(input: input, secondsToWait: secondsToWait)
+    }
+
+    @available(*, deprecated, message: "Please use createFluxPuLIDImages")
+    public func createFluxPulidImage(
+        input: ReplicateFluxPulidInputSchema,
+        version: String = "8baa7ef2255075b46f4d91cd238c21d31181b3e6a864463f967960bb0112525b",
+        pollAttempts: Int = 30,
+        secondsBetweenPollAttempts: UInt64 = 2
+    ) async throws -> [URL] {
+        return try await self.createFluxPuLIDImages(
+            version: version,
+            input: input,
+            secondsToWait: UInt(pollAttempts) * UInt(secondsBetweenPollAttempts)
+        )
+    }
+
+    @available(*, deprecated, message: "Please use createSDXLImages")
+    public func createSDXLImageURLs(
+        input: ReplicateSDXLInputSchema,
+        version: String = "7762fd07cf82c948538e41f63f77d685e02b063e37e496e96eefd46c929f9bdc",
+        secondsToWait: UInt
+    ) async throws -> [URL] {
+        return try await self.createSDXLImages(input: input, version: version, secondsToWait: secondsToWait)
+    }
+
+    @available(*, deprecated, message: "Please use createSDXLFreshInkImages")
+    public func createSDXLFreshInkImageURLs(
+        input: ReplicateSDXLFreshInkInputSchema,
+        version: String = "8515c238222fa529763ec99b4ba1fa9d32ab5d6ebc82b4281de99e4dbdcec943",
+        secondsToWait: Int
+    ) async throws -> [URL] {
+        return try await self.createSDXLFreshInkImages(input: input, version: version, secondsToWait: UInt(secondsToWait))
+    }
+
+    @available(*, deprecated, message: "Please use createFluxDevControlNetImages")
     public func createFluxDevControlNetImage(
         input: ReplicateFluxDevControlNetInputSchema,
         version: String = "f2c31c31d81278a91b2447a304dae654c64a5d5a70340fba811bb1cbd41019a2",
         pollAttempts: Int = 70,
         secondsBetweenPollAttempts: UInt64 = 5
     ) async throws -> [URL] {
-        return try await self.predictAndPollUsingVersion(
-            version: version,
+        return try await self.createFluxDevControlNetImages(
             input: input,
-            pollAttempts: pollAttempts,
-            secondsBetweenPollAttempts: secondsBetweenPollAttempts
+            version: version,
+            secondsToWait: UInt(pollAttempts) * UInt(secondsBetweenPollAttempts)
         )
     }
 }

--- a/Sources/AIProxy/Replicate/ReplicateService.swift
+++ b/Sources/AIProxy/Replicate/ReplicateService.swift
@@ -18,24 +18,25 @@ import Foundation
 
 public protocol ReplicateService {
 
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runOfficialModel`, which automatically handles waiting for the prediction to complete.
+    ///
+    /// This method will only succeed if the prediction completes within 60 seconds. By contrast, `runOfficialModel`
+    /// can wait longer, automatically switching from the sync API to the polling API if necessary.
+    ///
+    /// # Usage
+    ///
     /// This is the general purpose method for running official replicate models.
-    /// It is generic in the input and output, so it's up to you to pass appropriate types.
+    /// It is generic in the input and output, so it's up to you to pass the appropriate types.
+    ///
     /// To craft the appropriate types, look at the model's schema on replicate.
     /// You can find the schema by browsing to the model and tapping on `API` in the top nav and then `Schema` in the side nav.
-    /// If the output schema is a `URI`, for example, you can call this with:
+    /// If the output schema is a `URL`, for example, you can call this with (note the specialization of `<URL>` in the type annotation):
     ///
-    ///     let myPredictionResult: ReplicateSynchronousAPIOutput<URL> = replicateService.createSynchronousPredictionUsingOfficialModel(...)
-    ///     let myURL = myPredictionResult.output
+    ///     let predictionResponseBody: ReplicatePrediction<URL> = replicateService.createSynchronousPredictionUsingOfficialModel(...)
     ///
-    /// note the specialization of `<URL>` in the type annotation.
-    ///
-    /// There are convenience methods for running specific replicate models lower in this file, which are easier to call and
-    /// not generic. You can use those for guidance on how to call this general purpose method with your own model.
-    ///
-    /// Makes a POST request to the 'create a prediction using an official model' endpoint described here:
-    /// https://replicate.com/docs/reference/http#create-a-prediction-using-an-official-model
-    ///
-    /// Uses the synchronous API announced here: https://replicate.com/changelog/2024-10-09-synchronous-api
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#models.predictions.create
     ///
     /// - Parameters:
     ///
@@ -46,29 +47,32 @@ public protocol ReplicateService {
     ///
     ///   - input: The input schema, for example `ReplicateFluxSchnellInputSchema`
     ///
-    /// - Returns: The inference results wrapped in ReplicateSynchronousAPIOutput
-    func createSynchronousPredictionUsingOfficialModel<T: Encodable, U: Decodable>(
+    /// - Returns: The prediction response body
+    func createSynchronousPredictionUsingOfficialModel<Input: Encodable, Output: Decodable>(
         modelOwner: String,
         modelName: String,
-        input: T,
-        secondsToWait: Int
-    )  async throws -> ReplicateSynchronousResponseBody<U>
+        input: Input,
+        secondsToWait: UInt
+    )  async throws -> ReplicatePrediction<Output>
 
-    /// This is the general purpose method for running community replicate models.
-    /// It is generic in the input and output, so it's up to you to pass appropriate types.
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runCommunityModel`, which automatically handles waiting for the prediction to complete.
+    ///
+    /// This method will only succeed if the prediction completes within 60 seconds. By contrast, `runCommunityModel`
+    /// can wait longer, automatically switching from the sync API to the polling API if necessary.
+    ///
+    /// # Usage
+    /// This is the general purpose method for running official replicate models.
+    /// It is generic in the input and output, so it's up to you to pass the appropriate types.
+    ///
     /// To craft the appropriate types, look at the model's schema on replicate.
     /// You can find the schema by browsing to the model and tapping on `API` in the top nav and then `Schema` in the side nav.
-    /// If the output schema is a `URI`, for example, you can call this with:
+    /// If the output schema is a `URL`, for example, you can call this with (note the specialization of `<URL>` in the type annotation):
     ///
-    ///     let myPredictionResult: ReplicateSynchronousAPIOutput<URL> = replicateService.createSynchronousPredictionUsingVersion(...)
-    ///     let myURL = myPredictionResult.output
+    ///     let predictionResponseBody: ReplicatePrediction<URL> = replicateService.createSynchronousPredictionUsingVersion(...)
     ///
-    /// note the specialization of `<URL>` in the type annotation.
-    ///
-    /// Makes a POST request to the 'create a prediction using community model' endpoint described here:
-    /// https://replicate.com/docs/reference/http#predictions.create
-    ///
-    /// Uses the synchronous API announced here: https://replicate.com/changelog/2024-10-09-synchronous-api
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#predictions.create
     ///
     /// - Parameters:
     ///
@@ -76,17 +80,25 @@ public protocol ReplicateService {
     ///
     ///   - input: The input schema, for example `ReplicateFluxSchnellInputSchema`
     ///
-    /// - Returns: The inference results wrapped in ReplicateSynchronousAPIOutput
-    func createSynchronousPredictionUsingVersion<T: Encodable, U: Decodable>(
+    /// - Returns: The prediction response body
+    func createSynchronousPredictionUsingCommunityModel<Input: Encodable, Output: Decodable>(
         modelVersion: String,
-        input: T,
-        secondsToWait: Int
-    ) async throws -> ReplicateSynchronousResponseBody<U>
+        input: Input,
+        secondsToWait: UInt
+    ) async throws -> ReplicatePrediction<Output>
 
-    /// Prefer `createSynchronousPredictionUsingOfficialModel` to this method.
+
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runOfficialModel`, which automatically handles waiting for the prediction result.
     ///
-    /// Makes a POST request to the 'create a prediction using an official model' endpoint described here:
-    /// https://replicate.com/docs/reference/http#create-a-prediction-using-an-official-model
+    /// This method kicks off the prediction, but does not wait for completion. It is intended to be used in
+    /// combination with `pollForPredictionCompletion`
+    ///
+    /// By contrast, `runOfficialModel` will use the sync API to wait for the prediction result, automatically
+    /// switching from the sync API to the polling API if necessary.
+    ///
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#models.predictions.create
     ///
     /// - Parameters:
     ///
@@ -96,56 +108,53 @@ public protocol ReplicateService {
     ///
     ///   - input: The input schema, for example `ReplicateFluxSchnellInputSchema`
     ///
-    ///   - output: The output schema, for example `ReplicateFluxSchnellOutputSchema`
-    ///
-    /// - Returns: A prediction object that contains a `url` that can be queried using the
-    ///            `getPredictionResult` method or `pollForPredictionResult` method.
-    func createPredictionUsingOfficialModel<T: Encodable, U: Decodable>(
+    /// - Returns: A prediction object specialized by the `Output`, e.g. `ReplicateFluxSchnellOutputSchema`.
+    ///            The prediction object contains a `url` that can be queried using `getPrediction` or `pollForPredictionCompletion`.
+    func createPredictionUsingOfficialModel<Input: Encodable, Output: Decodable>(
         modelOwner: String,
         modelName: String,
-        input: T,
-        output: U.Type
-    )  async throws -> U
+        input: Input
+    ) async throws -> ReplicatePrediction<Output>
 
-    /// Prefer `createSynchronousPredictionUsingVersion` to this method.
+    /// You likely do not want to start with this method unless you have specific reasons for doing so.
+    /// Please see `runCommunityModel`, which automatically handles waiting for the prediction result.
     ///
-    /// Makes a POST request to the 'create a prediction' endpoint described here:
-    /// https://replicate.com/docs/reference/http#create-a-prediction
+    /// This method kicks off the prediction, but does not wait for completion. It is intended to be used in
+    /// combination with `pollForPredictionCompletion`
+    ///
+    /// By contrast, `runCommunityModel` will use the sync API to wait for the prediction result, automatically
+    /// switching from the sync API to the polling API if necessary.
+    ///
+    /// # References:
+    ///   - https://replicate.com/docs/reference/http#predictions.create
     ///
     /// - Parameters:
     ///
-    ///   - version: The version of the model that you would like to create a prediction
+    ///   - version: The version of the community model that you would like to create a prediction
     ///
     ///   - input: The input schema, for example `ReplicateSDXLInputSchema`
     ///
-    ///   - output: The output schema, for example `ReplicateSDXLOutputSchema`
-    ///
-    /// - Returns: A prediction object that contains a `url` that can be queried using the
-    ///            `getPredictionResult` method or `pollForPredictionResult` method.
-    func createPrediction<T: Encodable, U: Decodable>(
+    /// - Returns: A prediction object specialized by the `Output`, e.g. `ReplicateSDXLOutputSchema`.
+    ///            The prediction object contains a `url` that can be queried using `getPrediction` or `pollForPredictionCompletion`.
+    func createPredictionUsingCommunityModel<Input: Encodable, Output: Decodable>(
         version: String,
-        input: T,
-        output: U.Type
-    ) async throws -> U
+        input: Input
+    ) async throws -> ReplicatePrediction<Output>
 
-    /// Queries for a prediction result a single time
+    /// Get the current state of a prediction.
     ///
-    /// Prefer the synchronous API before reaching for this.
-    /// See `createSynchronousPredictionUsingOfficialModel` and `createSynchronousPredictionUsingVersion`
+    /// If you need to poll for the prediction to complete, see `pollForPredictionCompletion` defined below.
     ///
-    /// If you need to poll for the prediction output, see `pollForPredictionOutput` defined below.
+    /// # References
+    /// - https://replicate.com/docs/reference/http#predictions.get
     ///
     /// - Parameters:
-    ///   - url: The polling URL returned as part of a `createPrediction` request
+    ///   - url: The prediction URL returned as part of a `createPrediction` request
     ///
-    ///   - output: The decodable to map the returned response to. This is likely a
-    ///             ReplicatePredictionResponseBody specialized by the output schema of your model,
-    ///             e.g. ReplicatePredictionResponseBody<ReplicateSDXLOutputSchema>
-    /// - Returns: The prediction response body
-    func getPredictionResult<U: Decodable>(
-        url: URL,
-        output: U.Type
-    ) async throws -> U
+    /// - Returns: The prediction response body specialized by `Output`, which must be a decodable that matches the output schema of this model
+    func getPrediction<Output: Decodable>(
+        url: URL
+    ) async throws -> ReplicatePrediction<Output>
 
     /// Adds a new public or private model to your replicate account.
     /// You can use this as a starting point to fine-tune Flux.
@@ -184,24 +193,6 @@ public protocol ReplicateService {
         visibility: ReplicateModelVisibility
     ) async throws -> URL
 
-    /// Uploads a zip file to replicate for use in training Flux fine-tunes.
-    /// For instructions on what to place in the zip file, see the "prepare your training data"
-    /// of this guide: https://replicate.com/blog/fine-tune-flux
-    ///
-    /// - Parameters:
-    ///
-    ///   - zipData: The binary contents of your zip file. If you've added your zip file to xcassets, you
-    ///              can access the file's data with `NSDataAsset(name: "myfile").data`
-    ///
-    ///   - name: The name of the zip file, e.g. `myfile.zip`
-    ///
-    /// - Returns: The file upload response body, which contains a URL for where your zip file lives on
-    ///            replicate's network. You can pass this URL to training jobs.
-    func uploadTrainingZipFile(
-        zipData: Data,
-        name: String
-    ) async throws -> ReplicateFileUploadResponseBody
-
     /// Train a model. See the companion method `pollForTrainingResult` defined in this file.
     ///
     /// - Parameters:
@@ -221,185 +212,192 @@ public protocol ReplicateService {
         versionID: String,
         body: ReplicateTrainingRequestBody<T>
     ) async throws -> ReplicateTrainingResponseBody
+
+    /// Get the current state of a training.
+    ///
+    /// If you need to poll for the training to complete, see `pollForTrainingResult` defined below.
+    ///
+    /// - Parameters:
+    ///   - url: The URL returned as part of a `createTraining` request
+    ///
+    /// - Returns: The training response body
+    func getTraining(
+        url: URL
+    ) async throws -> ReplicateTrainingResponseBody
+
+    /// Uploads a file to replicate's CDN.
+    ///
+    /// - Parameters:
+    ///   - contents: The binary contents of your file. If you've added your file to xcassets, you
+    ///               can access the file's data with `NSDataAsset(name: "myfile").data`
+    ///   - contentType: The mime type of the file, e.g. "application/zip"
+    ///   - name: The name of the file, e.g. `myfile.zip`
+    ///
+    /// - Returns: The file upload response body, which contains the file's URL on Replicate's network.
+    ///            You can pass this URL to subsequent inference and training jobs.
+    func uploadFile(
+        contents: Data,
+        contentType: String,
+        name: String
+    ) async throws -> ReplicateFileUploadResponseBody
 }
 
 
 extension ReplicateService {
 
-    /// Prefer the `createSynchronousPredictionUsingOfficialModel` method instead of this method.
-    /// If your model does not support the synchronous API, then you can use this as a fallback.
-    /// Grep this codebase for `predictAndPollUsingOfficialModel` to see examples of satisfying T and U.
+    /// Runs an official replicate model and waits for the prediction to reach a terminal state.
+    /// The returned prediction will have a status in the terminal state (one of  `.succeeded`, `.failed`, or `.canceled`).
+    /// If we can't get a response body in a terminal state before `secondsToWait`, then `ReplicateError.reachedRetryLimit` is raised.
     ///
-    /// - Parameters:
-    ///   - modelOwner: The model owner. This is not your account name.
-    ///                 The owner is displayed in the URL of the model you are trying to call
+    /// Internally, this method starts with the synchronous API and then falls back to polling if the prediction has not completed
+    /// within sixty seconds.
     ///
-    ///   - modelName: The model name
+    /// # Usage
     ///
-    ///   - input: An encodable input. The input will be serialized and sent as JSON to replicate's HTTP API.
+    ///     let input = ReplicateFluxSchnellInputSchema(...)
+    ///     let prediction: ReplicatePrediction<[URL]> = try await replicateService.runOfficialModel(
+    ///         modelOwner: "black-forest-labs",
+    ///         modelName: "flux-schnell",
+    ///         input: input,
+    ///         secondsToWait: secondsToWait
+    ///     )
+    ///     let urls = try await replicateService.getPredictionOutput(prediction)
     ///
-    ///   - pollAttempts: Number of times to poll for the inference result before `ReplicateError.reachedRetryLimit` is thrown..
-    ///
-    ///   - secondsBetweenPollAttempts: Seconds between poll attempts
-    /// - Returns: The deserialized response body containing the inference result.
-    public func predictAndPollUsingOfficialModel<T: Encodable, U: Decodable>(
+    /// - Returns the ReplicatePrediction in a terminal state
+    public func runOfficialModel<T: Encodable, Output: Decodable>(
         modelOwner: String,
         modelName: String,
         input: T,
-        pollAttempts: Int,
-        secondsBetweenPollAttempts: UInt64
-    ) async throws -> U {
-        let predictionResponse = try await self.createPredictionUsingOfficialModel(
+        secondsToWait: UInt
+    )  async throws -> ReplicatePrediction<Output> {
+        let syncSecondsToWait = self.safeSecondsToWait(secondsToWait)
+        let responseBody: ReplicatePrediction<Output> = try await self.createSynchronousPredictionUsingOfficialModel(
             modelOwner: modelOwner,
             modelName: modelName,
             input: input,
-            output: ReplicatePredictionResponseBody<U>.self
+            secondsToWait: syncSecondsToWait
         )
-        return try await self.pollForPredictionOutput(
-            predictionResponse: predictionResponse,
-            pollAttempts: pollAttempts,
-            secondsBetweenPollAttempts: secondsBetweenPollAttempts
-        )
+        return try await self.transitionFromSyncToPollingAPIIfNecessary(responseBody, secondsToWait, syncSecondsToWait)
     }
 
-    /// Prefer the `createSynchronousPredictionUsingVersion` method instead of this method.
-    /// If your model does not support the synchronous API, then you can use this as a fallback.
-    /// Grep this codebase for `predictAndPollUsingVersion` to see examples of satisfying T and U.
+    /// Runs a community replicate model and waits for the prediction to reach a terminal state.
+    /// The returned prediction will have a status in the terminal state (one of  `.succeeded`, `.failed`, or `.canceled`).
+    /// If we can't get a response body in a terminal state before `secondsToWait`, then `ReplicateError.reachedRetryLimit` is raised.
     ///
-    /// - Parameters:
-    ///   - version: The model version GUID. You can find this string by tapping on the 'HTTP API'  card on the model's detail page
+    /// Internally, this method starts with the synchronous API and then falls back to polling if the prediction has not completed
+    /// within sixty seconds.
     ///
-    ///   - input: An encodable input. The input will be serialized and sent as JSON to replicate's HTTP API.
+    /// # Usage
     ///
-    ///   - pollAttempts: Number of times to poll for the inference result before `ReplicateError.reachedRetryLimit` is thrown..
+    ///     let input = ReplicateSDXLInputSchema(...)
+    ///     let prediction: ReplicatePrediction<[URL]> = try await replicateService.runCommunityModel(
+    ///         version: "7762fd07cf82c948538e41f63f77d685e02b063e37e496e96eefd46c929f9bdc",
+    ///         input: input,
+    ///         secondsToWait: secondsToWait
+    ///     )
+    ///     let urls = try await replicateService.getPredictionOutput(prediction)
     ///
-    ///   - secondsBetweenPollAttempts: Seconds between poll attempts
-    /// - Returns: The deserialized response body containing the inference result.
-    public func predictAndPollUsingVersion<T: Encodable, U: Decodable>(
+    /// - Returns the ReplicatePrediction in a terminal status
+    public func runCommunityModel<T: Encodable, Output: Decodable>(
         version: String,
         input: T,
-        pollAttempts: Int,
-        secondsBetweenPollAttempts: UInt64
-    ) async throws -> U {
-        let predictionResponse = try await self.createPrediction(
-            version: version,
+        secondsToWait: UInt
+    )  async throws -> ReplicatePrediction<Output> {
+        let syncSecondsToWait = self.safeSecondsToWait(secondsToWait)
+        let responseBody: ReplicatePrediction<Output> = try await self.createSynchronousPredictionUsingCommunityModel(
+            modelVersion: version,
             input: input,
-            output: ReplicatePredictionResponseBody<U>.self
+            secondsToWait: syncSecondsToWait
         )
-        return try await self.pollForPredictionOutput(
-            predictionResponse: predictionResponse,
-            pollAttempts: pollAttempts,
-            secondsBetweenPollAttempts: secondsBetweenPollAttempts
-        )
+        return try await self.transitionFromSyncToPollingAPIIfNecessary(responseBody, secondsToWait, syncSecondsToWait)
     }
 
-    /// Polls for the output, `T`, of a prediction request created with `createPrediction`
-    /// For an example of how to call this generic method, see the convenience method `createFluxProImage`.
+    /// Polls until the prediction reaches a terminal state (succeeded, failed, or canceled)
     ///
-    /// - Parameters:
-    ///
-    ///   - predictionResponse: The response from the `createPrediction` request
-    ///
-    ///   - pollAttempts: The number of attempts to poll for a completed prediction. Each poll is separated by 1
-    ///               second. The default is to try to fetch the resulting image for up to 60 seconds, after
-    ///               which ReplicateError.reachedRetryLimit will be thrown.
-    ///
-    /// - Returns: The completed prediction response body
-    public func pollForPredictionOutput<T>(
-        predictionResponse: ReplicatePredictionResponseBody<T>,
-        pollAttempts: Int,
-        secondsBetweenPollAttempts: UInt64
-    ) async throws -> T {
-        guard let pollURL = predictionResponse.urls?.get else {
-            throw ReplicateError.predictionDidNotIncludeURL
-        }
-        let pollResult: ReplicatePredictionResponseBody<T> = try await self.pollForPredictionResult(
-            url: pollURL,
-            numTries: pollAttempts,
-            nsBetweenPollAttempts: secondsBetweenPollAttempts * 1_000_000_000
-        )
-        guard let output = pollResult.output else {
-            throw ReplicateError.predictionDidNotIncludeOutput
-        }
-        return output
-    }
-
-    /// Polls for the result of a `createPrediction` request
-    ///
-    /// Prefer the synchronous API before reaching for this.
-    /// See `createSynchronousPredictionUsingOfficialModel` and `createSynchronousPredictionUsingVersion`
+    /// Please see `runOfficialModel` and `runCommunityModel` before reaching for this.
     ///
     /// - Parameters:
     ///
     ///   - url: The polling URL returned as part of a `createPrediction` request
     ///
-    ///   - numTries: The number of attempts to poll for a completed prediction. Each poll is separated by 1
-    ///               second. The default is to try to fetch the resulting image for up to 60 seconds, after
-    ///               which ReplicateError.reachedRetryLimit will be thrown.
+    ///   - pollAttempts: The number of attempts to poll for a completed prediction before `ReplicateError.reachedRetryLimit` is thrown.
+    ///
+    ///   - secondsBetweenPollAttempts: The number of seconds between polls
     ///
     /// - Returns: The completed prediction response body
-    public func pollForPredictionResult<U: Decodable>(
+    public func pollForPredictionCompletion<Output: Decodable>(
         url: URL,
-        numTries: Int,
-        nsBetweenPollAttempts: UInt64
-    ) async throws -> ReplicatePredictionResponseBody<U> {
-        try await Task.sleep(nanoseconds: nsBetweenPollAttempts)
-        for _ in 0..<numTries {
-            let response = try await self.getPredictionResult(
-                url: url,
-                output: ReplicatePredictionResponseBody<U>.self
+        pollAttempts: UInt,
+        secondsBetweenPollAttempts: UInt
+    ) async throws -> ReplicatePrediction<Output> {
+        try await Task.sleep(nanoseconds: UInt64(secondsBetweenPollAttempts) * 1_000_000_000)
+        for _ in 0..<pollAttempts {
+            let response: ReplicatePrediction<Output> = try await self.getPrediction(
+                url: url
             )
-            switch response.status {
-            case .canceled:
-                throw ReplicateError.predictionCanceled
-            case .failed:
-                throw ReplicateError.predictionFailed(response.error)
-            case .succeeded:
+            if response.status?.isTerminal == true {
                 return response
-            case .none, .processing, .starting:
-                try await Task.sleep(nanoseconds: nsBetweenPollAttempts)
             }
+            try await Task.sleep(nanoseconds: UInt64(secondsBetweenPollAttempts) * 1_000_000_000)
         }
         throw ReplicateError.reachedRetryLimit
     }
 
-    /// Polls for the result of a `createTraining` request
+    /// Polls until the training reaches a terminal state (succeeded, failed, or canceled)
     ///
     /// - Parameters:
     ///
     ///   - url: The polling URL returned as part of a `createTraining` request
     ///
-    ///   - numTries: The number of attempts to poll for a completed training before `ReplicateError.reachedRetryLimit` is thrown.
+    ///   - pollAttempts: The number of attempts to poll for a completed training before `ReplicateError.reachedRetryLimit` is thrown.
     ///
-    /// - Returns: The completed prediction response body
-    public func pollForTrainingResult(
+    ///   - secondsBetweenPollAttempts: The number of seconds between polls
+    ///
+    /// - Returns: The completed training response body
+    public func pollForTrainingCompletion(
         url: URL,
-        pollAttempts: Int,
-        secondsBetweenPollAttempts: UInt64 = 10
+        pollAttempts: UInt,
+        secondsBetweenPollAttempts: UInt
     ) async throws -> ReplicateTrainingResponseBody {
-        try await Task.sleep(nanoseconds: secondsBetweenPollAttempts * 1_000_000_000)
+        try await Task.sleep(nanoseconds: UInt64(secondsBetweenPollAttempts) * 1_000_000_000)
         for _ in 0..<pollAttempts {
-            let response = try await self.getPredictionResult(
-                url: url,
-                output: ReplicateTrainingResponseBody.self
-            )
-            print("AIProxy: polled replicate training. Current status: \(response.status?.rawValue ?? "none")")
-            switch response.status {
-            case .canceled:
-                throw ReplicateError.predictionCanceled
-            case .failed:
-                throw ReplicateError.predictionFailed(response.error)
-            case .succeeded:
+            let response = try await self.getTraining(url: url)
+            if response.status?.isTerminal == true {
                 return response
-            case .none, .processing, .starting:
-                try await Task.sleep(nanoseconds: secondsBetweenPollAttempts * 1_000_000_000)
             }
+            try await Task.sleep(nanoseconds: UInt64(secondsBetweenPollAttempts) * 1_000_000_000)
         }
         throw ReplicateError.reachedRetryLimit
     }
 
+    /// Uploads a zip file to replicate for use in training Flux fine-tunes.
+    /// For instructions on what to place in the zip file, see the "prepare your training data"
+    /// of this guide: https://replicate.com/blog/fine-tune-flux
+    ///
+    /// - Parameters:
+    ///
+    ///   - zipData: The binary contents of your zip file. If you've added your zip file to xcassets, you
+    ///              can access the file's data with `NSDataAsset(name: "myfile").data`
+    ///
+    ///   - name: The name of the zip file, e.g. `myfile.zip`
+    ///
+    /// - Returns: The file upload response body, which contains a URL for where your zip file lives on
+    ///            replicate's network. You can pass this URL to training jobs.
+    public func uploadTrainingZipFile(
+        zipData: Data,
+        name: String
+    ) async throws -> ReplicateFileUploadResponseBody {
+        return try await self.uploadFile(
+            contents: zipData,
+            contentType: "application/zip",
+            name: name
+        )
+    }
+
     /// See the usage examples in ReplicateService+Convenience.
-    public func synchronousResponseBodyToOutput<T>(_ responseBody: ReplicateSynchronousResponseBody<T>) async throws -> T {
+    public func getPredictionOutput<Output: Decodable>(
+        _ responseBody: ReplicatePrediction<Output>
+    ) async throws -> Output {
         if let error = responseBody.error {
             throw ReplicateError.predictionFailed(error)
         }
@@ -410,13 +408,12 @@ extension ReplicateService {
         }
 
         // Otherwise, fall back to making a request to `predictionResultURL`
-        guard let predictionResultURL = responseBody.predictionResultURL else {
+        guard let predictionResultURL = responseBody.urls?.get else {
             throw ReplicateError.predictionFailed("Replicate prediction did not include a result URL.")
         }
 
-        let prediction = try await self.getPredictionResult(
-            url: predictionResultURL,
-            output: ReplicatePredictionResponseBody<T>.self
+        let prediction: ReplicatePrediction<Output> = try await self.getPrediction(
+            url: predictionResultURL
         )
 
         guard let predictionOutput = prediction.output else {
@@ -429,7 +426,225 @@ extension ReplicateService {
                 """
             )
         }
-
         return predictionOutput
+    }
+
+    private func transitionFromSyncToPollingAPIIfNecessary<Output: Decodable>(
+        _ prediction: ReplicatePrediction<Output>,
+        _ secondsToWait: UInt,
+        _ secondsElapsed: UInt
+    ) async throws -> ReplicatePrediction<Output> {
+        // In the happy path, the prediction completed in the time allotted by the sync API.
+        // There is a bug in the sync API here. We can't just check to see if the `responseBody.status?.isTerminal == true`,
+        // because the sync API often returns predictions with the status still in `processing`, even though the prediction
+        // has finished and the `output` field is populated. Instead, we'll check for the presence of `output`.
+        if prediction.output != nil {
+            return prediction
+        }
+
+        guard secondsToWait - secondsElapsed >= 1 else {
+            throw ReplicateError.reachedRetryLimit
+        }
+
+        guard let pollURL = prediction.urls?.get else {
+            throw ReplicateError.predictionDidNotIncludeURL
+        }
+
+        let remainingTime = secondsToWait - secondsElapsed
+        let numberOfPollAttempts = UInt(remainingTime + 9) / 10
+        return try await self.pollForPredictionCompletion(
+            url: pollURL,
+            pollAttempts: numberOfPollAttempts,
+            secondsBetweenPollAttempts: 10
+        )
+    }
+}
+
+
+extension ReplicateService {
+    internal func safeSecondsToWait(_ secondsToWait: UInt, warn: Bool = false) -> UInt {
+        if secondsToWait > 60 && warn {
+            aiproxyLogger.warning(
+                """
+                The replicate sync API can not wait longer than 60 seconds.
+                Please use the convenience method XYZ, which will fall back to polling after 60 seconds ellapses.
+                """
+            )
+        }
+        return min(60, secondsToWait)
+    }
+}
+
+
+// MARK: - Deprecated
+extension ReplicateService {
+
+    @available(*, deprecated, message: "Use createSynchronousPredictionUsingCommunityModel")
+    func createSynchronousPredictionUsingVersion<T: Encodable, U: Decodable>(
+        modelVersion: String,
+        input: T,
+        secondsToWait: UInt
+    ) async throws -> ReplicatePrediction<U> {
+        return try await self.createSynchronousPredictionUsingCommunityModel(
+            modelVersion: modelVersion,
+            input: input,
+            secondsToWait: secondsToWait
+        )
+    }
+
+    @available(*, deprecated, message: "Use createPredictionUsingCommunityModel")
+    public func createPrediction<T: Encodable, Output: Decodable>(
+        version: String,
+        input: T
+    ) async throws -> ReplicatePrediction<Output> {
+        return try await self.createPredictionUsingCommunityModel(version: version, input: input)
+    }
+
+    @available(*, deprecated, message: "Use createPredictionUsingCommunityModel")
+    public func createPrediction<T: Encodable, Output: Decodable>(
+        version: String,
+        input: T,
+        output: ReplicatePredictionResponseBody<Output>.Type
+    ) async throws -> ReplicatePrediction<Output> {
+        return try await self.createPredictionUsingCommunityModel(version: version, input: input)
+    }
+
+    @available(*, deprecated, message: "Use getPrediction")
+    public func getPredictionResult<Output: Decodable>(
+        url: URL
+    ) async throws -> ReplicatePrediction<Output> {
+        return try await self.getPrediction(url: url)
+    }
+
+    @available(*, deprecated, message: "Please use runOfficialModel instead")
+    public func predictAndPollUsingOfficialModel<T: Encodable, U: Decodable>(
+        modelOwner: String,
+        modelName: String,
+        input: T,
+        pollAttempts: UInt,
+        secondsBetweenPollAttempts: UInt
+    ) async throws -> U {
+        let predictionResponse: ReplicatePrediction<U> = try await self.createPredictionUsingOfficialModel(
+            modelOwner: modelOwner,
+            modelName: modelName,
+            input: input
+        )
+        guard let url = predictionResponse.urls?.get else {
+            throw ReplicateError.predictionDidNotIncludeURL
+        }
+        let completedResponse: ReplicatePrediction<U> = try await self.pollForPredictionCompletion(
+            url: url,
+            pollAttempts: pollAttempts,
+            secondsBetweenPollAttempts: secondsBetweenPollAttempts
+        )
+        return try await self.synchronousResponseBodyToOutput(completedResponse)
+    }
+
+    @available(*, deprecated, message: "Please use runCommunityModel instead")
+    public func predictAndPollUsingVersion<T: Encodable, U: Decodable>(
+        version: String,
+        input: T,
+        pollAttempts: UInt,
+        secondsBetweenPollAttempts: UInt
+    ) async throws -> U {
+        let predictionResponse: ReplicatePrediction<U> = try await self.createPrediction(
+            version: version,
+            input: input
+        )
+        return try await self.pollForPredictionOutput(
+            predictionResponse: predictionResponse,
+            pollAttempts: pollAttempts,
+            secondsBetweenPollAttempts: secondsBetweenPollAttempts
+        )
+    }
+
+    @available(*, deprecated, message: "Use getPredictionOutput")
+    public func synchronousResponseBodyToOutput<Output: Decodable>(
+        _ responseBody: ReplicatePrediction<Output>
+    ) async throws -> Output {
+        return try await self.getPredictionOutput(responseBody)
+    }
+
+    @available(*, deprecated, message: "Use pollForPredictionCompletion instead")
+    public func pollForPredictionResult<U: Decodable>(
+        url: URL,
+        numTries: UInt,
+        nsBetweenPollAttempts: UInt
+    ) async throws -> ReplicatePrediction<U> {
+        try await Task.sleep(nanoseconds: UInt64(nsBetweenPollAttempts))
+        for _ in 0..<numTries {
+            let response: ReplicatePrediction<U> = try await self.getPredictionResult(
+                url: url
+            )
+            switch response.status {
+            case .canceled:
+                throw ReplicateError.predictionCanceled
+            case .failed:
+                throw ReplicateError.predictionFailed(response.error)
+            case .succeeded:
+                return response
+            case .none, .processing, .starting:
+                try await Task.sleep(nanoseconds: UInt64(nsBetweenPollAttempts))
+            }
+        }
+        throw ReplicateError.reachedRetryLimit
+    }
+
+    /// Please use `pollForPredictionCompletion` in place of this method.
+    ///
+    /// Polls for the output, `T`, of a prediction request created with `createPrediction`
+    /// For an example of how to call this generic method, see the convenience method `createFluxProImage`.
+    ///
+    /// - Parameters:
+    ///
+    ///   - predictionResponse: The response from the `createPrediction` request
+    ///
+    ///   - pollAttempts: The number of attempts to poll for a completed prediction. Each poll is separated by 1
+    ///               second. The default is to try to fetch the resulting image for up to 60 seconds, after
+    ///               which ReplicateError.reachedRetryLimit will be thrown.
+    ///
+    /// - Returns: The completed prediction response body
+    @available(*, deprecated, message: "Use pollForPredictionCompletion instead")
+    public func pollForPredictionOutput<T>(
+        predictionResponse: ReplicatePrediction<T>,
+        pollAttempts: UInt,
+        secondsBetweenPollAttempts: UInt
+    ) async throws -> T {
+        guard let pollURL = predictionResponse.urls?.get else {
+            throw ReplicateError.predictionDidNotIncludeURL
+        }
+        let pollResult: ReplicatePrediction<T> = try await self.pollForPredictionResult(
+            url: pollURL,
+            numTries: pollAttempts,
+            nsBetweenPollAttempts: secondsBetweenPollAttempts * 1_000_000_000
+        )
+        guard let output = pollResult.output else {
+            throw ReplicateError.predictionDidNotIncludeOutput
+        }
+        return output
+    }
+
+    @available(*, deprecated, message: "Use pollForTrainingCompletion instead")
+    public func pollForTrainingResult(
+        url: URL,
+        pollAttempts: UInt,
+        secondsBetweenPollAttempts: UInt = 10
+    ) async throws -> ReplicateTrainingResponseBody {
+        try await Task.sleep(nanoseconds: UInt64(secondsBetweenPollAttempts) * 1_000_000_000)
+        for _ in 0..<pollAttempts {
+            let response = try await self.getTraining(url: url)
+            print("AIProxy: polled replicate training. Current status: \(response.status?.rawValue ?? "none")")
+            switch response.status {
+            case .canceled:
+                throw ReplicateError.predictionCanceled
+            case .failed:
+                throw ReplicateError.predictionFailed(response.error)
+            case .succeeded:
+                return response
+            case .none, .processing, .starting:
+                try await Task.sleep(nanoseconds: UInt64(secondsBetweenPollAttempts) * 1_000_000_000)
+            }
+        }
+        throw ReplicateError.reachedRetryLimit
     }
 }

--- a/Sources/AIProxy/Replicate/ReplicateSynchronousAPIOutput.swift
+++ b/Sources/AIProxy/Replicate/ReplicateSynchronousAPIOutput.swift
@@ -7,9 +7,10 @@
 
 import Foundation
 
-@available(*, deprecated, message: "Use ReplicateSynchronousResponseBody as a replacement")
+@available(*, deprecated, message: "Use ReplicatePrediction as a replacement")
 public typealias ReplicateSynchronousAPIOutput = ReplicateSynchronousResponseBody
 
+@available(*, deprecated, message: "Use ReplicatePrediction as a replacement")
 public struct ReplicateSynchronousResponseBody<T: Decodable>: Decodable {
     public let error: String?
 
@@ -17,7 +18,7 @@ public struct ReplicateSynchronousResponseBody<T: Decodable>: Decodable {
 
     public let status: String?
 
-    /// The location of a ReplicatePredictionResponseBody
+    /// The location of a ReplicatePrediction
     public let predictionResultURL: URL?
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/AIProxy/Replicate/ReplicateTrainingResponseBody.swift
+++ b/Sources/AIProxy/Replicate/ReplicateTrainingResponseBody.swift
@@ -95,5 +95,9 @@ extension ReplicateTrainingResponseBody {
         case succeeded
         case failed
         case canceled
+
+        var isTerminal: Bool {
+            return [.succeeded, .failed, .canceled].contains(self)
+        }
     }
 }

--- a/Tests/AIProxyTests/ReplicatePredictionResponseBodyTests.swift
+++ b/Tests/AIProxyTests/ReplicatePredictionResponseBodyTests.swift
@@ -1,5 +1,5 @@
 //
-//  ReplicatePredictionResponseBodyTests.swift
+//  ReplicatePredictionTests.swift
 //
 //
 //  Created by Lou Zell on 8/25/24.
@@ -9,7 +9,7 @@ import XCTest
 import Foundation
 @testable import AIProxy
 
-final class ReplicatePredictionResponseBodyTests: XCTestCase {
+final class ReplicatePredictionTests: XCTestCase {
 
     func testCreatePredictionResponseIsDecodable() throws {
         let responseBody = """
@@ -32,7 +32,7 @@ final class ReplicatePredictionResponseBodyTests: XCTestCase {
           }
         }
         """
-        let res = try ReplicatePredictionResponseBody<ReplicateSDXLOutputSchema>.deserialize(
+        let res = try ReplicatePrediction<ReplicateSDXLOutputSchema>.deserialize(
             from: responseBody
         )
         XCTAssertEqual(
@@ -42,7 +42,7 @@ final class ReplicatePredictionResponseBodyTests: XCTestCase {
     }
 
     func testPollResponseIsDecodable() throws {
-        let responseBody = """
+        let responseBody = #"""
         {
           "id": "y4azg2rc11rgj0chj848dwg3cr",
           "model": "stability-ai/sdxl",
@@ -68,8 +68,8 @@ final class ReplicatePredictionResponseBodyTests: XCTestCase {
             "predict_time": 11.977849107
           }
         }
-        """
-        let res = try ReplicatePredictionResponseBody<ReplicateSDXLOutputSchema>.deserialize(
+        """#
+        let res = try ReplicatePrediction<ReplicateSDXLOutputSchema>.deserialize(
             from: responseBody
         )
         XCTAssertEqual("2024-08-27T04:11:38.588127861Z", res.completedAt)
@@ -80,7 +80,7 @@ final class ReplicatePredictionResponseBodyTests: XCTestCase {
     }
 
     func testReplicateFluxProResponseIsDecodable() throws {
-        let responseBody = """
+        let responseBody = #"""
         {
           "id": "kyzk126n5srgc0chs88tpfy69g",
           "model": "replicate/flux-pro-internal-model",
@@ -106,8 +106,8 @@ final class ReplicatePredictionResponseBodyTests: XCTestCase {
             "predict_time": 21.888670827
           }
         }
-        """
-        let res = try ReplicatePredictionResponseBody<ReplicateFluxProOutputSchema>.deserialize(from: responseBody)
+        """#
+        let res = try ReplicatePrediction<ReplicateFluxProOutputSchema>.deserialize(from: responseBody)
         XCTAssertEqual("2024-09-07T01:21:13.910476435Z", res.completedAt)
         XCTAssertEqual(
             "https://replicate.delivery/czjl/PxBiGkp8kYbNLpY0acmT04rsduBjEOGTdUrmweKtrl7E5KtJA/output.webp",

--- a/Tests/AIProxyTests/ReplicateSyncAPIResponseBodyTests.swift
+++ b/Tests/AIProxyTests/ReplicateSyncAPIResponseBodyTests.swift
@@ -47,7 +47,7 @@ final class ReplicateSyncAPIResponseBodyTests: XCTestCase {
           }
         }
         """#
-        let response = try ReplicateSynchronousResponseBody<[String]>.deserialize(from: responseBody)
+        let response = try ReplicatePrediction<[String]>.deserialize(from: responseBody)
         XCTAssertNil(response.output)
         XCTAssertEqual(
             "https://api.replicate.com/v1/predictions/kwvnpcac8drj00cmpp48fvvgbr",


### PR DESCRIPTION
Replicate users of the lib no longer have to juggle many calls into the replicate service from their calling code. We provide high level calls `runCommunityModel` and `runOfficialModel` that use the synchronous API for the allotted time, and then automatically fall back to polling if that time is exceeded.

Further, I had previously abstracted away the prediction object. This was not great, there may be things that developers want to do in the case of failure (look at logs, look at metrics, show the error message) that are easier by exposing the prediction object to the caller. So now those objects are exposed.

You can make a prediction using either `replicateService.runCommunityModel` or `replicateService.runOfficialModel`, both of which return the prediction object in a terminal state (succeeded, failed, or canceled). The caller can then inspect any properties that they want. If their only aim is to map the prediction object to the output, we have a helper for that: `replicateService.getPredictionOutput(prediction)`

Additional niceties:
- Added a `replicateService.uploadFile` method that uploads a file to Replicate's CDN. This is handy for using the uploaded file in predictions or as training data.
- Touched up the README examples for calling models that we haven't already added to `ReplicateService+Convenience.swift`. It should now be quite straightforward to do this, which is good. We want callers to explore the possibilities of Replicate, not be limited to what we've added convenience methods for.
  - If you look at the convenience method bodies, you will see that they are now very straightforward and can easily be modified to the developer's own aims. For example, calling an official model:
```
        let prediction: ReplicatePrediction<[URL]> = try await replicateService.runOfficialModel(
            modelOwner: "black-forest-labs",
            modelName: "flux-schnell",
            input: input,
            secondsToWait: secondsToWait
        )
        return try await replicateService.getPredictionOutput(prediction)
```

or calling a community model:
```
        let prediction: ReplicatePrediction<[URL]> = try await replicateService.runCommunityModel(
            version: version,
            input: input,
            secondsToWait: secondsToWait
        )
        return try await replicateService.getPredictionOutput(prediction)
```

