### PR TITLE
Conditionally compile around appTransactionID availability

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.105.0"
+    public static let sdkVersion = "0.107.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/AIProxyUtils.swift
+++ b/Sources/AIProxy/AIProxyUtils.swift
@@ -172,9 +172,13 @@ enum AIProxyUtils {
     }
 
     static func getAppTransactionID() async -> String? {
+        #if compiler(<6.1.2)
+        return nil
+        #else
         guard #available(iOS 16.0, watchOS 9.0, macOS 13.0, tvOS 16.0, visionOS 1.0, *) else {
             return nil
         }
+        // ...logic to get the verified app transaction...
 
         // Apple's docstring on `shared` states:
         // If your app fails to get an AppTransaction by accessing the shared property, see refresh().
@@ -199,6 +203,7 @@ enum AIProxyUtils {
         }
 
         return transactionID
+        #endif
     }
 }
 

--- a/Sources/AIProxy/AIProxyUtils.swift
+++ b/Sources/AIProxy/AIProxyUtils.swift
@@ -178,7 +178,6 @@ enum AIProxyUtils {
         guard #available(iOS 16.0, watchOS 9.0, macOS 13.0, tvOS 16.0, visionOS 1.0, *) else {
             return nil
         }
-        // ...logic to get the verified app transaction...
 
         // Apple's docstring on `shared` states:
         // If your app fails to get an AppTransaction by accessing the shared property, see refresh().


### PR DESCRIPTION
- Customers have been writing in on Intercom that they can't build the main branch
- appTransactionID is available in Xcode 16.4
- Use compiler version as proxy for base SDK to conditionally branch around appTransactionID usage

https://developer.apple.com/documentation/storekit/transaction/apptransactionid
https://forums.swift.org/t/conditionally-compile-based-on-ios-version-previewcgimagerepresentation-broke/50883/2