### PR TITLE
Add seconds to wait param for gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,7 +1251,8 @@ You can use all of the OpenAI snippets aboves with one change. Initialize the Op
     do {
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-2.0-flash-exp"
+            model: "gemini-2.0-flash-exp",
+            secondsToWait: 60
         )
         for part in response.candidates?.first?.content?.parts ?? [] {
             switch part {
@@ -1343,7 +1344,8 @@ You can use all of the OpenAI snippets aboves with one change. Initialize the Op
     do {
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-2.0-flash-exp"
+            model: "gemini-2.0-flash-exp",
+            secondsToWait: 60
         )
         for part in response.candidates?.first?.content?.parts ?? [] {
             switch part {
@@ -1408,7 +1410,8 @@ credits that you can put towards Gemini.
     do {
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-1.5-flash"
+            model: "gemini-1.5-flash",
+            secondsToWait: 60
         )
         for part in response.candidates?.first?.content?.parts ?? [] {
             switch part {
@@ -1479,7 +1482,8 @@ credits that you can put towards Gemini.
     do {
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-2.0-flash"
+            model: "gemini-2.0-flash",
+            secondsToWait: 60
         )
         for candidate in response.candidates ?? [] {
             for part in candidate.content?.parts ?? [] {
@@ -1550,7 +1554,8 @@ Add a file called `helloworld.m4a` to your Xcode assets before running this samp
         )
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-1.5-flash"
+            model: "gemini-1.5-flash",
+            secondsToWait: 60
         )
         for part in response.candidates?.first?.content?.parts ?? [] {
             switch part {
@@ -1629,7 +1634,8 @@ Add a file called 'my-image.jpg' to Xcode app assets. Then run this snippet:
         )
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-1.5-flash"
+            model: "gemini-1.5-flash",
+            secondsToWait: 60
         )
         for part in response.candidates?.first?.content?.parts ?? [] {
             switch part {
@@ -1747,7 +1753,8 @@ Use the file URL returned from the snippet above.
     do {
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-1.5-flash"
+            model: "gemini-1.5-flash",
+            secondsToWait: 60
         )
         for part in response.candidates?.first?.content?.parts ?? [] {
             switch part {
@@ -1850,7 +1857,8 @@ Use the file URL returned from the snippet above.
         )
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-2.0-flash"
+            model: "gemini-2.0-flash",
+            secondsToWait: 60
         )
         for part in response.candidates?.first?.content?.parts ?? [] {
             if case .text(let text) = part {
@@ -1945,7 +1953,8 @@ Use the file URL returned from the snippet above.
     do {
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-2.0-flash"
+            model: "gemini-2.0-flash",
+            secondsToWait: 60
         )
         for part in response.candidates?.first?.content?.parts ?? [] {
             if case .text(let text) = part {
@@ -2007,7 +2016,8 @@ Use the file URL returned from the snippet above.
     do {
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-2.0-flash-exp-image-generation"
+            model: "gemini-2.0-flash-exp-image-generation",
+            secondsToWait: 120
         )
         for part in response.candidates?.first?.content?.parts ?? [] {
             if case .inlineData(mimeType: let mimeType, base64Data: let base64Data) = part {
@@ -2122,7 +2132,8 @@ Use the file URL returned from the snippet above.
     do {
         let response = try await geminiService.generateContentRequest(
             body: requestBody,
-            model: "gemini-2.0-flash-exp-image-generation"
+            model: "gemini-2.0-flash-exp-image-generation",
+            secondsToWait: 120
         )
         for part in response.candidates?.first?.content?.parts ?? [] {
             if case .inlineData(mimeType: let mimeType, base64Data: let base64Data) = part {

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public struct AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.83.0"
+    public static let sdkVersion = "0.84.0"
 
     /// - Parameters:
     ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your provider's key.

--- a/Sources/AIProxy/Gemini/GeminiDirectService.swift
+++ b/Sources/AIProxy/Gemini/GeminiDirectService.swift
@@ -24,13 +24,17 @@ open class GeminiDirectService: GeminiService, DirectService {
     /// - Parameters:
     ///   - body: Request body
     ///   - model: The model to use for generating the completion, e.g. "gemini-1.5-flash"
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`.
+    ///                    Use `60` if you'd like to be consistent with the default URLSession timeout.
+    ///                    Use a longer timeout if you expect your generations to take longer than sixty seconds.
     /// - Returns: Content generated with Gemini
     public func generateContentRequest(
         body: GeminiGenerateContentRequestBody,
-        model: String
+        model: String,
+        secondsToWait: Int
     ) async throws -> GeminiGenerateContentResponseBody {
         let proxyPath = "/v1beta/models/\(model):generateContent"
-        let request = try AIProxyURLRequest.createDirect(
+        var request = try AIProxyURLRequest.createDirect(
             baseURL: "https://generativelanguage.googleapis.com",
             path: proxyPath,
             body:  body.serialize(),
@@ -40,6 +44,7 @@ open class GeminiDirectService: GeminiService, DirectService {
                 "X-Goog-Api-Key": self.unprotectedAPIKey
             ]
         )
+        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 

--- a/Sources/AIProxy/Gemini/GeminiProxiedService.swift
+++ b/Sources/AIProxy/Gemini/GeminiProxiedService.swift
@@ -26,13 +26,17 @@ open class GeminiProxiedService: GeminiService, ProxiedService {
     /// - Parameters:
     ///   - body: Request body
     ///   - model: The model to use for generating the completion, e.g. "gemini-1.5-flash"
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`.
+    ///                    Use `60` if you'd like to be consistent with the default URLSession timeout.
+    ///                    Use a longer timeout if you expect your generations to take longer than sixty seconds.
     /// - Returns: Content generated with Gemini
     public func generateContentRequest(
         body: GeminiGenerateContentRequestBody,
-        model: String
+        model: String,
+        secondsToWait: Int
     ) async throws -> GeminiGenerateContentResponseBody {
         let proxyPath = "/v1beta/models/\(model):generateContent"
-        let request = try await AIProxyURLRequest.create(
+        var request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
@@ -41,6 +45,7 @@ open class GeminiProxiedService: GeminiService, ProxiedService {
             verb: .post,
             contentType: "application/json"
         )
+        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 

--- a/Sources/AIProxy/Gemini/GeminiService.swift
+++ b/Sources/AIProxy/Gemini/GeminiService.swift
@@ -15,10 +15,14 @@ public protocol GeminiService {
     /// - Parameters:
     ///   - body: Request body
     ///   - model: The model to use for generating the completion, e.g. "gemini-1.5-flash"
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`.
+    ///                    Use `60` if you'd like to be consistent with the default URLSession timeout.
+    ///                    Use a longer timeout if you expect your generations to take longer than sixty seconds.
     /// - Returns: Content generated with Gemini
     func generateContentRequest(
         body: GeminiGenerateContentRequestBody,
-        model: String
+        model: String,
+        secondsToWait: Int
     ) async throws -> GeminiGenerateContentResponseBody
 
     /// Generate images with the Imagen API


### PR DESCRIPTION
Some image generations requests take longer than 60 seconds. I'm now enforcing that callers supply the timeout that makes sense for them. The docstring and README samples have a suggestion for folks that don't want to think about it.

I'm going to do this for more services and methods.

Relates to https://github.com/lzell/AIProxySwift/pull/121