### PR TITLE
Add support for OpenAI's semantic VAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,9 +978,11 @@ final class RealtimeManager {
             outputAudioFormat: .pcm16,
             temperature: 0.7,
             turnDetection: .init(
-                prefixPaddingMs: 200,
-                silenceDurationMs: 500,
-                threshold: 0.5
+                type: .serverVAD(
+                    prefixPaddingMs: 300,
+                    silenceDurationMs: 500,
+                    threshold: 0.5
+                )
             ),
             voice: "shimmer"
         )

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public struct AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.78.0"
+    public static let sdkVersion = "0.80.0"
 
     /// - Parameters:
     ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your provider's key.


### PR DESCRIPTION
To use semantic VAD, change your realtime session configuration callsite from this:

```swift
            // ...
            turnDetection: .init(
                type: .serverVAD(
                    prefixPaddingMs: 300,
                    silenceDurationMs: 500,
                    threshold: 0.5
                )
            ),
```

to this:

```swift
            // ...
            turnDetection: .init(
                type: .semanticVAD(
                    eagerness: .low
                )
            )
```