### PR TITLE
Add support for new TTS model and additional voices

### DIFF
--- a/Sources/AIProxy/OpenAI/OpenAITextToSpeechRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAITextToSpeechRequestBody.swift
@@ -62,6 +62,7 @@ extension OpenAITextToSpeechRequestBody {
     public enum Model: String, Encodable {
         case tts1 = "tts-1"
         case tts1HD = "tts-1-hd"
+        case gpt_4o_mini_tts = "gpt-4o-mini-tts"
     }
 }
 
@@ -81,10 +82,14 @@ extension OpenAITextToSpeechRequestBody {
 extension OpenAITextToSpeechRequestBody {
     public enum Voice: String, Encodable {
         case alloy
+        case ash
+        case ballad
+        case coral
         case echo
         case fable
         case onyx
         case nova
+        case sage
         case shimmer
     }
 }


### PR DESCRIPTION
Summary
This PR extends the TTS capabilities by introducing support for a new TTS model (gpt-4o-mini-tts) and several additional voices.

What’s Changed
- Added gpt-4o-mini-tts to the list of supported models in OpenAITextToSpeechRequestBody.Model.
- Added new voice options (ash, ballad, coral, sage) to the Voice enum.

Notes
- These changes are backward-compatible and extend current functionality.