### PR TITLE
Add optional `thinkingConfig` field for the new Gemini 2.5 flash model

### DIFF
--- a/Sources/AIProxy/Gemini/GeminiGenerateContentRequestBody.swift
+++ b/Sources/AIProxy/Gemini/GeminiGenerateContentRequestBody.swift
@@ -394,6 +394,7 @@ extension GeminiGenerateContentRequestBody {
         public let responseModalities: [String]?
         public let responseMimeType: String?
         public let responseSchema: [String: AIProxyJSONValue]?
+        public let thinkingConfig: ThinkingConfig?
 
         public init(
             maxOutputTokens: Int? = nil,
@@ -404,7 +405,8 @@ extension GeminiGenerateContentRequestBody {
             frequencyPenalty: Double? = nil,
             responseModalities: [String]? = nil,
             responseMimeType: String? = nil,
-            responseSchema: [String: AIProxyJSONValue]? = nil
+            responseSchema: [String: AIProxyJSONValue]? = nil,
+            thinkingConfig: ThinkingConfig? = nil
         ) {
             self.maxOutputTokens = maxOutputTokens
             self.temperature = temperature
@@ -415,6 +417,7 @@ extension GeminiGenerateContentRequestBody {
             self.responseModalities = responseModalities
             self.responseMimeType = responseMimeType
             self.responseSchema = responseSchema
+            self.thinkingConfig = thinkingConfig
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -427,6 +430,15 @@ extension GeminiGenerateContentRequestBody {
             case responseModalities
             case responseMimeType
             case responseSchema
+            case thinkingConfig
+        }
+        
+        public struct ThinkingConfig: Encodable {
+            public let thinkingBudget: Int
+            
+            public init(thinkingBudget: Int) {
+                self.thinkingBudget = thinkingBudget
+            }
         }
     }
 }

--- a/Sources/AIProxy/Gemini/GeminiGenerateContentResponseBody.swift
+++ b/Sources/AIProxy/Gemini/GeminiGenerateContentResponseBody.swift
@@ -173,5 +173,8 @@ extension GeminiGenerateContentResponseBody {
 
         /// Total token count for the generation request (prompt + response candidates).
         public let totalTokenCount: Int?
+
+        /// The number of tokens allocated for thinking.
+        public let thoughtsTokenCount: Int?
     }
 }

--- a/Tests/AIProxyTests/GeminiGenerateContentRequestTests.swift
+++ b/Tests/AIProxyTests/GeminiGenerateContentRequestTests.swift
@@ -205,6 +205,46 @@ final class GeminiGenerateContentRequestTests: XCTestCase {
             try requestBody.serialize(pretty: true)
         )
     }
+
+    func testRequestWithThinkingConfigIsEncodable() throws {
+        let requestBody = GeminiGenerateContentRequestBody(
+            contents: [
+                .init(
+                    parts: [.text("Explain the Occam's Razor concept and provide everyday examples of it")],
+                    role: "user"
+                )
+            ],
+            generationConfig: .init(
+                maxOutputTokens: 200,
+                temperature: 0.7,
+                thinkingConfig: .init(thinkingBudget: 1024)
+            )
+        )
+
+        XCTAssertEqual(#"""
+            {
+              "contents" : [
+                {
+                  "parts" : [
+                    {
+                      "text" : "Explain the Occam's Razor concept and provide everyday examples of it"
+                    }
+                  ],
+                  "role" : "user"
+                }
+              ],
+              "generationConfig" : {
+                "maxOutputTokens" : 200,
+                "temperature" : 0.7,
+                "thinkingConfig" : {
+                  "thinkingBudget" : 1024
+                }
+              }
+            }
+            """#,
+            try requestBody.serialize(pretty: true)
+        )
+    }
 }
 
 


### PR DESCRIPTION
Since `Gemini-2.5 Flash` is a hybrid model, you can enable/disabe thinking by specifying a `thinkingBudget` inside this field. If `0` then thinking is disabled, if `> 0` thinking is enabled and max tokens is capped at that int.