### PR TITLE
Add a configuration method to be called at launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ key secure and your AI bill predictable:
     import AIProxy
 
     @main
-    struct ClientTesteriOSApp: App {
+    struct MyApp: App {
         init() {
             AIProxy.configure(
                 logLevel: .debug,

--- a/README.md
+++ b/README.md
@@ -51,6 +51,51 @@ key secure and your AI bill predictable:
 
    <img src="https://github.com/lzell/AIProxySwift/assets/35940/fd76b588-5e19-4d4d-9748-8db3fd64df8e" alt="Set package rule" width="720">
 
+3. Call `AIProxy.configure` during app launch. In a SwiftUI app, you can add an `init` to your `MyApp.swift` file: 
+
+    ```swift
+    import AIProxy
+
+    @main
+    struct ClientTesteriOSApp: App {
+        init() {
+            AIProxy.configure(
+                logLevel: .debug,
+                printRequestBodies: false,  // Flip to true for library development
+                printResponseBodies: false, // Flip to true for library development
+                resolveDNSOverTLS: true,
+                useStableID: true
+            )
+        }
+        // ...
+    }
+    ```
+
+In a UIKit app, add `configure` to applicationDidFinishLaunching:
+
+    ```swift
+    import AIProxy
+
+    @UIApplicationMain
+    class AppDelegate: UIResponder, UIApplicationDelegate {
+
+        var window: UIWindow?
+
+        func application(_ application: UIApplication,
+                         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+            AIProxy.configure(
+                logLevel: .debug,
+                printRequestBodies: false,  // Flip to true for library development
+                printResponseBodies: false, // Flip to true for library development
+                resolveDNSOverTLS: true,
+                useStableID: true
+            )
+            // ...
+            return true
+        }
+        // ...
+    }
+    ```
 
 ### How to configure the package for use with AIProxy
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ key secure and your AI bill predictable:
     }
     ```
 
-In a UIKit app, add `configure` to applicationDidFinishLaunching:
+   In a UIKit app, add `configure` to applicationDidFinishLaunching:
 
     ```swift
     import AIProxy

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -15,7 +15,7 @@ public struct AIProxy {
     ///     import AIProxy
     ///
     ///     @main
-    ///     struct ClientTesteriOSApp: App {
+    ///     struct MyApp: App {
     ///         init() {
     ///             AIProxy.configure(
     ///                 logLevel: .debug,

--- a/Sources/AIProxy/AIProxyIdentifier.swift
+++ b/Sources/AIProxy/AIProxyIdentifier.swift
@@ -17,8 +17,12 @@ import IOKit
 
 struct AIProxyIdentifier {
     /// Generates a clientID for this device.
-    /// - Returns: a UIDevice ID on iOS, an IOKit ID on macOS
+    /// - Returns: The AIProxy stableID if the developer configured the SDK with `useStableID`.
+    ///            Otherwise, a UIDevice ID on iOS, an IOKit ID on macOS
     internal static func getClientID() -> String? {
+        if let stableID = AIProxy.stableID {
+            return stableID
+        }
 #if os(watchOS)
         return WKInterfaceDevice.current().identifierForVendor?.uuidString
 #elseif canImport(UIKit)

--- a/Sources/AIProxy/AIProxyURLRequest.swift
+++ b/Sources/AIProxy/AIProxyURLRequest.swift
@@ -20,7 +20,8 @@ struct AIProxyURLRequest {
         contentType: String? = nil,
         additionalHeaders: [String: String] = [:]
     ) async throws -> URLRequest {
-        let deviceCheckToken = await AIProxyDeviceCheck.getToken(forClient: clientID)
+        let resolvedClientID = clientID ?? AIProxyIdentifier.getClientID()
+        let deviceCheckToken = await AIProxyDeviceCheck.getToken(forClient: resolvedClientID)
 
         var proxyPath = proxyPath
         if !proxyPath.starts(with: "/") {
@@ -46,8 +47,8 @@ struct AIProxyURLRequest {
         request.httpBody = body
         request.addValue(partialKey, forHTTPHeaderField: "aiproxy-partial-key")
 
-        if let clientID = (clientID ?? AIProxyIdentifier.getClientID()) {
-            request.addValue(clientID, forHTTPHeaderField: "aiproxy-client-id")
+        if let resolvedClientID = resolvedClientID {
+            request.addValue(resolvedClientID, forHTTPHeaderField: "aiproxy-client-id")
         }
 
         if let deviceCheckToken = deviceCheckToken {

--- a/Sources/AIProxy/AnonymousAccount/AnonymousAccountStorage.swift
+++ b/Sources/AIProxy/AnonymousAccount/AnonymousAccountStorage.swift
@@ -18,21 +18,13 @@ final class AnonymousAccountStorage {
     /// A best-effort anonymous ID that is stable across multiple devices of an iCloud account
     static var resolvedAccount: AnonymousAccount? {
         get {
-            return _resolvedAccountAccessQueue.sync {
-                return _resolvedAccount
-            }
+            protectedPropertyQueue.sync { _resolvedAccount }
         }
         set {
-            _resolvedAccountAccessQueue.async(flags: .barrier) {
-                _resolvedAccount = newValue
-            }
+            protectedPropertyQueue.async(flags: .barrier) { _resolvedAccount = newValue }
         }
     }
     private static var _resolvedAccount: AnonymousAccount?
-    private static let _resolvedAccountAccessQueue = DispatchQueue(
-        label: "aiproxy-resolved-account-access-queue",
-        attributes: .concurrent
-    )
 
     /// The account chain that lead to the current resolution.
     private static var localAccountChain: [AnonymousAccount] = []

--- a/Sources/AIProxy/BackgroundNetworker.swift
+++ b/Sources/AIProxy/BackgroundNetworker.swift
@@ -47,7 +47,6 @@ struct BackgroundNetworker {
                 responseBody: responseBody
             )
         }
-
         return (asyncBytes, httpResponse)
     }
 }

--- a/Sources/AIProxy/DirectService.swift
+++ b/Sources/AIProxy/DirectService.swift
@@ -7,25 +7,9 @@
 
 import Foundation
 
-protocol DirectService {}
+protocol DirectService: ServiceMixin {}
 extension DirectService {
     var urlSession: URLSession {
         return AIProxyUtils.directURLSession()
-    }
-
-    func makeRequestAndDeserializeResponse<T: Decodable>(_ request: URLRequest) async throws -> T {
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
-            self.urlSession,
-            request
-        )
-        return try T.deserialize(from: data)
-    }
-
-    func makeRequestAndDeserializeStreamingChunks<T: Decodable>(_ request: URLRequest) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, T> {
-        let (asyncBytes, _) = try await BackgroundNetworker.makeRequestAndWaitForAsyncBytes(
-            self.urlSession,
-            request
-        )
-        return asyncBytes.lines.compactMap { T.deserialize(fromLine: $0) }
     }
 }

--- a/Sources/AIProxy/ProtectedPropertyQueue.swift
+++ b/Sources/AIProxy/ProtectedPropertyQueue.swift
@@ -1,0 +1,13 @@
+//
+//  ProtectedPropertyQueue.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 4/23/25.
+//
+
+import Foundation
+
+internal let protectedPropertyQueue = DispatchQueue(
+    label: "aiproxy-protected-property-queue",
+    attributes: .concurrent
+)

--- a/Sources/AIProxy/ProxiedService.swift
+++ b/Sources/AIProxy/ProxiedService.swift
@@ -7,25 +7,9 @@
 
 import Foundation
 
-protocol ProxiedService {}
+protocol ProxiedService: ServiceMixin {}
 extension ProxiedService {
     var urlSession: URLSession {
         return AIProxyUtils.proxiedURLSession()
-    }
-
-    func makeRequestAndDeserializeResponse<T: Decodable>(_ request: URLRequest) async throws -> T {
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
-            self.urlSession,
-            request
-        )
-        return try T.deserialize(from: data)
-    }
-
-    func makeRequestAndDeserializeStreamingChunks<T: Decodable>(_ request: URLRequest) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, T> {
-        let (asyncBytes, _) = try await BackgroundNetworker.makeRequestAndWaitForAsyncBytes(
-            self.urlSession,
-            request
-        )
-        return asyncBytes.lines.compactMap { T.deserialize(fromLine: $0) }
     }
 }

--- a/Sources/AIProxy/Serializable.swift
+++ b/Sources/AIProxy/Serializable.swift
@@ -9,6 +9,7 @@ import Foundation
 
 extension Encodable {
     func serialize(pretty: Bool = false) throws -> Data {
+        let pretty = pretty || AIProxy.printRequestBodies
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         if pretty {

--- a/Sources/AIProxy/ServiceMixin.swift
+++ b/Sources/AIProxy/ServiceMixin.swift
@@ -1,0 +1,86 @@
+//
+//  ServiceMixin.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 4/24/25.
+//
+
+import Foundation
+
+protocol ServiceMixin {
+    var urlSession: URLSession { get }
+}
+
+extension ServiceMixin {
+    func makeRequestAndDeserializeResponse<T: Decodable>(_ request: URLRequest) async throws -> T {
+        if AIProxy.printRequestBodies {
+            printRequestBody(request)
+        }
+        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
+            self.urlSession,
+            request
+        )
+        if AIProxy.printResponseBodies {
+            printBufferedResponseBody(data)
+        }
+        return try T.deserialize(from: data)
+    }
+
+    func makeRequestAndDeserializeStreamingChunks<T: Decodable>(_ request: URLRequest) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, T> {
+        if AIProxy.printRequestBodies {
+            printRequestBody(request)
+        }
+        let (asyncBytes, _) = try await BackgroundNetworker.makeRequestAndWaitForAsyncBytes(
+            self.urlSession,
+            request
+        )
+        return asyncBytes.lines.compactMap {
+            if AIProxy.printResponseBodies {
+                printStreamingResponseChunk($0)
+            }
+            return T.deserialize(fromLine: $0)
+        }
+    }
+}
+
+private extension URLRequest {
+    var readableURL: String {
+        return self.url?.absoluteString ?? ""
+    }
+
+    var readableBody: String {
+        guard let body = self.httpBody else {
+            return "None"
+        }
+
+        return String(data: body, encoding: .utf8) ?? "None"
+    }
+}
+
+private func printRequestBody(_ request: URLRequest) {
+    logIf(.debug)?.debug(
+        """
+        Making a request to \(request.readableURL)
+        with request body:
+        \(request.readableBody)
+        """
+    )
+}
+
+private func printBufferedResponseBody(_ data: Data) {
+    logIf(.debug)?.debug(
+        """
+        Received response body:
+        \(String(data: data, encoding: .utf8) ?? "")
+        """
+    )
+}
+
+private func printStreamingResponseChunk(_ chunk: String) {
+    logIf(.debug)?.debug(
+        """
+        Received streaming response chunk:
+        \(chunk)
+        """
+    )
+}


### PR DESCRIPTION
Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.

    import AIProxy

    @main
    struct ClientTesteriOSApp: App {
        init() {
            AIProxy.configure(
                logLevel: .debug,
                printRequestBodies: true,
                printResponseBodies: true,
                resolveDNSOverTLS: true,
                useStableID: true
            )
        }
        // ...
    }

Or in your UIKit app's applicationDidFinishLaunching:

    import AIProxy

    @UIApplicationMain
    class AppDelegate: UIResponder, UIApplicationDelegate {

         var window: UIWindow?

         func application(_ application: UIApplication,
                          didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
             AIProxy.configure(
                 logLevel: .debug,
                 printRequestBodies: true,
                 printResponseBodies: true,
                 resolveDNSOverTLS: true,
                 useStableID: true
             )
             // ...
             return true
         }
         // ...
     }
