### PR TITLE
feat: support custom versioning with noVersionPrefix format

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -225,13 +225,18 @@ public enum AIProxy {
     ///
     /// - Parameters:
     ///   - unprotectedAPIKey: Your OpenAI API key
+    ///   - baseURL: Optional base URL for the API requests
+    ///   - requestFormat: If you are sending requests to your own Azure deployment, set this to `.azureDeployment`.
+    ///                   Otherwise, you may leave this set to its default value of `.standard`
     /// - Returns: An instance of OpenAIService configured and ready to make requests
     public static func openAIDirectService(
         unprotectedAPIKey: String,
-        baseURL: String? = nil
+        baseURL: String? = nil,
+        requestFormat: OpenAIRequestFormat = .standard
     ) -> OpenAIService {
         return OpenAIDirectService(
             unprotectedAPIKey: unprotectedAPIKey,
+            requestFormat: requestFormat,
             baseURL: baseURL
         )
     }

--- a/Sources/AIProxy/OpenAI/OpenAIDirectService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIDirectService.swift
@@ -352,6 +352,8 @@ open class OpenAIDirectService: OpenAIService, DirectService {
             return "/v1/\(common)"
         case .azureDeployment(let apiVersion):
             return "/\(common)?api-version=\(apiVersion)"
+        case .noVersionPrefix:
+            return "/\(common)"
         }
     }
 }

--- a/Sources/AIProxy/OpenAI/OpenAIProxiedService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIProxiedService.swift
@@ -349,6 +349,8 @@ open class OpenAIProxiedService: OpenAIService, ProxiedService {
             return "/v1/\(common)"
         case .azureDeployment(let apiVersion):
             return "/\(common)?api-version=\(apiVersion)"
+        case .noVersionPrefix:
+            return "/\(common)"
         }
     }
 }

--- a/Sources/AIProxy/OpenAI/OpenAIRequestFormat.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRequestFormat.swift
@@ -21,7 +21,7 @@ public enum OpenAIRequestFormat {
     /// This is useful for API providers that use different version prefixes, like ByteDance's Volcengine:
     /// ```
     /// // For Volcengine API which uses v3:
-    /// let service = AIProxy.directOpenAIService(
+    /// let service = AIProxy.openAIDirectService(
     ///     unprotectedAPIKey: "your-api-key",
     ///     baseURL: "https://ark.cn-beijing.volces.com/api/v3",
     ///     requestFormat: .noVersionPrefix

--- a/Sources/AIProxy/OpenAI/OpenAIRequestFormat.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRequestFormat.swift
@@ -9,8 +9,23 @@ import Foundation
 
 public enum OpenAIRequestFormat {
     /// Requests are formatted for use with OpenAI
+    /// Automatically adds /v1/ prefix to all paths
     case standard
 
     /// Requests are formatted for use with your own Azure deployment
+    /// Appends ?api-version parameter to all paths
     case azureDeployment(apiVersion: String)
+    
+    /// Uses paths as-is without adding any version prefix
+    /// This allows for custom versioning by including the version in the baseURL.
+    /// This is useful for API providers that use different version prefixes, like ByteDance's Volcengine:
+    /// ```
+    /// // For Volcengine API which uses v3:
+    /// let service = AIProxy.directOpenAIService(
+    ///     unprotectedAPIKey: "your-api-key",
+    ///     baseURL: "https://ark.cn-beijing.volces.com/api/v3",
+    ///     requestFormat: .noVersionPrefix
+    /// )
+    /// ```
+    case noVersionPrefix
 }


### PR DESCRIPTION
Added a new noVersionPrefix case to OpenAIRequestFormat enum to support custom versioning by including the version in the baseURL. This is particularly useful for API providers that use different version prefixes, like ByteDance's Volcengine which uses v3 instead of v1.

For example:
```swift
// For Volcengine API which uses v3:
let service = AIProxy.openAIDirectService(
    unprotectedAPIKey: "your-api-key",
    baseURL: "https://ark.cn-beijing.volces.com/api/v3",
    requestFormat: .noVersionPrefix
)
```

This change provides more flexibility for API version handling by allowing users to include the version in the baseURL itself, rather than having it automatically added by the library.