### PR TITLE
Update away from Fal model that no longer runs inference

### DIFF
--- a/Sources/AIProxy/Fal/FalService+Convenience.swift
+++ b/Sources/AIProxy/Fal/FalService+Convenience.swift
@@ -92,7 +92,7 @@ extension FalService {
         input: FalTryonInputSchema
     ) async throws -> FalTryonOutputSchema {
         return try await self.createInferenceAndPollForResult(
-            model: "fashn/tryon",
+            model: "fal-ai/fashn/tryon/v1.5",
             input: input,
             pollAttempts: 60,
             secondsBetweenPollAttempts: 2


### PR DESCRIPTION
The model at `fashn/tryon` no longer runs inference, instead returning error:

```
{"detail":{"error":"EndpointDeprecated","message":"This endpoint is no longer supported. Please use the updated endpoint: https://fal.ai/models/fal-ai/fashn/tryon/v1.5"}}
```

This patch updates to the latest model and closes issue https://github.com/lzell/AIProxySwift/issues/168