### PR TITLE
Add support for OpenAI Realtime API tool calls

### DIFF
--- a/Sources/AIProxy/OpenAI/OpenAIRealtimeConversationItemCreate.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRealtimeConversationItemCreate.swift
@@ -7,24 +7,38 @@
 
 import Foundation
 
+/// https://platform.openai.com/docs/api-reference/realtime-client-events/conversation/item/create
 public struct OpenAIRealtimeConversationItemCreate: Encodable {
     public let type = "conversation.item.create"
     public let item: Item
+
+    public init(item: Item) {
+        self.item = item
+    }
 }
 
 // MARK: -
 public extension OpenAIRealtimeConversationItemCreate {
     struct Item: Encodable {
-        let type = "message"
-        let role: String
-        let content: [Content]
+        public let type = "message"
+        public let role: String
+        public let content: [Content]
+
+        public init(role: String, text: String) {
+            self.role = role
+            self.content = [.init(text: text)]
+        }
     }
 }
 
 // MARK: -
 public extension OpenAIRealtimeConversationItemCreate.Item {
     struct Content: Encodable {
-        let type = "input_text"
-        let text: String
+        public let type = "input_text"
+        public let text: String
+
+        public init(text: String) {
+            self.text = text
+        }
     }
 }

--- a/Sources/AIProxy/OpenAI/OpenAIRealtimeMessage.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRealtimeMessage.swift
@@ -12,4 +12,5 @@ public enum OpenAIRealtimeMessage {
     case responseCreated // "response.created"
     case responseAudioDelta(String) // "response.audio.delta"
     case inputAudioBufferSpeechStarted // "input_audio_buffer.speech_started"
+    case responseFunctionCallArgumentsDone(String, String) // "response.function_call_arguments.done"
 }

--- a/Sources/AIProxy/OpenAI/OpenAIRealtimeResponseCreate.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRealtimeResponseCreate.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// https://platform.openai.com/docs/api-reference/realtime-client-events/response
 public struct OpenAIRealtimeResponseCreate: Encodable {
     public let type = "response.create"
     public let response: Response?
@@ -18,17 +19,36 @@ public struct OpenAIRealtimeResponseCreate: Encodable {
 
 // MARK: -
 extension OpenAIRealtimeResponseCreate {
-
     public struct Response: Encodable {
         public let instructions: String?
         public let modalities: [String]?
+        public let tools: [Tool]?
 
         public init(
             instructions: String? = nil,
-            modalities: [String]? = nil
+            modalities: [String]? = nil,
+            tools: [Tool]? = nil
         ) {
-            self.modalities = modalities
             self.instructions = instructions
+            self.modalities = modalities
+            self.tools = tools
+        }
+    }
+}
+
+// MARK: -
+extension OpenAIRealtimeResponseCreate.Response {
+    public struct Tool: Encodable {
+        public let name: String
+        public let description: String
+        public let parameters: [String: AIProxyJSONValue]
+        public let type = "function"
+
+        public init(name: String, description: String, parameters: [String: AIProxyJSONValue]) {
+            self.name = name
+            self.description = description
+            self.parameters = parameters
+            
         }
     }
 }

--- a/Sources/AIProxy/OpenAI/OpenAIRealtimeResponseFunctionCallArgumentsDone.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRealtimeResponseFunctionCallArgumentsDone.swift
@@ -1,0 +1,22 @@
+//
+//  OpenAIRealtimeResponseDone.swift
+//  AIProxy
+//
+//  Created by Tim Wheeler on 4/22/25.
+//
+
+import Foundation
+
+/// Returned when the model-generated function call arguments are done streaming.
+/// Also emitted when a Response is interrupted, incomplete, or cancelled.
+/// https://platform.openai.com/docs/api-reference/realtime-server-events/response/function_call_arguments/done
+public struct OpenAIRealtimeResponseFunctionCallArgumentsDone: Encodable {
+    public let type = "response.function_call_arguments.done"
+    public let name: String?
+    public let arguments: String?
+
+    public init(name: String, arguments: String) {
+        self.name = name
+        self.arguments = arguments
+    }
+}

--- a/Sources/AIProxy/OpenAI/OpenAIRealtimeSession.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRealtimeSession.swift
@@ -141,6 +141,11 @@ open class OpenAIRealtimeSession {
             self.continuation?.yield(.responseCreated)
         case "input_audio_buffer.speech_started":
             self.continuation?.yield(.inputAudioBufferSpeechStarted)
+        case "response.function_call_arguments.done":
+            if let name = json["name"] as? String,
+               let arguments = json["arguments"] as? String {
+                self.continuation?.yield(.responseFunctionCallArgumentsDone(name, arguments))
+            }
         default:
             break
         }


### PR DESCRIPTION
This change adds support for OpenAI Realtime tool calls.

I've never authored any Swift code before, so would love some feedback @lzell !

**Note**
I noticed in the OpenAI [docs](https://platform.openai.com/docs/api-reference/realtime-server-events/response/function_call_arguments/done), the `name` (i.e. the tool name) property of the `response.function_call_arguments.done` event is not present, however in the OpenAI playground the `name` is part of the payload, see screenshot below.

![CleanShot 2025-04-24 at 08 14 34@2x](https://github.com/user-attachments/assets/85a753e2-21f9-4a87-a898-b7ca8625eba8)
