### PR TITLE
Make compiler enforce secondsToWait on all requests

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public struct AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.95.0"
+    public static let sdkVersion = "0.96.1"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///
@@ -170,6 +170,7 @@ public struct AIProxy {
             proxyPath: proxyPath,
             body: body,
             verb: verb,
+            secondsToWait: 60,
             additionalHeaders: headers
         )
     }

--- a/Sources/AIProxy/AIProxyURLRequest.swift
+++ b/Sources/AIProxy/AIProxyURLRequest.swift
@@ -17,6 +17,7 @@ struct AIProxyURLRequest {
         proxyPath: String,
         body: Data?,
         verb: AIProxyHTTPVerb,
+        secondsToWait: UInt,
         contentType: String? = nil,
         additionalHeaders: [String: String] = [:]
     ) async throws -> URLRequest {
@@ -77,6 +78,7 @@ struct AIProxyURLRequest {
             request.addValue(value, forHTTPHeaderField: headerField)
         }
 
+        request.timeoutInterval = TimeInterval(secondsToWait)
         return request
     }
 
@@ -87,6 +89,7 @@ struct AIProxyURLRequest {
         path: String,
         body: Data?,
         verb: AIProxyHTTPVerb,
+        secondsToWait: UInt,
         contentType: String? = nil,
         additionalHeaders: [String: String] = [:]
     ) throws -> URLRequest {
@@ -121,6 +124,7 @@ struct AIProxyURLRequest {
             request.addValue(value, forHTTPHeaderField: headerField)
         }
 
+        request.timeoutInterval = TimeInterval(secondsToWait)
         return request
     }
 

--- a/Sources/AIProxy/Anthropic/AnthropicDirectService.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicDirectService.swift
@@ -42,6 +42,7 @@ open class AnthropicDirectService: AnthropicService, DirectService {
             path: "/v1/messages",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: additionalHeaders
         )
@@ -72,6 +73,7 @@ open class AnthropicDirectService: AnthropicService, DirectService {
             path: "/v1/messages",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: additionalHeaders
         )

--- a/Sources/AIProxy/Anthropic/AnthropicProxiedService.swift
+++ b/Sources/AIProxy/Anthropic/AnthropicProxiedService.swift
@@ -45,6 +45,7 @@ open class AnthropicProxiedService: AnthropicService, ProxiedService {
             proxyPath: "/v1/messages",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: additionalHeaders
         )
@@ -76,6 +77,7 @@ open class AnthropicProxiedService: AnthropicService, ProxiedService {
             proxyPath: "/v1/messages",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: additionalHeaders
         )

