### PR TITLE
Add support for Flux Kontext on Replicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3929,6 +3929,92 @@ model owner and model name in the string.
     }
 ```
 
+### How to edit images with Flux Kontext Max
+
+```
+    import AIProxy
+
+    /* Uncomment for BYOK use cases */
+    // let replicateService = AIProxy.replicateDirectService(
+    //     unprotectedAPIKey: "your-replicate-key"
+    // )
+
+    /* Uncomment for all other production use cases */
+    // let replicateService = AIProxy.replicateService(
+    //     partialKey: "partial-key-from-your-developer-dashboard",
+    //     serviceURL: "service-url-from-your-developer-dashboard"
+    // )
+
+    guard let image = NSImage(named: "my_image") else {
+        print("Could not find an image named 'my_image' in your app assets")
+        return
+    }
+
+    guard let imageURL = AIProxy.encodeImageAsURL(image: image, compressionQuality: 0.5) else {
+        print("Could not encode image as a data URI")
+        return
+    }
+
+    do {
+        let input = ReplicateFluxKontextInputSchema(
+            inputImage: imageURL,
+            prompt: "Make the letters 3D, floating in space above Monument Valley, Utah"
+        )
+        let url = try await replicateService.createFluxKontextMaxImage(
+            input: input,
+            secondsToWait: 60
+        )
+        print("Done creating Flux Kontext Max image: ", url)
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
+    } catch {
+        print("Could not create Flux Kontext Max image: \(error.localizedDescription)")
+    }
+```
+
+### How to edit images with Flux Kontext Pro
+
+```
+    import AIProxy
+
+    /* Uncomment for BYOK use cases */
+    // let replicateService = AIProxy.replicateDirectService(
+    //     unprotectedAPIKey: "your-replicate-key"
+    // )
+
+    /* Uncomment for all other production use cases */
+    // let replicateService = AIProxy.replicateService(
+    //     partialKey: "partial-key-from-your-developer-dashboard",
+    //     serviceURL: "service-url-from-your-developer-dashboard"
+    // )
+
+    guard let image = NSImage(named: "my_image") else {
+        print("Could not find an image named 'my_image' in your app assets")
+        return
+    }
+
+    guard let imageURL = AIProxy.encodeImageAsURL(image: image, compressionQuality: 0.5) else {
+        print("Could not encode image as a data URI")
+        return
+    }
+
+    do {
+        let input = ReplicateFluxKontextInputSchema(
+            inputImage: imageURL,
+            prompt: "Make the letters 3D, floating in space above Monument Valley, Utah"
+        )
+        let url = try await replicateService.createFluxKontextProImage(
+            input: input,
+            secondsToWait: 60
+        )
+        print("Done creating Flux Kontext Pro image: ", url)
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
+    } catch {
+        print("Could not create Flux Kontext Pro image: \(error.localizedDescription)")
+    }
+```
+
 ***
 
 

--- a/README.md
+++ b/README.md
@@ -3962,7 +3962,7 @@ model owner and model name in the string.
         )
         let url = try await replicateService.createFluxKontextMaxImage(
             input: input,
-            secondsToWait: 60
+            secondsToWait: 120
         )
         print("Done creating Flux Kontext Max image: ", url)
     } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
@@ -4005,7 +4005,7 @@ model owner and model name in the string.
         )
         let url = try await replicateService.createFluxKontextProImage(
             input: input,
-            secondsToWait: 60
+            secondsToWait: 120
         )
         print("Done creating Flux Kontext Pro image: ", url)
     } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.103.0"
+    public static let sdkVersion = "0.104.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/Replicate/ReplicateFluxKontextInputSchema.swift
+++ b/Sources/AIProxy/Replicate/ReplicateFluxKontextInputSchema.swift
@@ -1,0 +1,46 @@
+//
+//  ReplicateFluxKontextInputSchema.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 5/31/25.
+//
+
+import Foundation
+
+public struct ReplicateFluxKontextInputSchema: Encodable {
+    // Required
+
+    /// Image to use as reference. Must be a URI (jpeg, png, gif, or webp).
+    public let inputImage: URL
+
+    /// Text description of what you want to generate, or the instruction on how to edit the given image.
+    public let prompt: String
+
+    // Optional
+
+    /// Aspect ratio of the generated image.
+    /// Use `"match_input_image"` to match the aspect ratio of the input image.
+    public let aspectRatio: String?
+
+    /// Random seed for reproducible generation.
+    public let seed: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case inputImage = "input_image"
+        case prompt
+        case aspectRatio = "aspect_ratio"
+        case seed
+    }
+
+    public init(
+        inputImage: URL,
+        prompt: String,
+        aspectRatio: String? = nil,
+        seed: Int? = nil
+    ) {
+        self.inputImage = inputImage
+        self.prompt = prompt
+        self.aspectRatio = aspectRatio
+        self.seed = seed
+    }
+}

--- a/Sources/AIProxy/Replicate/ReplicateService+Convenience.swift
+++ b/Sources/AIProxy/Replicate/ReplicateService+Convenience.swift
@@ -94,6 +94,48 @@ extension ReplicateService {
         return try await self.getPredictionOutput(prediction)
     }
 
+    /// Convenience method for creating an image through Black Forest Lab's Flux Kontext Max model:
+    /// https://replicate.com/black-forest-labs/flux-kontext-max
+    ///
+    /// - Parameters:
+    ///   - input: The input specification of the image you'd like to generate. See ReplicateFluxKontextInputSchema.swift
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
+    ///
+    /// - Returns: The URL of the generated Flux Kontext Max image
+    public func createFluxKontextMaxImage(
+        input: ReplicateFluxKontextInputSchema,
+        secondsToWait: UInt
+    ) async throws -> URL {
+        let prediction: ReplicatePrediction<URL> = try await self.runOfficialModel(
+            modelOwner: "black-forest-labs",
+            modelName: "flux-kontext-max",
+            input: input,
+            secondsToWait: secondsToWait
+        )
+        return try await self.getPredictionOutput(prediction)
+    }
+
+    /// Convenience method for creating an image through Black Forest Lab's Flux Kontext Pro model:
+    /// https://replicate.com/black-forest-labs/flux-kontext-pro
+    ///
+    /// - Parameters:
+    ///   - input: The input specification of the image you'd like to generate. See ReplicateFluxKontextInputSchema.swift
+    ///   - secondsToWait: Seconds to wait before raising a timeout error
+    ///
+    /// - Returns: The URL of the generated Flux Kontext Pro image
+    public func createFluxKontextProImage(
+        input: ReplicateFluxKontextInputSchema,
+        secondsToWait: UInt
+    ) async throws -> URL {
+        let prediction: ReplicatePrediction<URL> = try await self.runOfficialModel(
+            modelOwner: "black-forest-labs",
+            modelName: "flux-kontext-pro",
+            input: input,
+            secondsToWait: secondsToWait
+        )
+        return try await self.getPredictionOutput(prediction)
+    }
+
     /// Convenience method for creating image URLs through Black Forest Lab's Flux-Dev model.
     /// https://replicate.com/black-forest-labs/flux-dev
     ///


### PR DESCRIPTION
- SOTA image editing models. They cost $0.04 per image for pro and $0.08 per image for max.
- Send up an image (encoded as data URL) and prompt to modify the image with.
- Both models get a convenience high level call in `ReplicateService+Convenience.swift`
- See the README additions for an example of using both models