### PR TITLE
OpenAI Responses - Add PreviousResponseId to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ This is useful for `o1` and `o3` models.
 Use this approach to have a conversation with ChatGPT. All previous chat messages, whether
 issued by the user or the assistant (chatGPT), are fed back into the model on each request.
 
+As an alternative, you can use the new ChatGPT Responses API to hold the entire history by passing in the previousResponseId
+
 ```swift
     import AIProxy
 
@@ -1063,6 +1065,7 @@ final class RealtimeManager {
 
     let requestBody = OpenAICreateResponseRequestBody(
         input: .text("hello world"),
+        previousResponseId: nil,  // Pass this in on future requests to save chat history
         model: "gpt-4o"
     )
 

--- a/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
@@ -18,13 +18,22 @@ public struct OpenAICreateResponseRequestBody: Encodable {
     /// Text, image, or file inputs to the model, used to generate a response.
     public let input: Input
     public let model: String
+    public let previousResponseId: String?
 
     public init(
         input: OpenAICreateResponseRequestBody.Input,
-        model: String
+        model: String,
+        previousResponseId: String? = nil
     ) {
         self.input = input
         self.model = model
+        self.previousResponseId = previousResponseId
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case input
+        case model
+        case previousResponseId = "previous_response_id"
     }
 }
 

--- a/Tests/AIProxyTests/OpenAICreateResponseRequestTests.swift
+++ b/Tests/AIProxyTests/OpenAICreateResponseRequestTests.swift
@@ -52,7 +52,6 @@ final class OpenAICreateResponseRequestTests: XCTestCase {
     }
 
     func testResponseRequestIsEncodableWithImageInputs() throws {
-
         let requestBody = OpenAICreateResponseRequestBody(
             input: .items(
                 [
@@ -97,6 +96,35 @@ final class OpenAICreateResponseRequestTests: XCTestCase {
             """#,
             try requestBody.serialize(pretty: true)
         )
+    }
+    
+    func testResponseRequestIsEncodableWithPreviousResponseId() throws {
+        let requestBody = OpenAICreateResponseRequestBody(
+            input: .items(
+                [
+                    .message(
+                        role: .user,
+                        content: .text("Tell me another joke")
+                    ),
+                ]
+            ),
+            model: "gpt-4o",
+            previousResponseId: "1234"
+        )
+        XCTAssertEqual(
+                """
+                {
+                  "input" : [
+                    {
+                      "content" : "Tell me another joke",
+                      "role" : "user",
+                      "type" : "message"
+                    }
+                  ],
+                  "model" : "gpt-4o",
+                  "previous_response_id" : "1234"
+                }
+                """, try requestBody.serialize(pretty: true))
     }
 
 }


### PR DESCRIPTION
Allows the Chat Responses API to pass in a` previous_response_id`, allowing a user to pass in a single ID of a long conversation instead of manually passing in the entire chat history. This is the [recommended way to share entire chat](https://platform.openai.com/docs/guides/conversation-state#openai-apis-for-conversation-state) histories, but the parameter was missing in the request.

This PR adds the missing parameter, and a matching test case. It also updates the documentation to reflect this change.

Per the OpenAPI documentation:

Share context across generated responses with the previous_response_id parameter. This parameter lets you chain responses and create a threaded conversation.

https://platform.openai.com/docs/guides/conversation-state?api-mode=responses#openai-apis-for-conversation-state