### PR TITLE
Add additional request metadata

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.101.0"
+    public static let sdkVersion = "0.101.1"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/AIProxyURLRequest.swift
+++ b/Sources/AIProxy/AIProxyURLRequest.swift
@@ -56,9 +56,10 @@ enum AIProxyURLRequest {
             request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
         }
 
-        let bundleID = Bundle.main.bundleIdentifier ?? "unknown"
-        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-        request.addValue("v3|\(bundleID)|\(appVersion)|\(AIProxy.sdkVersion)|\(Date().timeIntervalSince1970)", forHTTPHeaderField: "aiproxy-metadata")
+        request.addValue(
+            AIProxyUtils.metadataHeader(withBodySize: body?.count ?? 0),
+            forHTTPHeaderField: "aiproxy-metadata"
+        )
 
         if let resolvedAccount = AnonymousAccountStorage.resolvedAccount {
             request.addValue(resolvedAccount.uuid, forHTTPHeaderField: "aiproxy-anonymous-id")

--- a/Sources/AIProxy/AIProxyUtils.swift
+++ b/Sources/AIProxy/AIProxyUtils.swift
@@ -73,6 +73,22 @@ enum AIProxyUtils {
         return URL(string: "data:image/jpeg;base64,\(jpegData.base64EncodedString())")
     }
 #endif
+
+    static func metadataHeader(withBodySize bodySize: Int?) -> String {
+        let ri = RuntimeInfo.current
+        let fields: [String] = [
+            "v4",
+            ri.bundleID,
+            ri.appVersion,
+            AIProxy.sdkVersion,
+            String(Date().timeIntervalSince1970),
+            ri.systemName,
+            ri.osVersion,
+            ri.deviceModel,
+            String(bodySize ?? 0)
+        ]
+        return fields.joined(separator: "|")
+    }
 }
 
 

--- a/Sources/AIProxy/ClientLibErrorLogger.swift
+++ b/Sources/AIProxy/ClientLibErrorLogger.swift
@@ -7,10 +7,6 @@
 
 import Foundation
 
-#if canImport(UIKit)
-import UIKit
-#endif
-
 private let kLibError = "client-lib-error"
 private let kGlobal = "global"
 