--- a/Sources/AIProxy/Brave/BraveDirectService.swift
+++ b/Sources/AIProxy/Brave/BraveDirectService.swift
@@ -26,22 +26,22 @@ open class BraveDirectService: BraveService, DirectService {
     ///            BraveWebSearchResponseBody to understand how to get the information you want out of it.
     public func webSearchRequest(
         query: String,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> BraveWebSearchResponseBody {
         guard let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
             throw AIProxyError.assertion("Could not create an encoded version of query params for brave search")
         }
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.search.brave.com",
             path: "/res/v1/web/search?q=" + encodedQuery,
             body: nil,
             verb: .get,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "X-Subscription-Token": self.unprotectedAPIKey
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 }

--- a/Sources/AIProxy/Brave/BraveProxiedService.swift
+++ b/Sources/AIProxy/Brave/BraveProxiedService.swift
@@ -35,21 +35,21 @@ open class BraveProxiedService: BraveService, ProxiedService {
     ///            BraveWebSearchResponseBody to understand how to get the information you want out of it.
     public func webSearchRequest(
         query: String,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> BraveWebSearchResponseBody {
         guard let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
             throw AIProxyError.assertion("Could not create an encoded version of query params for brave search")
         }
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: "/res/v1/web/search?q=" + encodedQuery,
             body: nil,
             verb: .get,
+            secondsToWait: secondsToWait,
             contentType: "application/json"
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 }

--- a/Sources/AIProxy/Brave/BraveService.swift
+++ b/Sources/AIProxy/Brave/BraveService.swift
@@ -19,7 +19,7 @@ public protocol BraveService {
     ///            BraveWebSearchResponseBody to understand how to get the information you want out of it.
     func webSearchRequest(
         query: String,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> BraveWebSearchResponseBody
 }
 

--- a/Sources/AIProxy/DeepL/DeepLDirectService.swift
+++ b/Sources/AIProxy/DeepL/DeepLDirectService.swift
@@ -32,6 +32,7 @@ open class DeepLDirectService: DeepLService, DirectService {
             path: "/v2/translate",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "DeepL-Auth-Key \(self.unprotectedAPIKey)"

--- a/Sources/AIProxy/DeepL/DeepLProxiedService.swift
+++ b/Sources/AIProxy/DeepL/DeepLProxiedService.swift
@@ -36,6 +36,7 @@ open class DeepLProxiedService: DeepLService, ProxiedService {
             proxyPath: "/v2/translate",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeResponse(request)

--- a/Sources/AIProxy/DeepSeek/DeepSeekDirectService.swift
+++ b/Sources/AIProxy/DeepSeek/DeepSeekDirectService.swift
@@ -31,23 +31,23 @@ open class DeepSeekDirectService: DeepSeekService, DirectService {
     ///            https://api-docs.deepseek.com/api/create-chat-completion#responses
     public func chatCompletionRequest(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> DeepSeekChatCompletionResponseBody {
         var body = body
         body.stream = false
         body.streamOptions = nil
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: self.baseURL,
             path: "/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)",
                 "Accept": "application/json"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -61,23 +61,23 @@ open class DeepSeekDirectService: DeepSeekService, DirectService {
     ///           https://api-docs.deepseek.com/api/create-chat-completion#responses
     public func streamingChatCompletionRequest(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: self.baseURL,
             path: "/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)",
                 "Accept": "application/json"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeStreamingChunks(request)
     }
 }

--- a/Sources/AIProxy/DeepSeek/DeepSeekProxiedService.swift
+++ b/Sources/AIProxy/DeepSeek/DeepSeekProxiedService.swift
@@ -34,24 +34,24 @@ open class DeepSeekProxiedService: DeepSeekService, ProxiedService {
     ///            https://api-docs.deepseek.com/api/create-chat-completion#responses
     public func chatCompletionRequest(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> DeepSeekChatCompletionResponseBody {
         var body = body
         body.stream = false
         body.streamOptions = nil
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: "/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Accept": "application/json"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -65,24 +65,24 @@ open class DeepSeekProxiedService: DeepSeekService, ProxiedService {
     ///           https://api-docs.deepseek.com/api/create-chat-completion#responses
     public func streamingChatCompletionRequest(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: "/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Accept": "application/json"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeStreamingChunks(request)
     }
 }

--- a/Sources/AIProxy/DeepSeek/DeepSeekService.swift
+++ b/Sources/AIProxy/DeepSeek/DeepSeekService.swift
@@ -19,7 +19,7 @@ public protocol DeepSeekService {
     ///            https://api-docs.deepseek.com/api/create-chat-completion#responses
     func chatCompletionRequest(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> DeepSeekChatCompletionResponseBody
 
     /// Initiates a streaming chat completion request to /chat/completions.
@@ -32,7 +32,7 @@ public protocol DeepSeekService {
     ///           https://api-docs.deepseek.com/api/create-chat-completion#responses
     func streamingChatCompletionRequest(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk>
 }
 

--- a/Sources/AIProxy/EachAI/EachAIDirectService.swift
+++ b/Sources/AIProxy/EachAI/EachAIDirectService.swift
@@ -39,6 +39,7 @@ open class EachAIDirectService: EachAIService, DirectService {
             path: "/api/v1/\(workflowID)/trigger",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "X-API-Key": self.unprotectedAPIKey
@@ -59,6 +60,7 @@ open class EachAIDirectService: EachAIService, DirectService {
             path: "/api/v1/\(workflowID)/executions/\(triggerID)",
             body: nil,
             verb: .get,
+            secondsToWait: 60,
             additionalHeaders: [
                 "X-API-Key": self.unprotectedAPIKey
             ]

--- a/Sources/AIProxy/EachAI/EachAIProxiedService.swift
+++ b/Sources/AIProxy/EachAI/EachAIProxiedService.swift
@@ -47,6 +47,7 @@ open class EachAIProxiedService: EachAIService, ProxiedService {
             proxyPath: "/api/v1/\(workflowID)/trigger",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeResponse(request)
@@ -65,7 +66,8 @@ open class EachAIProxiedService: EachAIService, ProxiedService {
             clientID: self.clientID,
             proxyPath: "/api/v1/\(workflowID)/executions/\(triggerID)",
             body: nil,
-            verb: .get
+            verb: .get,
+            secondsToWait: 60
         )
         return try await self.makeRequestAndDeserializeResponse(request)
     }

--- a/Sources/AIProxy/ElevenLabs/ElevenLabsDirectService.swift
+++ b/Sources/AIProxy/ElevenLabs/ElevenLabsDirectService.swift
@@ -37,6 +37,7 @@ open class ElevenLabsDirectService: ElevenLabsService, DirectService {
             path: "/v1/text-to-speech/\(voiceID)",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "xi-api-key": self.unprotectedAPIKey
@@ -70,6 +71,7 @@ open class ElevenLabsDirectService: ElevenLabsService, DirectService {
             path: "/v1/speech-to-speech/\(voiceID)",
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: [
                 "xi-api-key": self.unprotectedAPIKey
@@ -99,6 +101,7 @@ open class ElevenLabsDirectService: ElevenLabsService, DirectService {
             path: "/v1/speech-to-text",
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: [
                 "xi-api-key": self.unprotectedAPIKey

--- a/Sources/AIProxy/ElevenLabs/ElevenLabsProxiedService.swift
+++ b/Sources/AIProxy/ElevenLabs/ElevenLabsProxiedService.swift
@@ -42,6 +42,7 @@ open class ElevenLabsProxiedService: ElevenLabsService, ProxiedService {
             proxyPath: "/v1/text-to-speech/\(voiceID)",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
@@ -74,6 +75,7 @@ open class ElevenLabsProxiedService: ElevenLabsService, ProxiedService {
             proxyPath: "/v1/speech-to-speech/\(voiceID)",
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)"
         )
         let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
@@ -102,6 +104,7 @@ open class ElevenLabsProxiedService: ElevenLabsService, ProxiedService {
             proxyPath: "/v1/speech-to-text",
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)"
         )
         return try await self.makeRequestAndDeserializeResponse(request)

--- a/Sources/AIProxy/Fal/FalDirectService.swift
+++ b/Sources/AIProxy/Fal/FalDirectService.swift
@@ -35,6 +35,7 @@ open class FalDirectService: FalService, DirectService {
             path: model,
             body: input.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Key \(self.unprotectedAPIKey)"
@@ -68,6 +69,7 @@ open class FalDirectService: FalService, DirectService {
             path: url.path,
             body: nil,
             verb: .get,
+            secondsToWait: 60,
             additionalHeaders: [
                 "Authorization": "Key \(self.unprotectedAPIKey)"
             ]
@@ -98,6 +100,7 @@ open class FalDirectService: FalService, DirectService {
             path: "/storage/upload/initiate",
             body: initiateUpload.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Key \(self.unprotectedAPIKey)"

--- a/Sources/AIProxy/Fal/FalProxiedService.swift
+++ b/Sources/AIProxy/Fal/FalProxiedService.swift
@@ -41,6 +41,7 @@ open class FalProxiedService: FalService, ProxiedService {
             proxyPath: model,
             body: input.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeResponse(request)
@@ -71,7 +72,8 @@ open class FalProxiedService: FalService, ProxiedService {
             clientID: self.clientID,
             proxyPath: url.path,
             body: nil,
-            verb: .get
+            verb: .get,
+            secondsToWait: 60
         )
         let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
             self.urlSession,
@@ -101,6 +103,7 @@ open class FalProxiedService: FalService, ProxiedService {
             proxyPath: "/storage/upload/initiate",
             body: initiateUpload.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
 

--- a/Sources/AIProxy/FireworksAI/FireworksAIDirectService.swift
+++ b/Sources/AIProxy/FireworksAI/FireworksAIDirectService.swift
@@ -30,7 +30,7 @@ open class FireworksAIDirectService: FireworksAIService, DirectService {
     ///            https://api-docs.deepseek.com/api/create-chat-completion#responses
     public func deepSeekR1Request(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> DeepSeekChatCompletionResponseBody {
         if body.model != "accounts/fireworks/models/deepseek-r1" {
             logIf(.warning)?.warning("Attempting to use deepSeekR1Request with an unknown model")
@@ -38,18 +38,18 @@ open class FireworksAIDirectService: FireworksAIService, DirectService {
         var body = body
         body.stream = false
         body.streamOptions = nil
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.fireworks.ai",
             path: "/inference/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)",
                 "Accept": "application/json"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -64,7 +64,7 @@ open class FireworksAIDirectService: FireworksAIService, DirectService {
     ///           https://api-docs.deepseek.com/api/create-chat-completion#responses
     public func streamingDeepSeekR1Request(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
         if body.model != "accounts/fireworks/models/deepseek-r1" {
             logIf(.warning)?.warning("Attempting to use deepSeekR1Request with an unknown model")
@@ -72,18 +72,18 @@ open class FireworksAIDirectService: FireworksAIService, DirectService {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.fireworks.ai",
             path: "/inference/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)",
                 "Accept": "application/json"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeStreamingChunks(request)
    }
 }

--- a/Sources/AIProxy/FireworksAI/FireworksAIProxiedService.swift
+++ b/Sources/AIProxy/FireworksAI/FireworksAIProxiedService.swift
@@ -36,7 +36,7 @@ open class FireworksAIProxiedService: FireworksAIService, ProxiedService {
     ///            https://api-docs.deepseek.com/api/create-chat-completion#responses
     public func deepSeekR1Request(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> DeepSeekChatCompletionResponseBody {
         if body.model != "accounts/fireworks/models/deepseek-r1" {
             logIf(.warning)?.warning("Attempting to use deepSeekR1Request with an unknown model")
@@ -44,16 +44,16 @@ open class FireworksAIProxiedService: FireworksAIService, ProxiedService {
         var body = body
         body.stream = false
         body.streamOptions = nil
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: "/inference/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json"
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -68,7 +68,7 @@ open class FireworksAIProxiedService: FireworksAIService, ProxiedService {
     ///           https://api-docs.deepseek.com/api/create-chat-completion#responses
     public func streamingDeepSeekR1Request(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
         if body.model != "accounts/fireworks/models/deepseek-r1" {
             logIf(.warning)?.warning("Attempting to use deepSeekR1Request with an unknown model")
@@ -76,16 +76,16 @@ open class FireworksAIProxiedService: FireworksAIService, ProxiedService {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: "/inference/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json"
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeStreamingChunks(request)
     }
 }

--- a/Sources/AIProxy/FireworksAI/FireworksAIService.swift
+++ b/Sources/AIProxy/FireworksAI/FireworksAIService.swift
@@ -20,7 +20,7 @@ public protocol FireworksAIService {
     ///            https://api-docs.deepseek.com/api/create-chat-completion#responses
     func deepSeekR1Request(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> DeepSeekChatCompletionResponseBody
 
     /// Initiates a streaming chat completion request to DeepSeek R1 at api.fireworks.ai/inference/v1/chat/completions
@@ -34,6 +34,6 @@ public protocol FireworksAIService {
     ///           https://api-docs.deepseek.com/api/create-chat-completion#responses
     func streamingDeepSeekR1Request(
         body: DeepSeekChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk>
 }

--- a/Sources/AIProxy/Gemini/GeminiDirectService.swift
+++ b/Sources/AIProxy/Gemini/GeminiDirectService.swift
@@ -31,20 +31,20 @@ open class GeminiDirectService: GeminiService, DirectService {
     public func generateContentRequest(
         body: GeminiGenerateContentRequestBody,
         model: String,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> GeminiGenerateContentResponseBody {
         let proxyPath = "/v1beta/models/\(model):generateContent"
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://generativelanguage.googleapis.com",
             path: proxyPath,
             body:  body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "X-Goog-Api-Key": self.unprotectedAPIKey
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -59,6 +59,7 @@ open class GeminiDirectService: GeminiService, DirectService {
             path: proxyPath,
             body:  body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "X-Goog-Api-Key": self.unprotectedAPIKey
@@ -95,6 +96,7 @@ open class GeminiDirectService: GeminiService, DirectService {
             path: "/upload/v1beta/files",
             body: body.serialize(withBoundary: boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/related; boundary=\(boundary)",
             additionalHeaders: [
                 "X-Goog-Upload-Protocol": "multipart",
@@ -124,6 +126,7 @@ open class GeminiDirectService: GeminiService, DirectService {
             path: fileURL.path,
             body: nil,
             verb: .delete,
+            secondsToWait: 60,
             additionalHeaders: [
                 "X-Goog-Api-Key": self.unprotectedAPIKey
             ]
@@ -147,6 +150,7 @@ open class GeminiDirectService: GeminiService, DirectService {
             path: fileURL.path,
             body: nil,
             verb: .get,
+            secondsToWait: 60,
             additionalHeaders: [
                 "X-Goog-Api-Key": self.unprotectedAPIKey
             ]

--- a/Sources/AIProxy/Gemini/GeminiProxiedService.swift
+++ b/Sources/AIProxy/Gemini/GeminiProxiedService.swift
@@ -33,19 +33,19 @@ open class GeminiProxiedService: GeminiService, ProxiedService {
     public func generateContentRequest(
         body: GeminiGenerateContentRequestBody,
         model: String,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> GeminiGenerateContentResponseBody {
         let proxyPath = "/v1beta/models/\(model):generateContent"
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: proxyPath,
             body:  body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json"
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -62,6 +62,7 @@ open class GeminiProxiedService: GeminiService, ProxiedService {
             proxyPath: proxyPath,
             body:  body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeResponse(request)
@@ -97,6 +98,7 @@ open class GeminiProxiedService: GeminiService, ProxiedService {
             proxyPath: "/upload/v1beta/files",
             body: body.serialize(withBoundary: boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/related; boundary=\(boundary)",
             additionalHeaders: ["X-Goog-Upload-Protocol": "multipart"]
         )
@@ -127,7 +129,8 @@ open class GeminiProxiedService: GeminiService, ProxiedService {
             clientID: self.clientID,
             proxyPath: fileURL.path,
             body: nil,
-            verb: .delete
+            verb: .delete,
+            secondsToWait: 60
         )
         let (_, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
             self.urlSession,
@@ -148,7 +151,8 @@ open class GeminiProxiedService: GeminiService, ProxiedService {
             clientID: self.clientID,
             proxyPath: fileURL.path,
             body: nil,
-            verb: .get
+            verb: .get,
+            secondsToWait: 60
         )
         let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
             AIProxyUtils.proxiedURLSession(),

--- a/Sources/AIProxy/Gemini/GeminiService.swift
+++ b/Sources/AIProxy/Gemini/GeminiService.swift
@@ -22,7 +22,7 @@ public protocol GeminiService {
     func generateContentRequest(
         body: GeminiGenerateContentRequestBody,
         model: String,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> GeminiGenerateContentResponseBody
 
     /// Generate images with the Imagen API

--- a/Sources/AIProxy/Groq/GroqDirectService.swift
+++ b/Sources/AIProxy/Groq/GroqDirectService.swift
@@ -38,6 +38,7 @@ open class GroqDirectService: GroqService, DirectService {
             path: "/openai/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -63,6 +64,7 @@ open class GroqDirectService: GroqService, DirectService {
             path: "/openai/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -87,6 +89,7 @@ open class GroqDirectService: GroqService, DirectService {
             path: "/openai/v1/audio/transcriptions",
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"

--- a/Sources/AIProxy/Groq/GroqProxiedService.swift
+++ b/Sources/AIProxy/Groq/GroqProxiedService.swift
@@ -43,6 +43,7 @@ open class GroqProxiedService: GroqService, ProxiedService {
             proxyPath: "/openai/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeResponse(request)
@@ -67,6 +68,7 @@ open class GroqProxiedService: GroqService, ProxiedService {
             proxyPath: "/openai/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeStreamingChunks(request)
@@ -90,6 +92,7 @@ open class GroqProxiedService: GroqService, ProxiedService {
             proxyPath: "/openai/v1/audio/transcriptions",
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)"
         )
 

--- a/Sources/AIProxy/Mistral/MistralDirectService.swift
+++ b/Sources/AIProxy/Mistral/MistralDirectService.swift
@@ -34,6 +34,7 @@ open class MistralDirectService: MistralService, DirectService {
             path: "/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -59,6 +60,7 @@ open class MistralDirectService: MistralService, DirectService {
             path: "/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"

--- a/Sources/AIProxy/Mistral/MistralProxiedService.swift
+++ b/Sources/AIProxy/Mistral/MistralProxiedService.swift
@@ -42,6 +42,7 @@ open class MistralProxiedService: MistralService, ProxiedService {
             proxyPath: "/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeResponse(request)
@@ -66,6 +67,7 @@ open class MistralProxiedService: MistralService, ProxiedService {
             proxyPath: "/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeStreamingChunks(request)

--- a/Sources/AIProxy/OpenAI/OpenAIDirectService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIDirectService.swift
@@ -34,22 +34,22 @@ open class OpenAIDirectService: OpenAIService, DirectService {
     ///            https://platform.openai.com/docs/api-reference/chat/object
     public func chatCompletionRequest(
         body: OpenAIChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> OpenAIChatCompletionResponseBody {
         var body = body
         body.stream = false
         body.streamOptions = nil
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: self.baseURL,
             path: self.resolvedPath("chat/completions"),
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -63,22 +63,22 @@ open class OpenAIDirectService: OpenAIService, DirectService {
     ///            https://platform.openai.com/docs/api-reference/chat/streaming
     public func streamingChatCompletionRequest(
         body: OpenAIChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: self.baseURL,
             path: self.resolvedPath("chat/completions"),
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeStreamingChunks(request)
     }
 
@@ -92,19 +92,19 @@ open class OpenAIDirectService: OpenAIService, DirectService {
     ///            https://platform.openai.com/docs/api-reference/images/object
     public func createImageRequest(
         body: OpenAICreateImageRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> OpenAICreateImageResponseBody {
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: self.baseURL,
             path: self.resolvedPath("images/generations"),
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -118,7 +118,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
     ///            https://platform.openai.com/docs/api-reference/images/object
     public func createImageEditRequest(
         body: OpenAICreateImageEditRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> OpenAICreateImageResponseBody {
         let boundary = UUID().uuidString
         let request = try AIProxyURLRequest.createDirect(
@@ -126,6 +126,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
             path: self.resolvedPath("images/edits"),
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -151,6 +152,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
             path: self.resolvedPath("audio/transcriptions"),
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -185,6 +187,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
             path: self.resolvedPath("audio/speech"),
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -212,6 +215,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
             path: self.resolvedPath("moderations"),
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -235,6 +239,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
             path: self.resolvedPath("embeddings"),
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -265,6 +270,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
             path: "/v1/realtime?model=\(model)",
             body: nil,
             verb: .get,
+            secondsToWait: 60,
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)",
                 "OpenAI-Beta": "realtime=v1",
@@ -306,6 +312,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
             path: "/v1/files",
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -324,6 +331,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
             path: self.resolvedPath("responses"),
             body: try requestBody.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -19,7 +19,7 @@ public protocol OpenAIService {
     ///            https://platform.openai.com/docs/api-reference/chat/object
     func chatCompletionRequest(
         body: OpenAIChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> OpenAIChatCompletionResponseBody
     
     /// Initiates a streaming chat completion request to /v1/chat/completions.
@@ -32,7 +32,7 @@ public protocol OpenAIService {
     ///            https://platform.openai.com/docs/api-reference/chat/streaming
     func streamingChatCompletionRequest(
         body: OpenAIChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk>
     
     /// Initiates a create image request to /v1/images/generations
@@ -45,7 +45,7 @@ public protocol OpenAIService {
     ///            https://platform.openai.com/docs/api-reference/images/object
     func createImageRequest(
         body: OpenAICreateImageRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> OpenAICreateImageResponseBody
 
     /// Initiates a create image edit request to `v1/images/edits`
@@ -58,7 +58,7 @@ public protocol OpenAIService {
     ///            https://platform.openai.com/docs/api-reference/images/object
     func createImageEditRequest(
         body: OpenAICreateImageEditRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> OpenAICreateImageResponseBody
 
     /// Initiates a create transcription request to v1/audio/transcriptions

--- a/Sources/AIProxy/OpenRouter/OpenRouterDirectService.swift
+++ b/Sources/AIProxy/OpenRouter/OpenRouterDirectService.swift
@@ -29,22 +29,22 @@ open class OpenRouterDirectService: OpenRouterService, DirectService {
     ///            https://openrouter.ai/docs/responses
     public func chatCompletionRequest(
         body: OpenRouterChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> OpenRouterChatCompletionResponseBody {
         var body = body
         body.stream = false
         body.streamOptions = nil
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: self.baseURL,
             path: "/api/v1/chat/completions",
             body: body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -59,22 +59,22 @@ open class OpenRouterDirectService: OpenRouterService, DirectService {
     ///            https://openrouter.ai/docs/responses
     public func streamingChatCompletionRequest(
         body: OpenRouterChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenRouterChatCompletionChunk> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: self.baseURL,
             path: "/api/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeStreamingChunks(request)
     }
 }

--- a/Sources/AIProxy/OpenRouter/OpenRouterProxiedService.swift
+++ b/Sources/AIProxy/OpenRouter/OpenRouterProxiedService.swift
@@ -35,21 +35,21 @@ open class OpenRouterProxiedService: OpenRouterService, ProxiedService {
     ///            https://openrouter.ai/docs/responses
     public func chatCompletionRequest(
         body: OpenRouterChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> OpenRouterChatCompletionResponseBody {
         var body = body
         body.stream = false
         body.streamOptions = nil
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: "/api/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json"
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -64,21 +64,21 @@ open class OpenRouterProxiedService: OpenRouterService, ProxiedService {
     ///            https://openrouter.ai/docs/responses
     public func streamingChatCompletionRequest(
         body: OpenRouterChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenRouterChatCompletionChunk> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)
-        var request = try await AIProxyURLRequest.create(
+        let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
             clientID: self.clientID,
             proxyPath: "/api/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait,
             contentType: "application/json"
         )
-        request.timeoutInterval = TimeInterval(secondsToWait)
         return try await self.makeRequestAndDeserializeStreamingChunks(request)
     }
 }

--- a/Sources/AIProxy/OpenRouter/OpenRouterService.swift
+++ b/Sources/AIProxy/OpenRouter/OpenRouterService.swift
@@ -20,7 +20,7 @@ public protocol OpenRouterService {
     ///            https://openrouter.ai/docs/responses
     func chatCompletionRequest(
         body: OpenRouterChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> OpenRouterChatCompletionResponseBody
 
     /// Initiates a streaming chat completion request to /api/v1/chat/completions.
@@ -34,7 +34,7 @@ public protocol OpenRouterService {
     ///            https://openrouter.ai/docs/responses
     func streamingChatCompletionRequest(
         body: OpenRouterChatCompletionRequestBody,
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenRouterChatCompletionChunk>
 }
 

--- a/Sources/AIProxy/Perplexity/PerplexityDirectService.swift
+++ b/Sources/AIProxy/Perplexity/PerplexityDirectService.swift
@@ -35,6 +35,7 @@ open class PerplexityDirectService: PerplexityService, DirectService {
             path: "/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -61,6 +62,7 @@ open class PerplexityDirectService: PerplexityService, DirectService {
             path: "/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"

--- a/Sources/AIProxy/Perplexity/PerplexityProxiedService.swift
+++ b/Sources/AIProxy/Perplexity/PerplexityProxiedService.swift
@@ -43,6 +43,7 @@ open class PerplexityProxiedService: PerplexityService, ProxiedService {
             proxyPath: "/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeResponse(request)
@@ -68,6 +69,7 @@ open class PerplexityProxiedService: PerplexityService, ProxiedService {
             proxyPath: "/chat/completions",
             body:  try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeStreamingChunks(request)

--- a/Sources/AIProxy/ReceiptValidation/ReceiptValidationService.swift
+++ b/Sources/AIProxy/ReceiptValidation/ReceiptValidationService.swift
@@ -36,6 +36,7 @@ open class ReceiptValidationService: ProxiedService {
             proxyPath: "/validate",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeResponse(request)

--- a/Sources/AIProxy/RemoteLogger/RemoteLoggerService.swift
+++ b/Sources/AIProxy/RemoteLogger/RemoteLoggerService.swift
@@ -41,6 +41,7 @@ open class RemoteLoggerService: ProxiedService {
                 errorMessage: errorMessage
             ).serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         ) {
             _ = try? await BackgroundNetworker.makeRequestAndWaitForData(

--- a/Sources/AIProxy/Replicate/ReplicateDirectService.swift
+++ b/Sources/AIProxy/Replicate/ReplicateDirectService.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-private let kTimeoutBufferForSyncAPIInSeconds: TimeInterval = 5
+private let kTimeoutBufferForSyncAPIInSeconds: UInt = 5
 
 open class ReplicateDirectService: ReplicateService, DirectService {
 
@@ -57,18 +57,18 @@ open class ReplicateDirectService: ReplicateService, DirectService {
     )  async throws -> ReplicatePrediction<Output> {
         let secondsToWait = self.safeSecondsToWait(secondsToWait, warn: true)
         let requestBody = ReplicatePredictionRequestBody(input: input)
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.replicate.com",
             path: "/v1/models/\(modelOwner)/\(modelName)/predictions",
             body: requestBody.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait + kTimeoutBufferForSyncAPIInSeconds,
             contentType: "application/json",
             additionalHeaders: [
                 "Prefer": "wait=\(secondsToWait)",
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait) + kTimeoutBufferForSyncAPIInSeconds
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -108,18 +108,18 @@ open class ReplicateDirectService: ReplicateService, DirectService {
             input: input,
             version: modelVersion
         )
-        var request = try AIProxyURLRequest.createDirect(
+        let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.replicate.com",
             path: "/v1/predictions",
             body: requestBody.serialize(),
             verb: .post,
+            secondsToWait: secondsToWait + kTimeoutBufferForSyncAPIInSeconds,
             contentType: "application/json",
             additionalHeaders: [
                 "Prefer": "wait=\(secondsToWait)",
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
         )
-        request.timeoutInterval = TimeInterval(secondsToWait) + kTimeoutBufferForSyncAPIInSeconds
         return try await self.makeRequestAndDeserializeResponse(request)
     }
 
@@ -156,6 +156,7 @@ open class ReplicateDirectService: ReplicateService, DirectService {
             path: "/v1/models/\(modelOwner)/\(modelName)/predictions",
             body: requestBody.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -197,6 +198,7 @@ open class ReplicateDirectService: ReplicateService, DirectService {
             path: "/v1/predictions",
             body: requestBody.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -228,6 +230,7 @@ open class ReplicateDirectService: ReplicateService, DirectService {
             path: url.path,
             body: nil,
             verb: .get,
+            secondsToWait: 60,
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
@@ -286,6 +289,7 @@ open class ReplicateDirectService: ReplicateService, DirectService {
             path: "/v1/models",
             body: requestBody.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -322,6 +326,7 @@ open class ReplicateDirectService: ReplicateService, DirectService {
             path: "/v1/models/\(modelOwner)/\(modelName)/versions/\(versionID)/trainings",
             body: body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -350,6 +355,7 @@ open class ReplicateDirectService: ReplicateService, DirectService {
             path: url.path,
             body: nil,
             verb: .get,
+            secondsToWait: 60,
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
             ]
@@ -383,6 +389,7 @@ open class ReplicateDirectService: ReplicateService, DirectService {
             path: "/v1/files",
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"

--- a/Sources/AIProxy/Replicate/ReplicateService+Convenience.swift
+++ b/Sources/AIProxy/Replicate/ReplicateService+Convenience.swift
@@ -311,7 +311,7 @@ extension ReplicateService {
     public func createSDXLFreshInkImageURLs(
         input: ReplicateSDXLFreshInkInputSchema,
         version: String = "8515c238222fa529763ec99b4ba1fa9d32ab5d6ebc82b4281de99e4dbdcec943",
-        secondsToWait: Int
+        secondsToWait: UInt
     ) async throws -> [URL] {
         return try await self.createSDXLFreshInkImages(input: input, version: version, secondsToWait: UInt(secondsToWait))
     }

--- a/Sources/AIProxy/StabilityAI/StabilityAIDirectService.swift
+++ b/Sources/AIProxy/StabilityAI/StabilityAIDirectService.swift
@@ -60,6 +60,7 @@ open class StabilityAIDirectService: StabilityAIService, DirectService {
             path: path,
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: [
                 "Accept": "image/*",

--- a/Sources/AIProxy/StabilityAI/StabilityAIProxiedService.swift
+++ b/Sources/AIProxy/StabilityAI/StabilityAIProxiedService.swift
@@ -64,6 +64,7 @@ open class StabilityAIProxiedService: StabilityAIService, ProxiedService {
             proxyPath: path,
             body: formEncode(body, boundary),
             verb: .post,
+            secondsToWait: 60,
             contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: ["Accept": "image/*"]
         )

--- a/Sources/AIProxy/TogetherAI/TogetherAIDirectService.swift
+++ b/Sources/AIProxy/TogetherAI/TogetherAIDirectService.swift
@@ -33,6 +33,7 @@ open class TogetherAIDirectService: TogetherAIService, DirectService {
             path: "/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -57,6 +58,7 @@ open class TogetherAIDirectService: TogetherAIService, DirectService {
             path: "/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"

--- a/Sources/AIProxy/TogetherAI/TogetherAIProxiedService.swift
+++ b/Sources/AIProxy/TogetherAI/TogetherAIProxiedService.swift
@@ -39,6 +39,7 @@ open class TogetherAIProxiedService: TogetherAIService, ProxiedService {
             proxyPath: "/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeResponse(request)
@@ -62,6 +63,7 @@ open class TogetherAIProxiedService: TogetherAIService, ProxiedService {
             proxyPath: "/v1/chat/completions",
             body: try body.serialize(),
             verb: .post,
+            secondsToWait: 60,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeStreamingChunks(request)


### PR DESCRIPTION
- There was a bug in gpt-image-1 editing where the `secondsToWait` argument was unused
- Solved it for that case and added preventative measures to avoid missing it again