### PR TITLE
Isolate DeviceCheck to the main actor

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.101.2"
+    public static let sdkVersion = "0.101.3"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/AIProxyDeviceCheck.swift
+++ b/Sources/AIProxy/AIProxyDeviceCheck.swift
@@ -32,6 +32,7 @@ enum AIProxyDeviceCheck {
     /// to only be used by developers of your app, and is intended to only be included as a an environment variable.
     ///
     /// - Returns: A base 64 encoded DeviceCheck token, if possible
+    @MainActor
     internal static func getToken(forClient clientID: String?) async -> String? {
         // We have seen `EXC_BAD_ACCESS` on accessing `DCDevice.current.isSupported` in the wild.
         // My theory is that the `DCDevice.h` header uses `NS_ASSUME_NONNULL_BEGIN` when it should not.


### PR DESCRIPTION
This is a follow-up to https://github.com/lzell/AIProxySwift/pull/163

Nothing that I can find in the DCDevice.h or DeviceCheck docs indicate that this is necessary. However, I'm throwing this at the problem and then I will later revert if the remote logger branches introduced in PR 163 fire.