### PR TITLE
Expose secondsToWait for groq requests

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.96.1"
+    public static let sdkVersion = "0.98.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/Groq/GroqDirectService.swift
+++ b/Sources/AIProxy/Groq/GroqDirectService.swift
@@ -26,10 +26,12 @@ open class GroqDirectService: GroqService, DirectService {
     /// - Parameters:
     ///   - body: The chat completion request body. See this reference:
     ///           https://console.groq.com/docs/api-reference#chat-create
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`
     /// - Returns: A ChatCompletionResponse. See this reference:
     ///            https://platform.openai.com/docs/api-reference/chat/object
     public func chatCompletionRequest(
-        body: GroqChatCompletionRequestBody
+        body: GroqChatCompletionRequestBody,
+        secondsToWait: UInt
     ) async throws -> GroqChatCompletionResponseBody {
         var body = body
         body.stream = false
@@ -38,7 +40,7 @@ open class GroqDirectService: GroqService, DirectService {
             path: "/openai/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
-            secondsToWait: 60,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -52,10 +54,12 @@ open class GroqDirectService: GroqService, DirectService {
     /// - Parameters:
     ///   - body: The chat completion request body. See this reference:
     ///           https://console.groq.com/docs/api-reference#chat-create
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`
     /// - Returns: An async sequence of completion chunks. See this reference:
     ///            https://platform.openai.com/docs/api-reference/chat/streaming
     public func streamingChatCompletionRequest(
-        body: GroqChatCompletionRequestBody
+        body: GroqChatCompletionRequestBody,
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, GroqChatCompletionStreamingChunk> {
         var body = body
         body.stream = true
@@ -64,7 +68,7 @@ open class GroqDirectService: GroqService, DirectService {
             path: "/openai/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
-            secondsToWait: 60,
+            secondsToWait: secondsToWait,
             contentType: "application/json",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"
@@ -78,10 +82,12 @@ open class GroqDirectService: GroqService, DirectService {
     /// - Parameters:
     ///   - body: The audio transcription request body. See this reference:
     ///           https://console.groq.com/docs/api-reference#audio-transcription
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`
     /// - Returns: An transcription response. See this reference:
     ///            https://platform.openai.com/docs/api-reference/audio/json-object
     public func createTranscriptionRequest(
-        body: GroqTranscriptionRequestBody
+        body: GroqTranscriptionRequestBody,
+        secondsToWait: UInt
     ) async throws -> GroqTranscriptionResponseBody {
         let boundary = UUID().uuidString
         let request = try AIProxyURLRequest.createDirect(
@@ -89,7 +95,7 @@ open class GroqDirectService: GroqService, DirectService {
             path: "/openai/v1/audio/transcriptions",
             body: formEncode(body, boundary),
             verb: .post,
-            secondsToWait: 60,
+            secondsToWait: secondsToWait,
             contentType: "multipart/form-data; boundary=\(boundary)",
             additionalHeaders: [
                 "Authorization": "Bearer \(self.unprotectedAPIKey)"

--- a/Sources/AIProxy/Groq/GroqProxiedService.swift
+++ b/Sources/AIProxy/Groq/GroqProxiedService.swift
@@ -29,10 +29,12 @@ open class GroqProxiedService: GroqService, ProxiedService {
     /// - Parameters:
     ///   - body: The chat completion request body. See this reference:
     ///           https://console.groq.com/docs/api-reference#chat-create
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`
     /// - Returns: A ChatCompletionResponse. See this reference:
     ///            https://platform.openai.com/docs/api-reference/chat/object
     public func chatCompletionRequest(
-        body: GroqChatCompletionRequestBody
+        body: GroqChatCompletionRequestBody,
+        secondsToWait: UInt
     ) async throws -> GroqChatCompletionResponseBody {
         var body = body
         body.stream = false
@@ -43,7 +45,7 @@ open class GroqProxiedService: GroqService, ProxiedService {
             proxyPath: "/openai/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
-            secondsToWait: 60,
+            secondsToWait: secondsToWait,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeResponse(request)
@@ -54,10 +56,12 @@ open class GroqProxiedService: GroqService, ProxiedService {
     /// - Parameters:
     ///   - body: The chat completion request body. See this reference:
     ///           https://console.groq.com/docs/api-reference#chat-create
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`
     /// - Returns: An async sequence of completion chunks. See this reference:
     ///            https://platform.openai.com/docs/api-reference/chat/streaming
     public func streamingChatCompletionRequest(
-        body: GroqChatCompletionRequestBody
+        body: GroqChatCompletionRequestBody,
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, GroqChatCompletionStreamingChunk> {
         var body = body
         body.stream = true
@@ -68,7 +72,7 @@ open class GroqProxiedService: GroqService, ProxiedService {
             proxyPath: "/openai/v1/chat/completions",
             body:  try body.serialize(),
             verb: .post,
-            secondsToWait: 60,
+            secondsToWait: secondsToWait,
             contentType: "application/json"
         )
         return try await self.makeRequestAndDeserializeStreamingChunks(request)
@@ -79,10 +83,12 @@ open class GroqProxiedService: GroqService, ProxiedService {
     /// - Parameters:
     ///   - body: The audio transcription request body. See this reference:
     ///           https://console.groq.com/docs/api-reference#audio-transcription
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`
     /// - Returns: An transcription response. See this reference:
     ///            https://platform.openai.com/docs/api-reference/audio/json-object
     public func createTranscriptionRequest(
-        body: GroqTranscriptionRequestBody
+        body: GroqTranscriptionRequestBody,
+        secondsToWait: UInt
     ) async throws -> GroqTranscriptionResponseBody {
         let boundary = UUID().uuidString
         let request = try await AIProxyURLRequest.create(
@@ -92,7 +98,7 @@ open class GroqProxiedService: GroqService, ProxiedService {
             proxyPath: "/openai/v1/audio/transcriptions",
             body: formEncode(body, boundary),
             verb: .post,
-            secondsToWait: 60,
+            secondsToWait: secondsToWait,
             contentType: "multipart/form-data; boundary=\(boundary)"
         )
 

--- a/Sources/AIProxy/Groq/GroqService.swift
+++ b/Sources/AIProxy/Groq/GroqService.swift
@@ -13,10 +13,12 @@ public protocol GroqService {
     /// - Parameters:
     ///   - body: The chat completion request body. See this reference:
     ///           https://console.groq.com/docs/api-reference#chat-create
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`
     /// - Returns: A ChatCompletionResponse. See this reference:
     ///            https://platform.openai.com/docs/api-reference/chat/object
     func chatCompletionRequest(
-        body: GroqChatCompletionRequestBody
+        body: GroqChatCompletionRequestBody,
+        secondsToWait: UInt
     ) async throws -> GroqChatCompletionResponseBody
 
     /// Initiates a streaming chat completion request to Groq.
@@ -24,10 +26,12 @@ public protocol GroqService {
     /// - Parameters:
     ///   - body: The chat completion request body. See this reference:
     ///           https://console.groq.com/docs/api-reference#chat-create
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`
     /// - Returns: An async sequence of completion chunks. See this reference:
     ///            https://platform.openai.com/docs/api-reference/chat/streaming
     func streamingChatCompletionRequest(
-        body: GroqChatCompletionRequestBody
+        body: GroqChatCompletionRequestBody,
+        secondsToWait: UInt
     ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, GroqChatCompletionStreamingChunk>
 
     /// Initiates a transcription request to /openai/v1/audio/transcriptions
@@ -35,10 +39,11 @@ public protocol GroqService {
     /// - Parameters:
     ///   - body: The audio transcription request body. See this reference:
     ///           https://console.groq.com/docs/api-reference#audio-transcription
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`
     /// - Returns: An transcription response. See this reference:
     ///            https://platform.openai.com/docs/api-reference/audio/json-object
     func createTranscriptionRequest(
-        body: GroqTranscriptionRequestBody
+        body: GroqTranscriptionRequestBody,
+        secondsToWait: UInt
     ) async throws -> GroqTranscriptionResponseBody
-
 }


### PR DESCRIPTION
Groq requests were previously hardcoded to a max timeout of 60 seconds. It is now configurable by the caller