### PR TITLE
Use StoreKit's appTransactionID as anonymous ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,8 +1240,8 @@ final class RealtimeManager {
                     } else {
                         isOpenAIReadyForAudio = true
                     }
-                case .responseAudioDelta(let base64Audio):
-                    audioController.playPCM16Audio(from: base64Audio)
+                case .responseAudioDelta(let base64String):
+                    audioController.playPCM16Audio(base64String: base64String)
                 case .inputAudioBufferSpeechStarted:
                     audioController.interruptPlayback()
                 case .responseCreated:


### PR DESCRIPTION
- StoreKit now has an appTransactionID that is back deployed to iOS 16
- If a developer specifies `useStableID` in their `AIProxy.configure` call, we first try to use appTransactionID as the stable ID. If StoreKit can't verify the app receipt, then we fall back to our own anonymous identifiers. I think a stronger form of this condition would be to reject requests that don't have a verified appTransactionID, but that is a larger change that will need to be introduced with consideration.

My new guidance for developers is they should use the following configure call:
```swift
    func application(
        _ application: UIApplication,
        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
    ) -> Bool {
        AIProxy.configure(
            logLevel: .debug,
            printRequestBodies: false,
            printResponseBodies: false,
            resolveDNSOverTLS: true,
            useStableID: true,
        )
        return true
    }
```
