### PR TITLE
Improve streaming fn signatures

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.115.0"
+    public static let sdkVersion = "0.116.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/DeepSeek/DeepSeekDirectService.swift
+++ b/Sources/AIProxy/DeepSeek/DeepSeekDirectService.swift
@@ -62,7 +62,7 @@ open class DeepSeekDirectService: DeepSeekService, DirectService {
     public func streamingChatCompletionRequest(
         body: DeepSeekChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<DeepSeekChatCompletionChunk, Error> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)

--- a/Sources/AIProxy/DeepSeek/DeepSeekProxiedService.swift
+++ b/Sources/AIProxy/DeepSeek/DeepSeekProxiedService.swift
@@ -66,7 +66,7 @@ open class DeepSeekProxiedService: DeepSeekService, ProxiedService {
     public func streamingChatCompletionRequest(
         body: DeepSeekChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<DeepSeekChatCompletionChunk, Error> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)

--- a/Sources/AIProxy/DeepSeek/DeepSeekService.swift
+++ b/Sources/AIProxy/DeepSeek/DeepSeekService.swift
@@ -33,7 +33,7 @@ public protocol DeepSeekService {
     func streamingChatCompletionRequest(
         body: DeepSeekChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk>
+    ) async throws -> AsyncThrowingStream<DeepSeekChatCompletionChunk, Error>
 }
 
 extension DeepSeekService {
@@ -45,7 +45,7 @@ extension DeepSeekService {
 
     public func streamingChatCompletionRequest(
         body: DeepSeekChatCompletionRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<DeepSeekChatCompletionChunk, Error> {
         return try await self.streamingChatCompletionRequest(body: body, secondsToWait: 60)
     }
 }

--- a/Sources/AIProxy/FireworksAI/FireworksAIDirectService.swift
+++ b/Sources/AIProxy/FireworksAI/FireworksAIDirectService.swift
@@ -65,7 +65,7 @@ open class FireworksAIDirectService: FireworksAIService, DirectService {
     public func streamingDeepSeekR1Request(
         body: DeepSeekChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<DeepSeekChatCompletionChunk, Error> {
         if body.model != "accounts/fireworks/models/deepseek-r1" {
             logIf(.warning)?.warning("Attempting to use deepSeekR1Request with an unknown model")
         }

--- a/Sources/AIProxy/FireworksAI/FireworksAIProxiedService.swift
+++ b/Sources/AIProxy/FireworksAI/FireworksAIProxiedService.swift
@@ -69,7 +69,7 @@ open class FireworksAIProxiedService: FireworksAIService, ProxiedService {
     public func streamingDeepSeekR1Request(
         body: DeepSeekChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<DeepSeekChatCompletionChunk, Error> {
         if body.model != "accounts/fireworks/models/deepseek-r1" {
             logIf(.warning)?.warning("Attempting to use deepSeekR1Request with an unknown model")
         }

--- a/Sources/AIProxy/FireworksAI/FireworksAIService.swift
+++ b/Sources/AIProxy/FireworksAI/FireworksAIService.swift
@@ -35,5 +35,5 @@ public protocol FireworksAIService {
     func streamingDeepSeekR1Request(
         body: DeepSeekChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, DeepSeekChatCompletionChunk>
+    ) async throws -> AsyncThrowingStream<DeepSeekChatCompletionChunk, Error>
 }

--- a/Sources/AIProxy/Gemini/GeminiDirectService.swift
+++ b/Sources/AIProxy/Gemini/GeminiDirectService.swift
@@ -63,7 +63,7 @@ open class GeminiDirectService: GeminiService, DirectService {
         body: GeminiGenerateContentRequestBody,
         model: String,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, GeminiGenerateContentResponseBody> {
+    ) async throws -> AsyncThrowingStream<GeminiGenerateContentResponseBody, Error> {
         let proxyPath = "/v1beta/models/\(model):streamGenerateContent?alt=sse"
         let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://generativelanguage.googleapis.com",

--- a/Sources/AIProxy/Gemini/GeminiProxiedService.swift
+++ b/Sources/AIProxy/Gemini/GeminiProxiedService.swift
@@ -64,7 +64,7 @@ open class GeminiProxiedService: GeminiService, ProxiedService {
         body: GeminiGenerateContentRequestBody,
         model: String,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, GeminiGenerateContentResponseBody> {
+    ) async throws -> AsyncThrowingStream<GeminiGenerateContentResponseBody, Error> {
         let proxyPath = "/v1beta/models/\(model):streamGenerateContent?alt=sse"
         let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,

--- a/Sources/AIProxy/Gemini/GeminiService.swift
+++ b/Sources/AIProxy/Gemini/GeminiService.swift
@@ -40,7 +40,7 @@ public protocol GeminiService {
         body: GeminiGenerateContentRequestBody,
         model: String,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, GeminiGenerateContentResponseBody>
+    ) async throws -> AsyncThrowingStream<GeminiGenerateContentResponseBody, Error>
 
     /// Generate images with the Imagen API
     func makeImagenRequest(

--- a/Sources/AIProxy/Groq/GroqDirectService.swift
+++ b/Sources/AIProxy/Groq/GroqDirectService.swift
@@ -60,7 +60,7 @@ open class GroqDirectService: GroqService, DirectService {
     public func streamingChatCompletionRequest(
         body: GroqChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, GroqChatCompletionStreamingChunk> {
+    ) async throws -> AsyncThrowingStream<GroqChatCompletionStreamingChunk, Error> {
         var body = body
         body.stream = true
         let request = try AIProxyURLRequest.createDirect(

--- a/Sources/AIProxy/Groq/GroqProxiedService.swift
+++ b/Sources/AIProxy/Groq/GroqProxiedService.swift
@@ -62,7 +62,7 @@ open class GroqProxiedService: GroqService, ProxiedService {
     public func streamingChatCompletionRequest(
         body: GroqChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, GroqChatCompletionStreamingChunk> {
+    ) async throws -> AsyncThrowingStream<GroqChatCompletionStreamingChunk, Error> {
         var body = body
         body.stream = true
         let request = try await AIProxyURLRequest.create(

--- a/Sources/AIProxy/Groq/GroqService.swift
+++ b/Sources/AIProxy/Groq/GroqService.swift
@@ -32,7 +32,7 @@ public protocol GroqService {
     func streamingChatCompletionRequest(
         body: GroqChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, GroqChatCompletionStreamingChunk>
+    ) async throws -> AsyncThrowingStream<GroqChatCompletionStreamingChunk, Error>
 
     /// Initiates a transcription request to /openai/v1/audio/transcriptions
     ///

--- a/Sources/AIProxy/Mistral/MistralDirectService.swift
+++ b/Sources/AIProxy/Mistral/MistralDirectService.swift
@@ -56,7 +56,7 @@ open class MistralDirectService: MistralService, DirectService {
     public func streamingChatCompletionRequest(
         body: MistralChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, MistralChatCompletionStreamingChunk> {
+    ) async throws -> AsyncThrowingStream<MistralChatCompletionStreamingChunk, Error> {
         var body = body
         body.stream = true
         let request = try AIProxyURLRequest.createDirect(

--- a/Sources/AIProxy/Mistral/MistralProxiedService.swift
+++ b/Sources/AIProxy/Mistral/MistralProxiedService.swift
@@ -61,7 +61,7 @@ open class MistralProxiedService: MistralService, ProxiedService {
     public func streamingChatCompletionRequest(
         body: MistralChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, MistralChatCompletionStreamingChunk> {
+    ) async throws -> AsyncThrowingStream<MistralChatCompletionStreamingChunk, Error> {
         var body = body
         body.stream = true
         let request = try await AIProxyURLRequest.create(

--- a/Sources/AIProxy/Mistral/MistralService.swift
+++ b/Sources/AIProxy/Mistral/MistralService.swift
@@ -31,7 +31,7 @@ public protocol MistralService {
     func streamingChatCompletionRequest(
         body: MistralChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, MistralChatCompletionStreamingChunk>
+    ) async throws -> AsyncThrowingStream<MistralChatCompletionStreamingChunk, Error>
 
     /// Initiates an OCR request to Mistral
     ///

--- a/Sources/AIProxy/OpenAI/OpenAIDirectService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIDirectService.swift
@@ -64,7 +64,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
     public func streamingChatCompletionRequest(
         body: OpenAIChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<OpenAIChatCompletionChunk, Error> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)
@@ -359,7 +359,7 @@ open class OpenAIDirectService: OpenAIService, DirectService {
     public func createStreamingResponse(
         requestBody: OpenAICreateResponseRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIResponseStreamingEvent> {
+    ) async throws -> AsyncThrowingStream<OpenAIResponseStreamingEvent, Error> {
         var requestBody = requestBody
         requestBody.stream = true
         let request = try AIProxyURLRequest.createDirect(

--- a/Sources/AIProxy/OpenAI/OpenAIProxiedService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIProxiedService.swift
@@ -67,7 +67,7 @@ open class OpenAIProxiedService: OpenAIService, ProxiedService {
     public func streamingChatCompletionRequest(
         body: OpenAIChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<OpenAIChatCompletionChunk, Error> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)
@@ -356,7 +356,7 @@ open class OpenAIProxiedService: OpenAIService, ProxiedService {
     public func createStreamingResponse(
         requestBody: OpenAICreateResponseRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIResponseStreamingEvent> {
+    ) async throws -> AsyncThrowingStream<OpenAIResponseStreamingEvent, Error> {
         var requestBody = requestBody
         requestBody.stream = true
         let request = try await AIProxyURLRequest.create(

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -33,7 +33,7 @@ public protocol OpenAIService {
     func streamingChatCompletionRequest(
         body: OpenAIChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk>
+    ) async throws -> AsyncThrowingStream<OpenAIChatCompletionChunk, Error>
 
     /// Initiates a create image request to /v1/images/generations
     ///
@@ -169,7 +169,7 @@ public protocol OpenAIService {
     func createStreamingResponse(
         requestBody: OpenAICreateResponseRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIResponseStreamingEvent>
+    ) async throws -> AsyncThrowingStream<OpenAIResponseStreamingEvent, Error>
 
     /// Creates a vector store
     ///
@@ -207,7 +207,7 @@ extension OpenAIService {
 
     public func streamingChatCompletionRequest(
         body: OpenAIChatCompletionRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<OpenAIChatCompletionChunk, Error> {
         return try await self.streamingChatCompletionRequest(body: body, secondsToWait: 60)
     }
 
@@ -219,14 +219,14 @@ extension OpenAIService {
 
     public func createStreamingResponse(
         requestBody: OpenAICreateResponseRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIResponseStreamingEvent> {
+    ) async throws -> AsyncThrowingStream<OpenAIResponseStreamingEvent, Error> {
         return try await self.createStreamingResponse(requestBody: requestBody, secondsToWait: 60)
     }
 
     @available(*, deprecated, message: "This has been renamed to createStreamingResponse")
     public func createStreamingResponseEvents(
         requestBody: OpenAICreateResponseRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIResponseStreamingEvent> {
+    ) async throws -> AsyncThrowingStream<OpenAIResponseStreamingEvent, Error> {
         return try await self.createStreamingResponse(requestBody: requestBody, secondsToWait: 60)
     }
 }

--- a/Sources/AIProxy/OpenRouter/OpenRouterDirectService.swift
+++ b/Sources/AIProxy/OpenRouter/OpenRouterDirectService.swift
@@ -60,7 +60,7 @@ open class OpenRouterDirectService: OpenRouterService, DirectService {
     public func streamingChatCompletionRequest(
         body: OpenRouterChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenRouterChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<OpenRouterChatCompletionChunk, Error> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)

--- a/Sources/AIProxy/OpenRouter/OpenRouterProxiedService.swift
+++ b/Sources/AIProxy/OpenRouter/OpenRouterProxiedService.swift
@@ -65,7 +65,7 @@ open class OpenRouterProxiedService: OpenRouterService, ProxiedService {
     public func streamingChatCompletionRequest(
         body: OpenRouterChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenRouterChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<OpenRouterChatCompletionChunk, Error> {
         var body = body
         body.stream = true
         body.streamOptions = .init(includeUsage: true)

--- a/Sources/AIProxy/OpenRouter/OpenRouterService.swift
+++ b/Sources/AIProxy/OpenRouter/OpenRouterService.swift
@@ -35,7 +35,7 @@ public protocol OpenRouterService {
     func streamingChatCompletionRequest(
         body: OpenRouterChatCompletionRequestBody,
         secondsToWait: UInt
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenRouterChatCompletionChunk>
+    ) async throws -> AsyncThrowingStream<OpenRouterChatCompletionChunk, Error>
 }
 
 extension OpenRouterService {
@@ -47,7 +47,7 @@ extension OpenRouterService {
 
     public func streamingChatCompletionRequest(
         body: OpenRouterChatCompletionRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenRouterChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<OpenRouterChatCompletionChunk, Error> {
         return try await self.streamingChatCompletionRequest(body: body, secondsToWait: 60)
     }
 }

--- a/Sources/AIProxy/Perplexity/PerplexityDirectService.swift
+++ b/Sources/AIProxy/Perplexity/PerplexityDirectService.swift
@@ -54,7 +54,7 @@ open class PerplexityDirectService: PerplexityService, DirectService {
     /// - Returns: An async sequence of completion chunks.
     public func streamingChatCompletionRequest(
         body: PerplexityChatCompletionRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, PerplexityChatCompletionResponseBody> {
+    ) async throws -> AsyncThrowingStream<PerplexityChatCompletionResponseBody, Error> {
         var body = body
         body.stream = true
         let request = try AIProxyURLRequest.createDirect(

--- a/Sources/AIProxy/Perplexity/PerplexityProxiedService.swift
+++ b/Sources/AIProxy/Perplexity/PerplexityProxiedService.swift
@@ -59,7 +59,7 @@ open class PerplexityProxiedService: PerplexityService, ProxiedService {
     /// - Returns: An async sequence of completion chunks.
     public func streamingChatCompletionRequest(
         body: PerplexityChatCompletionRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, PerplexityChatCompletionResponseBody> {
+    ) async throws -> AsyncThrowingStream<PerplexityChatCompletionResponseBody, Error> {
         var body = body
         body.stream = true
         let request = try await AIProxyURLRequest.create(

--- a/Sources/AIProxy/Perplexity/PerplexityService.swift
+++ b/Sources/AIProxy/Perplexity/PerplexityService.swift
@@ -29,5 +29,5 @@ public protocol PerplexityService {
     /// - Returns: An async sequence of completion chunks.
     func streamingChatCompletionRequest(
         body: PerplexityChatCompletionRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, PerplexityChatCompletionResponseBody>
+    ) async throws -> AsyncThrowingStream<PerplexityChatCompletionResponseBody, Error>
 }

--- a/Sources/AIProxy/ServiceMixin.swift
+++ b/Sources/AIProxy/ServiceMixin.swift
@@ -26,19 +26,44 @@ extension ServiceMixin {
         return try T.deserialize(from: data)
     }
 
-    func makeRequestAndDeserializeStreamingChunks<T: Decodable>(_ request: URLRequest) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, T> {
+    func makeRequestAndDeserializeStreamingChunks<T: Decodable>(_ request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
         if AIProxy.printRequestBodies {
             printRequestBody(request)
         }
+
         let (asyncBytes, _) = try await BackgroundNetworker.makeRequestAndWaitForAsyncBytes(
             self.urlSession,
             request
         )
-        return asyncBytes.lines.compactMap {
+
+        let sequence = asyncBytes.lines.compactMap { (line: String) -> T? in
             if AIProxy.printResponseBodies {
-                printStreamingResponseChunk($0)
+                printStreamingResponseChunk(line)
             }
-            return T.deserialize(fromLine: $0)
+            return T.deserialize(fromLine: line)
+        }
+
+        // This swift juggling is because I don't want the return types of our API to be
+        // something like: AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk>
+        //
+        // So instead I manually map it to an AsyncStream with a nice signature of AsyncStream<OpenAIChatCompletionChunk>.
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    for try await item in sequence {
+                        if Task.isCancelled {
+                            break
+                        }
+                        continuation.yield(item)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
         }
     }
 }

--- a/Sources/AIProxy/ServiceMixin.swift
+++ b/Sources/AIProxy/ServiceMixin.swift
@@ -46,7 +46,7 @@ extension ServiceMixin {
         // This swift juggling is because I don't want the return types of our API to be
         // something like: AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk>
         //
-        // So instead I manually map it to an AsyncStream with a nice signature of AsyncStream<OpenAIChatCompletionChunk>.
+        // So instead I manually map it to an AsyncStream with a nice signature of AsyncThrowingStream<OpenAIChatCompletionChunk, Error>.
         return AsyncThrowingStream { continuation in
             let task = Task {
                 do {

--- a/Sources/AIProxy/TogetherAI/TogetherAIDirectService.swift
+++ b/Sources/AIProxy/TogetherAI/TogetherAIDirectService.swift
@@ -51,7 +51,7 @@ open class TogetherAIDirectService: TogetherAIService, DirectService {
     /// - Returns: A chat completion response. See the reference above.
     public func streamingChatCompletionRequest(
         body: TogetherAIChatCompletionRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<OpenAIChatCompletionChunk, Error> {
         var body = body
         body.stream = true
         let request = try AIProxyURLRequest.createDirect(

--- a/Sources/AIProxy/TogetherAI/TogetherAIProxiedService.swift
+++ b/Sources/AIProxy/TogetherAI/TogetherAIProxiedService.swift
@@ -54,7 +54,7 @@ open class TogetherAIProxiedService: TogetherAIService, ProxiedService {
     /// - Returns: A chat completion response. See the reference above.
     public func streamingChatCompletionRequest(
         body: TogetherAIChatCompletionRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk> {
+    ) async throws -> AsyncThrowingStream<OpenAIChatCompletionChunk, Error> {
         var body = body
         body.stream = true
         let request = try await AIProxyURLRequest.create(

--- a/Sources/AIProxy/TogetherAI/TogetherAIService.swift
+++ b/Sources/AIProxy/TogetherAI/TogetherAIService.swift
@@ -28,5 +28,5 @@ public protocol TogetherAIService {
     /// - Returns: A chat completion response. See the reference above.
     func streamingChatCompletionRequest(
         body: TogetherAIChatCompletionRequestBody
-    ) async throws -> AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>, OpenAIChatCompletionChunk>
+    ) async throws -> AsyncThrowingStream<OpenAIChatCompletionChunk, Error>
 }


### PR DESCRIPTION
- Using much cleaner `AsyncThrowingStream` return types in all streaming functions.
  - I was previously leaking details of how the async sequence was created, e.g. `AsyncCompactMapSequence<AsyncLineSequence<URLSession.AsyncBytes>...` was in the return type
  - Callers shouldn't by concerned with the details of how the sequence is constructed. Instead they just want to loop over the streaming chunks, e.g. `AsyncThrowingStream<OpenAIChatCompletionChunk, Error>`
- Calling code remains unchanged, provided the user isn't manually annotating the return types.