### PR TITLE
Refactor OpenAI service with request builders

### DIFF
--- a/Sources/AIProxy/OpenAI/OpenAIDirectRequestBuilder.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIDirectRequestBuilder.swift
@@ -29,4 +29,41 @@ internal struct OpenAIDirectRequestBuilder: OpenAIRequestBuilder {
             additionalHeaders: mergedHeaders
         )
     }
+
+    func multipartPOST(
+        path: String,
+        body: MultipartFormEncodable,
+        secondsToWait: UInt,
+        additionalHeaders: [String : String]
+    ) async throws -> URLRequest {
+        var mergedHeaders = additionalHeaders
+        mergedHeaders["Authorization"] = "Bearer \(self.unprotectedAPIKey)"
+        let boundary = UUID().uuidString
+        return try AIProxyURLRequest.createDirect(
+            baseURL: self.baseURL,
+            path: path,
+            body: formEncode(body, boundary),
+            verb: .post,
+            secondsToWait: secondsToWait,
+            contentType: "multipart/form-data; boundary=\(boundary)",
+            additionalHeaders: mergedHeaders
+        )
+    }
+
+    func plainGET(
+        path: String,
+        secondsToWait: UInt,
+        additionalHeaders: [String : String]
+    ) async throws -> URLRequest {
+        var mergedHeaders = additionalHeaders
+        mergedHeaders["Authorization"] = "Bearer \(self.unprotectedAPIKey)"
+        return try AIProxyURLRequest.createDirect(
+            baseURL: self.baseURL,
+            path: path,
+            body: nil,
+            verb: .get,
+            secondsToWait: secondsToWait,
+            additionalHeaders: mergedHeaders
+        )
+    }
 }

--- a/Sources/AIProxy/OpenAI/OpenAIProxiedRequestBuilder.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIProxiedRequestBuilder.swift
@@ -32,4 +32,41 @@ internal struct OpenAIProxiedRequestBuilder: OpenAIRequestBuilder {
             additionalHeaders: additionalHeaders
         )
     }
+
+    func multipartPOST(
+        path: String,
+        body: MultipartFormEncodable,
+        secondsToWait: UInt,
+        additionalHeaders: [String : String]
+    ) async throws -> URLRequest {
+        let boundary = UUID().uuidString
+        return try await AIProxyURLRequest.create(
+            partialKey: self.partialKey,
+            serviceURL: self.serviceURL ?? legacyURL,
+            clientID: self.clientID,
+            proxyPath: path,
+            body: formEncode(body, boundary),
+            verb: .post,
+            secondsToWait: secondsToWait,
+            contentType: "multipart/form-data; boundary=\(boundary)",
+            additionalHeaders: additionalHeaders
+        )
+    }
+
+    func plainGET(
+        path: String,
+        secondsToWait: UInt,
+        additionalHeaders: [String : String]
+    ) async throws -> URLRequest {
+        return try await AIProxyURLRequest.create(
+            partialKey: self.partialKey,
+            serviceURL: self.serviceURL ?? legacyURL,
+            clientID: self.clientID,
+            proxyPath: path,
+            body: nil,
+            verb: .get,
+            secondsToWait: secondsToWait,
+            additionalHeaders: additionalHeaders
+        )
+    }
 }

--- a/Sources/AIProxy/OpenAI/OpenAIRequestBuilder.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRequestBuilder.swift
@@ -8,10 +8,23 @@
 import Foundation
 
 protocol OpenAIRequestBuilder {
-    
+
     func jsonPOST(
         path: String,
         body: Encodable,
+        secondsToWait: UInt,
+        additionalHeaders: [String: String]
+    ) async throws -> URLRequest
+
+    func multipartPOST(
+        path: String,
+        body: MultipartFormEncodable,
+        secondsToWait: UInt,
+        additionalHeaders: [String: String]
+    ) async throws -> URLRequest
+
+    func plainGET(
+        path: String,
         secondsToWait: UInt,
         additionalHeaders: [String: String]
     ) async throws -> URLRequest


### PR DESCRIPTION
## Summary
- refactor `OpenAIService` to delegate request creation to a builder and networking to a mixin
- extend `OpenAIRequestBuilder` to support multipart and GET requests
- implement new builder methods for proxied and direct OpenAI services

## Testing
- `swift test --disable-sandbox` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_6872850ea8048325b35f6667499bd593