### PR TITLE
improved tool use with anthropic

### DIFF
--- a/Sources/AIProxy/Anthropic/AnthropicMessageRequestBody.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicMessageRequestBody.swift
@@ -267,12 +267,19 @@ public enum AnthropicInputContent: Encodable {
     case image(mediaType: AnthropicImageMediaType, data: String)
     case pdf(data: String)
     case text(String)
+    case toolUse(id: String, name: String, input: [String: AIProxyJSONValue])
+    case toolResult(toolUseId: String, content: String)
 
     private enum CodingKeys: String, CodingKey {
         case image
         case source
         case text
         case type
+        case id
+        case name
+        case input
+        case toolUseId = "tool_use_id"
+        case content
     }
 
     private enum SourceCodingKeys: String, CodingKey {
@@ -299,6 +306,15 @@ public enum AnthropicInputContent: Encodable {
         case .text(let txt):
             try container.encode("text", forKey: .type)
             try container.encode(txt, forKey: .text)
+        case .toolUse(id: let id, name: let name, input: let input):
+            try container.encode("tool_use", forKey: .type)
+            try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try container.encode(input, forKey: .input)
+        case .toolResult(toolUseId: let toolUseId, content: let content):
+            try container.encode("tool_result", forKey: .type)
+            try container.encode(toolUseId, forKey: .toolUseId)
+            try container.encode(content, forKey: .content)
         }
     }
 }
@@ -344,6 +360,25 @@ public enum AnthropicToolChoice: Encodable {
     case any
     case auto
     case tool(name: String)
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        switch self {
+        case .auto:
+            try container.encode("auto", forKey: .type)
+        case .any:
+            try container.encode("any", forKey: .type)
+        case .tool(let name):
+            try container.encode("tool", forKey: .type)
+            try container.encode(name, forKey: .name)
+        }
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case name
+    }
 }
 
 

--- a/Sources/AIProxy/Anthropic/AnthropicMessageResponseBody.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicMessageResponseBody.swift
@@ -33,7 +33,7 @@ public struct AnthropicMessageResponseBody: Decodable {
 
 public enum AnthropicMessageResponseContent: Decodable {
     case text(String)
-    case toolUse(id: String, name: String, input: [String: Any])
+    case toolUse(id: String, name: String, input: [String: AIProxyJSONValue])
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -59,7 +59,7 @@ public enum AnthropicMessageResponseContent: Decodable {
             let id = try container.decode(String.self, forKey: .id)
             let name = try container.decode(String.self, forKey: .name)
             let input = try container.decode([String: AIProxyJSONValue].self, forKey: .input)
-            self = .toolUse(id: id, name: name, input: input.untypedDictionary)
+            self = .toolUse(id: id, name: name, input: input)
         }
     }
 }


### PR DESCRIPTION
Add the required changes to respond back to Anthropic with the tool use and tool response options. Example usage: 

```swift
for content in response.content {
      switch content {
      case .text(let message):
          print("MESSAGE: \(message)")
          messages.append(
              .init(
                  content: [.text(message)],
                  role: .assistant
              )
          )

      case .toolUse(id: let id, name: let toolName, input: let toolInput):
          
          if toolName == "mytool" {
              if case .string(let thought) = toolInput["myinput"]  {
                  print("TOOL: \(myinput)")
                  
                  messages.append(
                      .init(
                          content: [.toolUse(id: id, name: toolName, input: toolInput)],
                          role: .assistant
                      )
                  )
                  
                  messages.append(
                      .init(
                          content: [.toolResult(toolUseId: id, content: thought)], role: .user
                      )
                  )
                  try await callClaude()
              } else {
                  print("Claude used the think tool with invalid input: \(toolInput)")
              }
          } else {
              print("Claude used an unknown tool: \(toolName)")
          }
      }
  }
```