### PR TITLE
Enforce DeviceCheck token is populated in request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6042,6 +6042,38 @@ If you do not have existing client or user IDs, no problem! Leave the `clientID`
 out, and we'll generate IDs for you. See `AIProxyIdentifier.swift` if you would like to see
 ID generation specifics.
 
+### How to respond to DeviceCheck errors
+
+Apple's DeviceCheck is a core component of our security model.
+
+If your app can't generate a DeviceCheck token from the device, then it is unable to make a request to AIProxy's backend.
+In such a case, you can pop UI to the end user by catching AIProxyError.deviceCheckIsUnavailble:
+
+```swift
+    let requestBody = OpenAIChatCompletionRequestBody(
+        model: "gpt-4.1-mini-2025-04-14",
+        messages: [
+            .system(content: .text("You are a helpful assistant")),
+            .user(content: .text("hello world"))
+        ]
+    )
+
+    do {
+        let response = try await openAIService.chatCompletionRequest(
+            body: requestBody,
+            secondsToWait: 60
+        )
+    } catch let error as AIProxyError where error == .deviceCheckIsUnavailable {
+        // Pop UI to the end user here. Here is a sample message:
+        //
+        //     We could not create a required credential to make your AI request.
+        //     Please make sure you are connected to the internet and your system clock is accurately set.
+        //
+    } catch {
+        print("Could not create an OpenAI chat completion: \(error.localizedDescription)")
+    }
+```
+
 
 ### How to catch Foundation errors for specific conditions
 

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.119.0"
+    public static let sdkVersion = "0.120.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/AIProxyError.swift
+++ b/Sources/AIProxy/AIProxyError.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum AIProxyError: LocalizedError {
+public enum AIProxyError: LocalizedError, Equatable {
 
     /// This error is thrown if any programmer assumptions are broken and the library can't continue.
     ///
@@ -45,14 +45,29 @@ public enum AIProxyError: LocalizedError {
     /// production, because the rate limits that you apply will rate limit live users!
     case unsuccessfulRequest(statusCode: Int, responseBody: String)
 
+    /// A core component of our security model is Apple's DeviceCheck.
+    /// If we can't generate a DeviceCheck token, then the app is not allowed to make requests to AIProxy's backend.
+    /// Catch this error to pop UI to the end user.
+    /// Our suggested copy for the alert is:
+    /// "We could not create a required credential to make your AI request. Please make sure you are connected to the internet and your system clock is accurately set."
+    case deviceCheckIsUnavailable
+
+    /// Raised from the iOS simulator if the `AIPROXY_DEVICE_CHECK_BYPASS` token is not set.
+    /// The bypass token is needed on simulators only, where Apple's DeviceCheck is not available.
+    case deviceCheckBypassIsMissing
+
     public var errorDescription: String? {
         switch self {
         case .assertion(let message):
-            return "An AIProxy precondition was not met: \(message)"
-
+            return "AIProxy - A library precondition was not met: \(message)"
         case .unsuccessfulRequest(statusCode: let statusCode, responseBody: let responseBody):
-            return "An AIProxy request resulted in a status code of \(statusCode) with response body: \(responseBody)."
+            return "AIProxy - the request resulted in a status code of \(statusCode) with response body: \(responseBody)."
+        case .deviceCheckIsUnavailable:
+            return "AIProxy - Apple's DeviceCheck is not available on this device. Please make sure you are connected to the internet and your system clock is accurately set."
+        case .deviceCheckBypassIsMissing:
+            return "AIProxy - You are running on a simulator without setting the AIPROXY_DEVICE_CHECK_BYPASS env variable. Please see the integration guide for instructions on setting AIPROXY_DEVICE_CHECK_BYPASS: https://www.aiproxy.pro/docs/integration-guide.html"
         }
+
     }
 }
 

--- a/Sources/AIProxy/AIProxyURLRequest.swift
+++ b/Sources/AIProxy/AIProxyURLRequest.swift
@@ -59,17 +59,17 @@ enum AIProxyURLRequest {
             request.addValue(resolvedAccount.uuid, forHTTPHeaderField: "aiproxy-anonymous-id")
         }
 
-#if targetEnvironment(simulator)
+    #if targetEnvironment(simulator)
         guard let deviceCheckBypass = ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] else {
             throw AIProxyError.deviceCheckBypassIsMissing
         }
         request.addValue(deviceCheckBypass, forHTTPHeaderField: "aiproxy-devicecheck-bypass")
-#else
+    #else
         guard let deviceCheckToken = await AIProxyDeviceCheck.getToken(forClient: resolvedClientID) else {
             throw AIProxyError.deviceCheckIsUnavailable
         }
         request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
-#endif
+    #endif
 
         if let contentType = contentType {
             request.addValue(contentType, forHTTPHeaderField: "Content-Type")

--- a/Sources/AIProxy/AIProxyURLRequest.swift
+++ b/Sources/AIProxy/AIProxyURLRequest.swift
@@ -10,6 +10,7 @@ import Foundation
 enum AIProxyURLRequest {
 
     /// Creates a URLRequest that is configured for use with an AIProxy URLSession.
+    /// Can raise `AIProxyError.deviceCheckIsUnavailable` or `AIProxyError.deviceCheckBypassIsMissing`
     static func create(
         partialKey: String,
         serviceURL: String,
@@ -22,7 +23,6 @@ enum AIProxyURLRequest {
         additionalHeaders: [String: String] = [:]
     ) async throws -> URLRequest {
         let resolvedClientID = clientID ?? AIProxyIdentifier.getClientID()
-        let deviceCheckToken = await AIProxyDeviceCheck.getToken(forClient: resolvedClientID)
 
         var proxyPath = proxyPath
         if !proxyPath.starts(with: "/") {
@@ -50,10 +50,6 @@ enum AIProxyURLRequest {
         request.addValue(partialKey, forHTTPHeaderField: "aiproxy-partial-key")
         request.addValue(resolvedClientID, forHTTPHeaderField: "aiproxy-client-id")
 
-        if let deviceCheckToken = deviceCheckToken {
-            request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
-        }
-
         request.addValue(
             AIProxyUtils.metadataHeader(withBodySize: body?.count ?? 0),
             forHTTPHeaderField: "aiproxy-metadata"
@@ -63,11 +59,17 @@ enum AIProxyURLRequest {
             request.addValue(resolvedAccount.uuid, forHTTPHeaderField: "aiproxy-anonymous-id")
         }
 
-    #if targetEnvironment(simulator)
-        if let deviceCheckBypass = ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] {
-            request.addValue(deviceCheckBypass, forHTTPHeaderField: "aiproxy-devicecheck-bypass")
+#if targetEnvironment(simulator)
+        guard let deviceCheckBypass = ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] else {
+            throw AIProxyError.deviceCheckBypassIsMissing
         }
-    #endif
+        request.addValue(deviceCheckBypass, forHTTPHeaderField: "aiproxy-devicecheck-bypass")
+#else
+        guard let deviceCheckToken = await AIProxyDeviceCheck.getToken(forClient: resolvedClientID) else {
+            throw AIProxyError.deviceCheckIsUnavailable
+        }
+        request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
+#endif
 
         if let contentType = contentType {
             request.addValue(contentType, forHTTPHeaderField: "Content-Type")


### PR DESCRIPTION
Apple's DeviceCheck is a core component of our security model.

We now enforce that all requests from the lib include either an `aiproxy-devicecheck` or `aiproxy-devicecheck-bypass` header. If neither of these are available, then we `raise` before the request is attempted.

If your app can't generate a DeviceCheck token from the device, then it is unable to make a request to AIProxy's backend.
In such a case, you can pop UI to the end user by catching AIProxyError.deviceCheckIsUnavailble:

```swift
    let requestBody = OpenAIChatCompletionRequestBody(
        model: "gpt-4.1-mini-2025-04-14",
        messages: [
            .system(content: .text("You are a helpful assistant")),
            .user(content: .text("hello world"))
        ]
    )

    do {
        let response = try await openAIService.chatCompletionRequest(
            body: requestBody,
            secondsToWait: 60
        )
    } catch let error as AIProxyError where error == .deviceCheckIsUnavailable {
        // Pop UI to the end user here. Here is a sample message:
        //
        //     We could not create a required credential to make your AI request.
        //     Please make sure you are connected to the internet and your system clock is accurately set.
        //
    } catch {
        print("Could not create an OpenAI chat completion: \(error.localizedDescription)")
    }
```