### PR TITLE
Protect against a clientID of nil

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.110.0"
+    public static let sdkVersion = "0.110.1"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -1019,7 +1019,7 @@ public enum AIProxy {
         do {
             return try await AnonymousAccountStorage.sync()
         } catch {
-            logIf(.critical)?.critical("Could not configure an AIProxy anonymous account: \(error.localizedDescription)")
+            logIf(.error)?.error("AIProxy: Could not configure an anonymous account: \(error.localizedDescription)")
         }
         return nil
     }

--- a/Sources/AIProxy/AIProxyIdentifier.swift
+++ b/Sources/AIProxy/AIProxyIdentifier.swift
@@ -19,19 +19,22 @@ enum AIProxyIdentifier {
     /// Generates a clientID for this device.
     /// - Returns: The AIProxy stableID if the developer configured the SDK with `useStableID`.
     ///            Otherwise, a UIDevice ID on iOS, an IOKit ID on macOS
-    internal static func getClientID() -> String? {
+    internal static func getClientID() -> String {
         if let stableID = AIProxy.stableID {
             return stableID
         }
 #if os(watchOS)
-        return WKInterfaceDevice.current().identifierForVendor?.uuidString
+        let clientID = WKInterfaceDevice.current().identifierForVendor?.uuidString
 #elseif canImport(UIKit)
-        return UIDevice.current.identifierForVendor?.uuidString
+        let clientID = UIDevice.current.identifierForVendor?.uuidString
 #elseif canImport(IOKit)
-        return getIdentifierFromIOKit()
-#else
-        return nil
+        let clientID = getIdentifierFromIOKit()
 #endif
+        if let clientID = clientID {
+            return clientID
+        }
+        ClientLibErrorLogger.logClientIdentifierIsNil()
+        return "unknown"
     }
 
 #if canImport(IOKit)

--- a/Sources/AIProxy/AIProxyURLRequest.swift
+++ b/Sources/AIProxy/AIProxyURLRequest.swift
@@ -48,10 +48,7 @@ enum AIProxyURLRequest {
         request.httpMethod = verb.toString(hasBody: body != nil)
         request.httpBody = body
         request.addValue(partialKey, forHTTPHeaderField: "aiproxy-partial-key")
-
-        if let resolvedClientID = resolvedClientID {
-            request.addValue(resolvedClientID, forHTTPHeaderField: "aiproxy-client-id")
-        }
+        request.addValue(resolvedClientID, forHTTPHeaderField: "aiproxy-client-id")
 
         if let deviceCheckToken = deviceCheckToken {
             request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")

--- a/Sources/AIProxy/AIProxyUtils.swift
+++ b/Sources/AIProxy/AIProxyUtils.swift
@@ -196,8 +196,8 @@ enum AIProxyUtils {
         }
 
         let transactionID = verifiedAppTransaction.appTransactionID
-        guard transactionID != "0" else {
-            logIf(.info)?.info("AIProxy: Storekit's appTransactionID is zero, ignoring it")
+        guard transactionID != "0" && transactionID != "" else {
+            logIf(.info)?.info("AIProxy: Storekit's appTransactionID is zero or empty, ignoring it")
             return nil
         }
 

--- a/Sources/AIProxy/AnonymousAccount/AnonymousAccountStorage.swift
+++ b/Sources/AIProxy/AnonymousAccount/AnonymousAccountStorage.swift
@@ -58,7 +58,7 @@ final class AnonymousAccountStorage {
         // meaning the one that was created earliest. The design of this class is to eventually resolve out
         // to the earliest account across multiple devices.
         if !AIProxyStorage.ukvsSync() {
-            logIf(.error)?.error("Could not synchronize NSUbiquitousKeyValueStore. Please ensure you enabled the key/value store in Target > Signing & Capabilities > iCloud > Key-Value storage?")
+            logIf(.error)?.error("AIProxy: Could not synchronize NSUbiquitousKeyValueStore. Please ensure you enabled the key/value store in Target > Signing & Capabilities > iCloud > Key-Value storage")
         }
         if let ukvsAccountData = AIProxyStorage.ukvsAccountData() {
             let ukvsAccount = try AnonymousAccount.deserialize(from: ukvsAccountData)

--- a/Sources/AIProxy/ClientLibErrorLogger.swift
+++ b/Sources/AIProxy/ClientLibErrorLogger.swift
@@ -11,18 +11,23 @@ private let kLibError = "client-lib-error"
 private let kGlobal = "global"
 
 struct ClientLibErrorLogger {
+    static func logClientIdentifierIsNil() {
+        let payload = buildPayload(errorType: "error-client-id-nil", errorMessage: nil)
+        deliver(payload, clientID: nil)
+    }
+
     static func logDeviceCheckSingletonIsNil(clientID: String?) {
-        let payload = buildPayload(errorType: "dc-singleton-nil", errorMessage: nil)
+        let payload = buildPayload(errorType: "error-dc-singleton-nil", errorMessage: nil)
         deliver(payload, clientID: clientID)
     }
 
     static func logDeviceCheckNotSupported(clientID: String?) {
-        let payload = buildPayload(errorType: "dc-not-supported", errorMessage: nil)
+        let payload = buildPayload(errorType: "error-dc-not-supported", errorMessage: nil)
         deliver(payload, clientID: clientID)
     }
 
     static func logDeviceCheckCouldNotGenerateToken(_ msg: String, clientID: String?) {
-        let payload = buildPayload(errorType: "dc-token-gen-failed", errorMessage: msg)
+        let payload = buildPayload(errorType: "error-dc-token-gen-failed", errorMessage: msg)
         deliver(payload, clientID: clientID)
     }
 }
@@ -78,10 +83,7 @@ private func buildRequest(_ payload: Payload, clientID: String?) -> URLRequest? 
     var request = URLRequest(url: libErrorURL)
     request.httpMethod = "POST"
     request.httpBody = body
-
-    if let clientID = clientID ?? AIProxyIdentifier.getClientID() {
-        request.addValue(clientID, forHTTPHeaderField: "aiproxy-client-id")
-    }
+    request.addValue(clientID ?? AIProxyIdentifier.getClientID(), forHTTPHeaderField: "aiproxy-client-id")
 
     request.addValue(
         AIProxyUtils.metadataHeader(withBodySize: body.count),


### PR DESCRIPTION
With 'useStableID' enabled, we try to get a clientID through a series of fallbacks: appTransactionID, keychain-synced UUID, and finally IDFV. There are user reports of all three of these failing. This patch adds a final backstop, setting the clientID to "unknown"