### PR TITLE
ElevenLabs speaker_id is a String, convert it to a Double

### DIFF
--- a/Sources/AIProxy/ElevenLabs/ElevenLabsSpeechToTextResponseBody.swift
+++ b/Sources/AIProxy/ElevenLabs/ElevenLabsSpeechToTextResponseBody.swift
@@ -79,6 +79,22 @@ extension ElevenLabsSpeechToTextResponseBody {
             case speakerID = "speaker_id"
             case characters
         }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.text = try container.decode(String.self, forKey: .text)
+            self.type = try container.decodeIfPresent(WordType.self, forKey: .type)
+            self.start = try container.decodeIfPresent(Double.self, forKey: .start)
+            self.end = try container.decodeIfPresent(Double.self, forKey: .end)
+            self.characters = try container.decodeIfPresent([Character].self, forKey: .characters)
+
+            if let stringSpeakerID = try container.decodeIfPresent(String.self, forKey: .speakerID),
+               let doubleValue = Double(stringSpeakerID.filter({ $0.isNumber })) {
+                self.speakerID = doubleValue
+            } else {
+                self.speakerID = nil
+            }
+        }
     }
 
     public struct AdditionalFormat: Decodable {


### PR DESCRIPTION
Fixes this issue, where the `ElevenLabsSpeechToTextResponseBody.Word` `speakerID` property is a Double, but the response returns a String.	

![IMG_7791](https://github.com/user-attachments/assets/2328107a-24b6-4db4-8cb0-59d14c2baa19)