@@ -52,33 +48,15 @@ private struct Payload: Encodable {
 
 
 private func buildPayload(errorType: String, errorMessage: String?) -> Payload {
-    let bundle = Bundle.main
-    let infoDict = bundle.infoDictionary ?? [:]
-
-    let appName = infoDict["CFBundleName"] as? String ?? "Unknown"
-    let appVersion = infoDict["CFBundleShortVersionString"] as? String ?? "Unknown"
-    let buildNumber = infoDict["CFBundleVersion"] as? String ?? "Unknown"
-    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-    let osVersionString = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
-
-    var deviceModel = "Unknown"
-    var systemName = "Unknown"
-
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    deviceModel = UIDevice.current.model
-    systemName = UIDevice.current.systemName
-    #elseif os(macOS)
-    deviceModel = Host.current().localizedName ?? "Mac"
-    systemName = "macOS"
-    #endif
+    let runtimeInfo = RuntimeInfo.current
 
     return Payload(
-        appName: appName,
-        appVersion: appVersion,
-        buildNumber: buildNumber,
-        deviceModel: deviceModel,
-        systemName: systemName,
-        osVersion: osVersionString,
+        appName: runtimeInfo.appName,
+        appVersion: runtimeInfo.appVersion,
+        buildNumber: runtimeInfo.buildNumber,
+        deviceModel: runtimeInfo.deviceModel,
+        systemName: runtimeInfo.systemName,
+        osVersion: runtimeInfo.osVersion,
         errorType: errorType,
         errorMessage: errorMessage,
         timestamp: Date().timeIntervalSince1970
@@ -100,10 +78,10 @@ private func buildRequest(_ payload: Payload, clientID: String?) -> URLRequest? 
         request.addValue(clientID, forHTTPHeaderField: "aiproxy-client-id")
     }
 
-    if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as?  String,
-       let bundleID = Bundle.main.bundleIdentifier{
-        request.addValue("v2|\(bundleID)|\(appVersion)|\(AIProxy.sdkVersion)", forHTTPHeaderField: "aiproxy-metadata")
-    }
+    request.addValue(
+        AIProxyUtils.metadataHeader(withBodySize: body.count),
+        forHTTPHeaderField: "aiproxy-metadata"
+    )
 
     if let resolvedAccount = AnonymousAccountStorage.resolvedAccount {
         request.addValue(resolvedAccount.uuid, forHTTPHeaderField: "aiproxy-anonymous-id")

--- a/Sources/AIProxy/RuntimeInfo.swift
+++ b/Sources/AIProxy/RuntimeInfo.swift
@@ -23,27 +23,47 @@ struct RuntimeInfo {
     static var current: RuntimeInfo = {
         let bundle = Bundle.main
         let infoDict = bundle.infoDictionary ?? [:]
-        var deviceModel = "Unknown"
-        var systemName = "Unknown"
-        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-        let osVersionString = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
-
-        #if os(iOS) || os(tvOS) || os(watchOS)
-        deviceModel = UIDevice.current.model
-        systemName = UIDevice.current.systemName
-        #elseif os(macOS)
-        deviceModel = Host.current().localizedName ?? "Mac"
-        systemName = "macOS"
-        #endif
 
         return RuntimeInfo(
             appName: infoDict["CFBundleName"] as? String ?? "Unknown",
             appVersion: infoDict["CFBundleShortVersionString"] as? String ?? "Unknown",
             buildNumber: infoDict["CFBundleVersion"] as? String ?? "Unknown",
             bundleID: bundle.bundleIdentifier ?? "Unknown",
-            deviceModel: deviceModel,
-            osVersion: osVersionString,
-            systemName: systemName
+            deviceModel: getDeviceModel(),
+            osVersion: getOSVersion(),
+            systemName: getSystemName()
         )
     }()
+}
+
+private func getDeviceModel() -> String {
+    #if os(macOS)
+    let sysCallName = "hw.model"
+    #else
+    let sysCallName = "hw.machine"
+    #endif
+    var size: size_t = 0
+    guard sysctlbyname(sysCallName, nil, &size, nil, 0) == noErr, size > 0 else {
+        return "Unknown"
+    }
+
+    var machine = [CChar](repeating: 0, count: size)
+    guard sysctlbyname(sysCallName, &machine, &size, nil, 0) == noErr else {
+        return "Unknown"
+    }
+
+    return String(cString: machine)
+}
+
+private func getSystemName() -> String {
+    #if os(macOS)
+    return "macOS"
+    #else
+    return UIDevice.current.systemName
+    #endif
+}
+
+private func getOSVersion() -> String {
+    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+    return "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
 }

--- a/Sources/AIProxy/RuntimeInfo.swift
+++ b/Sources/AIProxy/RuntimeInfo.swift
@@ -58,6 +58,8 @@ private func getDeviceModel() -> String {
 private func getSystemName() -> String {
     #if os(macOS)
     return "macOS"
+    #elseif os(watchOS)
+    return "watchOS"
     #else
     return UIDevice.current.systemName
     #endif

--- a/Sources/AIProxy/RuntimeInfo.swift
+++ b/Sources/AIProxy/RuntimeInfo.swift
@@ -1,0 +1,49 @@
+//
+//  RuntimeInfo.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 5/21/25.
+//
+
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+struct RuntimeInfo {
+    let appName: String
+    let appVersion: String
+    let buildNumber: String
+    let bundleID: String
+    let deviceModel: String
+    let osVersion: String
+    let systemName: String
+
+    static var current: RuntimeInfo = {
+        let bundle = Bundle.main
+        let infoDict = bundle.infoDictionary ?? [:]
+        var deviceModel = "Unknown"
+        var systemName = "Unknown"
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let osVersionString = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+
+        #if os(iOS) || os(tvOS) || os(watchOS)
+        deviceModel = UIDevice.current.model
+        systemName = UIDevice.current.systemName
+        #elseif os(macOS)
+        deviceModel = Host.current().localizedName ?? "Mac"
+        systemName = "macOS"
+        #endif
+
+        return RuntimeInfo(
+            appName: infoDict["CFBundleName"] as? String ?? "Unknown",
+            appVersion: infoDict["CFBundleShortVersionString"] as? String ?? "Unknown",
+            buildNumber: infoDict["CFBundleVersion"] as? String ?? "Unknown",
+            bundleID: bundle.bundleIdentifier ?? "Unknown",
+            deviceModel: deviceModel,
+            osVersion: osVersionString,
+            systemName: systemName
+        )
+    }()
+}


### PR DESCRIPTION
Additional metadata to assist in understanding DC failures. They seem to be more frequent on macOS apps. Starting to collect stats on it.