### PR TITLE
Add support for Structured Outputs through OpenAI Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1334,6 +1334,116 @@ Note: there is also a streaming version of this snippet below.
     }
 ```
 
+### How to make a Structured Outputs request with OpenAI's Responses API
+
+```swift
+    import AIProxy
+
+    /* Uncomment for BYOK use cases */
+    // let openAIService = AIProxy.openAIDirectService(
+    //     unprotectedAPIKey: "your-openai-key"
+    // )
+
+    /* Uncomment for all other production use cases */
+    // let openAIService = AIProxy.openAIService(
+    //     partialKey: "partial-key-from-your-developer-dashboard",
+    //     serviceURL: "service-url-from-your-developer-dashboard"
+    // )
+
+    let schema: [String: AIProxyJSONValue] = [
+        "type": "object",
+        "properties": [
+            "colors": [
+                "type": "array",
+                "items": [
+                    "type": "object",
+                    "properties": [
+                        "name": [
+                            "type": "string",
+                            "description": "A descriptive name to give the color"
+                        ],
+                        "hex_code": [
+                            "type": "string",
+                            "description": "The hex code of the color"
+                        ]
+                    ],
+                    "required": ["name", "hex_code"],
+                    "additionalProperties": false
+                ]
+            ]
+        ],
+        "required": ["colors"],
+        "additionalProperties": false
+    ]
+    let requestBody = OpenAICreateResponseRequestBody(
+        input: .items([
+            .message(role: .system, content: .text("You are a color palette generator")),
+            .message(role: .user, content: .text("Return a peaches and cream color palette"))
+        ]),
+        model: "gpt-4o",
+        text: .init(
+            format: .jsonSchema(
+                name: "palette",
+                schema: schema,
+                description: "A list of colors that make up a color pallete",
+                strict: true
+            )
+        )
+    )
+
+    do {
+        let response = try await openAIService.createResponse(
+            requestBody: requestBody,
+            secondsToWait: 120
+        )
+        print(response.outputText)
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received \(statusCode) status code with response body: \(responseBody)")
+    } catch {
+        print("Could not get a structured output response from OpenAI: \(error.localizedDescription)")
+    }
+```
+
+### How to make a JSON mode request with OpenAI's Responses API
+
+Please also see the Structured Outputs snippet above, which is a more modern way of getting a JSON response
+
+```swift
+    import AIProxy
+
+    /* Uncomment for BYOK use cases */
+    // let openAIService = AIProxy.openAIDirectService(
+    //     unprotectedAPIKey: "your-openai-key"
+    // )
+
+    /* Uncomment for all other production use cases */
+    // let openAIService = AIProxy.openAIService(
+    //     partialKey: "partial-key-from-your-developer-dashboard",
+    //     serviceURL: "service-url-from-your-developer-dashboard"
+    // )
+
+    let requestBody = OpenAICreateResponseRequestBody(
+        input: .items([
+            .message(role: .system, content: .text("Return valid JSON only")),
+            .message(role: .user, content: .text("Return alice and bob in a list of names"))
+        ]),
+        model: "gpt-4o",
+        text: .init(format: .jsonObject)
+    )
+
+    do {
+        let response = try await openAIService.createResponse(
+            requestBody: requestBody,
+            secondsToWait: 120
+        )
+        print(response.outputText)
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received \(statusCode) status code with response body: \(responseBody)")
+    } catch {
+        print("Could not get a JSON mode response from OpenAI: \(error.localizedDescription)")
+    }
+```
+
 ### How to make a web search call using OpenAI's Responses API
 Note: there is also a streaming version of this snippet below.
 

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.120.0"
+    public static let sdkVersion = "0.121.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
@@ -73,8 +73,10 @@ public struct OpenAICreateResponseRequestBody: Encodable {
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     public let user: String?
 
+    /// This field is not well-named; it's a configuration field that controls the response text, not the response text itself.
+    ///
     /// Configuration options for a text response from the model. Can be plain text or structured JSON data.
-    public let text: OpenAIResponse.Text?
+    public let text: OpenAIResponse.TextConfiguration?
 
     private enum CodingKeys: String, CodingKey {
         case input
@@ -108,7 +110,7 @@ public struct OpenAICreateResponseRequestBody: Encodable {
         temperature: Double? = nil,
         topP: Double? = nil,
         user: String? = nil,
-        text: OpenAIResponse.Text? = nil
+        text: OpenAIResponse.TextConfiguration? = nil
     ) {
         self.input = input
         self.model = model

--- a/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
@@ -73,8 +73,8 @@ public struct OpenAICreateResponseRequestBody: Encodable {
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     public let user: String?
 
-    /// Text generation settings.
-    public let text: TextSettings?
+    /// Configuration options for a text response from the model. Can be plain text or structured JSON data.
+    public let text: OpenAIResponse.Text?
 
     private enum CodingKeys: String, CodingKey {
         case input
@@ -108,7 +108,7 @@ public struct OpenAICreateResponseRequestBody: Encodable {
         temperature: Double? = nil,
         topP: Double? = nil,
         user: String? = nil,
-        text: OpenAICreateResponseRequestBody.TextSettings? = nil
+        text: OpenAIResponse.Text? = nil
     ) {
         self.input = input
         self.model = model
@@ -682,54 +682,3 @@ extension OpenAICreateResponseRequestBody {
         }
     }
 }
-
-// MARK: - Text Settings
-extension OpenAICreateResponseRequestBody {
-    /// Text generation settings for the response
-    public struct TextSettings: Codable {
-        /// The format specification for the text output
-        public let format: Format?
-
-        public init(format: Format? = nil) {
-            self.format = format
-        }
-    }
-
-    /// Format specification for text output
-    public struct Format: Codable {
-        /// The format type
-        public let type: FormatType?
-
-        /// The name of the schema (required for json_schema type)
-        public let name: String?
-
-        /// The JSON schema definition (required for json_schema type)
-        public let schema: [String: AIProxyJSONValue]?
-
-        /// Whether to enable strict schema adherence (optional for json_schema type)
-        public let strict: Bool?
-
-        public init(
-            type: FormatType? = nil,
-            name: String? = nil,
-            schema: [String: AIProxyJSONValue]? = nil,
-            strict: Bool? = nil
-        ) {
-            self.type = type
-            self.name = name
-            self.schema = schema
-            self.strict = strict
-        }
-    }
-
-    /// Available text output format types
-    public enum FormatType: String, Codable {
-        /// Plain text format
-        case text
-        /// JSON object format
-        case jsonObject = "json_object"
-        /// Structured JSON with schema validation
-        case jsonSchema = "json_schema"
-    }
-}
-

--- a/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+
 /// OpenAI's most advanced interface for generating model responses.
 /// Supports text and image inputs, and text outputs.
 /// Create stateful interactions with the model, using the output of previous responses as input.

--- a/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
@@ -126,6 +126,9 @@ public struct OpenAICreateResponseRequestBody: Encodable {
         self.user = user
         self.text = text
     }
+
+    // For naming consistency with sdkVersion <= 0.120.0
+    public typealias TextSettings = OpenAIResponse.TextConfiguration
 }
 
 extension OpenAICreateResponseRequestBody {

--- a/Sources/AIProxy/OpenAI/OpenAIResponse.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponse.swift
@@ -66,7 +66,7 @@ public struct OpenAIResponse: Decodable {
     /// Learn more:
     /// - [Text inputs and outputs](https://platform.openai.com/docs/guides/text)
     /// - [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs)
-    public let text: ResponseTextConfig?
+    public let text: OpenAIResponse.Text?
 
     /// What sampling temperature to use, between 0 and 2.
     /// Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
@@ -103,7 +103,29 @@ public struct OpenAIResponse: Decodable {
     /// [Learn more](https://platform.openai.com/docs/guides/safety-best-practices#end-user-ids).
     public let user: String?
     
-    public init(createdAt: Double?, error: ResponseError?, id: String?, incompleteDetails: IncompleteDetails?, instructions: String?, maxOutputTokens: Int?, metadata: [String : String]?, model: String?, output: [ResponseOutputItem], parallelToolCalls: Bool?, previousResponseId: String?, reasoning: Reasoning?, status: Status?, text: ResponseTextConfig?, temperature: Double?, toolChoice: OpenAICreateResponseRequestBody.ToolChoice?, tools: [OpenAICreateResponseRequestBody.Tool]?, topP: Double?, truncation: String?, usage: ResponseUsage?, user: String?) {
+    public init(
+        createdAt: Double?,
+        error: ResponseError?,
+        id: String?,
+        incompleteDetails: IncompleteDetails?,
+        instructions: String?,
+        maxOutputTokens: Int?,
+        metadata: [String : String]?,
+        model: String?,
+        output: [ResponseOutputItem],
+        parallelToolCalls: Bool?,
+        previousResponseId: String?,
+        reasoning: Reasoning?,
+        status: Status?,
+        text: OpenAIResponse.Text?,
+        temperature: Double?,
+        toolChoice: OpenAICreateResponseRequestBody.ToolChoice?,
+        tools: [OpenAICreateResponseRequestBody.Tool]?,
+        topP: Double?,
+        truncation: String?,
+        usage: ResponseUsage?,
+        user: String?
+    ) {
         self.createdAt = createdAt
         self.error = error
         self.id = id
@@ -209,10 +231,6 @@ extension OpenAIResponse {
         case inProgress = "in_progress"
     }
 
-    public struct ResponseTextConfig: Decodable {
-        let format: Format
-    }
-
     /// Represents the literal options: "none", "auto", or "required".
     public enum ToolChoiceOptions: String, Decodable {
         case none = "none"
@@ -248,33 +266,6 @@ extension OpenAIResponse.Reasoning {
         case low
         case medium
         case high
-    }
-}
-
-extension OpenAIResponse.ResponseTextConfig {
-    public enum Format: String, Decodable {
-        case jsonSchema = "json_schema"
-        case text = "text"
-
-        private enum CodingKeys: String, CodingKey {
-            case type
-        }
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            let formatValue = try container.decode(String.self, forKey: .type)
-            switch formatValue {
-            case "json_schema":
-                self = .jsonSchema
-            case "text":
-                self = .text
-            default:
-                throw DecodingError.dataCorruptedError(
-                    forKey: .type,
-                    in: container,
-                    debugDescription: "Unknown format type: \(formatValue)"
-                )
-            }
-        }
     }
 }
 

--- a/Sources/AIProxy/OpenAI/OpenAIResponse.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponse.swift
@@ -61,12 +61,14 @@ public struct OpenAIResponse: Decodable {
     /// One of `completed`, `failed`, `in_progress`, or `incomplete`.
     public let status: Status?
 
+    /// This field is not well-named; it's a configuration field that controls the response text, not the response text itself.
+    ///
     /// Configuration options for a text response from the model.
     /// Can be plain text or structured JSON data.
     /// Learn more:
     /// - [Text inputs and outputs](https://platform.openai.com/docs/guides/text)
     /// - [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs)
-    public let text: OpenAIResponse.Text?
+    public let text: OpenAIResponse.TextConfiguration?
 
     /// What sampling temperature to use, between 0 and 2.
     /// Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
@@ -117,7 +119,7 @@ public struct OpenAIResponse: Decodable {
         previousResponseId: String?,
         reasoning: Reasoning?,
         status: Status?,
-        text: OpenAIResponse.Text?,
+        text: OpenAIResponse.TextConfiguration?,
         temperature: Double?,
         toolChoice: OpenAICreateResponseRequestBody.ToolChoice?,
         tools: [OpenAICreateResponseRequestBody.Tool]?,

--- a/Sources/AIProxy/OpenAI/OpenAIResponseStreamingEvent.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponseStreamingEvent.swift
@@ -57,25 +57,6 @@ public enum OpenAIResponseStreamingEvent: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case type
-//        case sequenceNumber = "sequence_number"
-//        case response
-//        case outputIndex = "output_index"
-//        case item
-//        case itemId = "item_id"
-//        case contentIndex = "content_index"
-//        case summaryIndex = "summary_index"
-//        case part
-//        case delta
-//        case text
-//        case refusal
-//        case arguments
-//        case partialImageIndex = "partial_image_index"
-//        case partialImageB64 = "partial_image_b64"
-//        case annotationIndex = "annotation_index"
-//        case annotation
-//        case code
-//        case message
-//        case param
     }
 
     public init(from decoder: Decoder) throws {

--- a/Sources/AIProxy/OpenAI/OpenAIResponseText.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponseText.swift
@@ -1,0 +1,121 @@
+//
+//  OpenAIResponseText.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 7/21/25.
+//
+
+extension OpenAIResponse {
+    public struct Text: Codable {
+        /// The format specification for the text output
+        public let format: Format?
+
+        public init(format: Format) {
+            self.format = format
+        }
+    }
+}
+
+extension OpenAIResponse.Text {
+    /// An object specifying the format that the model must output.
+    /// The case `.jsonObject` is **not recommended for gpt-4o and newer models.**
+    public enum Format: Codable {
+
+        /// This case is no longer recommended.
+        /// Using `.jsonSchema` is preferred for models that support it.
+        ///
+        /// Enables the older JSON mode, which ensures the message the model generates is valid JSON.
+        /// Important: when using JSON mode, you must also instruct the model to produce JSON yourself via a
+        /// system or user message. Without this, the model may generate an unending stream of whitespace until
+        /// the generation reaches the token limit, resulting in a long-running and seemingly "stuck" request.
+        /// Also note that the message content may be partially cut off if `finish_reason="length"`, which indicates
+        /// the generation exceeded `max_tokens` or the conversation exceeded the max context length.
+        case jsonObject
+
+        /// Enables Structured Outputs which ensures the model will match your supplied JSON schema.
+        /// Learn more in the Structured Outputs guide: https://platform.openai.com/docs/guides/structured-outputs
+        ///
+        /// - Parameters:
+        ///   - name: The name of the response format. Must be a-z, A-Z, 0-9, or contain underscores and dashes,
+        ///           with a maximum length of 64.
+        ///
+        ///   - schema: The schema for the response format, described as a JSON Schema object.
+        ///
+        ///   - description: A description of what the response format is for, used by the model to determine how
+        ///                  to respond in the format.
+        ///
+        ///   - strict: Whether to enable strict schema adherence when generating the output. If set to true, the
+        ///             model will always follow the exact schema defined in the schema field. Only a subset of JSON Schema
+        ///             is supported when strict is true. To learn more, read the Structured Outputs guide.
+        case jsonSchema(
+            name: String,
+            schema: [String: AIProxyJSONValue],
+            description: String? = nil,
+            strict: Bool? = nil
+        )
+
+        /// Instructs the model to produce text only.
+        case text
+
+        private enum RootKey: String, CodingKey {
+            case type
+
+            // There is a difference in structure compared to the chat completion implementation of OpenAIChatCompletionRequestBody.ResponseFormat.
+            // In the responsesAPI, these fields are not nested under a separate key.
+            case name
+            case schema
+            case strict
+            case description
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: RootKey.self)
+            switch self {
+            case .jsonObject:
+                try container.encode("json_object", forKey: .type)
+            case .jsonSchema(
+                name: let name,
+                schema: let schema,
+                description: let description,
+                strict: let strict
+            ):
+                try container.encode("json_schema", forKey: .type)
+                try container.encode(name, forKey: .name)
+                try container.encode(schema, forKey: .schema)
+                try container.encodeIfPresent(description, forKey: .description)
+                try container.encodeIfPresent(strict, forKey: .strict)
+            case .text:
+                try container.encode("text", forKey: .type)
+            }
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: RootKey.self)
+            let type = try container.decode(String.self, forKey: .type)
+
+            switch type {
+            case "json_object":
+                self = .jsonObject
+            case "json_schema":
+                let name = try container.decode(String.self, forKey: .name)
+                let schema = try container.decode([String: AIProxyJSONValue].self, forKey: .schema)
+                let description = try container.decodeIfPresent(String.self, forKey: .description)
+                let strict = try container.decodeIfPresent(Bool.self, forKey: .strict)
+                self = .jsonSchema(
+                    name: name,
+                    schema: schema,
+                    description: description,
+                    strict: strict
+                )
+            case "text":
+                self = .text
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: .type,
+                    in: container,
+                    debugDescription: "Unknown response format type: \(type)"
+                )
+            }
+        }
+    }
+}

--- a/Sources/AIProxy/OpenAI/OpenAIResponseTextConfiguration.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponseTextConfiguration.swift
@@ -6,7 +6,7 @@
 //
 
 extension OpenAIResponse {
-    public struct Text: Codable {
+    public struct TextConfiguration: Codable {
         /// The format specification for the text output
         public let format: Format?
 
@@ -16,7 +16,7 @@ extension OpenAIResponse {
     }
 }
 
-extension OpenAIResponse.Text {
+extension OpenAIResponse.TextConfiguration {
     /// An object specifying the format that the model must output.
     /// The case `.jsonObject` is **not recommended for gpt-4o and newer models.**
     public enum Format: Codable {

--- a/Sources/AIProxy/OpenAI/OpenAIResponseTextConfiguration.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponseTextConfiguration.swift
@@ -1,5 +1,5 @@
 //
-//  OpenAIResponseText.swift
+//  OpenAIResponseTextConfiguration.swift
 //  AIProxy
 //
 //  Created by Lou Zell on 7/21/25.

--- a/Tests/AIProxyTests/OpenAICreateResponseRequestTests.swift
+++ b/Tests/AIProxyTests/OpenAICreateResponseRequestTests.swift
@@ -127,5 +127,107 @@ final class OpenAICreateResponseRequestTests: XCTestCase {
                 """, try requestBody.serialize(pretty: true))
     }
 
+    func testResponseRequestIsEncodableWithStructuredOutputs() throws {
+        let schema: [String: AIProxyJSONValue] = [
+            "type": "object",
+            "properties": [
+                "colors": [
+                    "type": "array",
+                    "items": [
+                        "type": "object",
+                        "properties": [
+                            "name": [
+                                "type": "string",
+                                "description": "A descriptive name to give the color"
+                            ],
+                            "hex_code": [
+                                "type": "string",
+                                "description": "The hex code of the color"
+                            ]
+                        ],
+                        "required": ["name", "hex_code"],
+                        "additionalProperties": false
+                    ]
+                ]
+            ],
+            "required": ["colors"],
+            "additionalProperties": false
+        ]
+        let requestBody = OpenAICreateResponseRequestBody(
+            input: .items([
+                .message(role: .system, content: .text("You are a color palette generator")),
+                .message(role: .user, content: .text("Return a peaches and cream color palette"))
+            ]),
+            model: "gpt-4o",
+            text: .init(
+                format: .jsonSchema(
+                    name: "palette",
+                    schema: schema,
+                    description: "A list of colors that make up a color pallete",
+                    strict: true
+                )
+            )
+        )
+
+        XCTAssertEqual(
+            """
+            {
+              "input" : [
+                {
+                  "content" : "You are a color palette generator",
+                  "role" : "system",
+                  "type" : "message"
+                },
+                {
+                  "content" : "Return a peaches and cream color palette",
+                  "role" : "user",
+                  "type" : "message"
+                }
+              ],
+              "model" : "gpt-4o",
+              "text" : {
+                "format" : {
+                  "description" : "A list of colors that make up a color pallete",
+                  "name" : "palette",
+                  "schema" : {
+                    "additionalProperties" : false,
+                    "properties" : {
+                      "colors" : {
+                        "items" : {
+                          "additionalProperties" : false,
+                          "properties" : {
+                            "hex_code" : {
+                              "description" : "The hex code of the color",
+                              "type" : "string"
+                            },
+                            "name" : {
+                              "description" : "A descriptive name to give the color",
+                              "type" : "string"
+                            }
+                          },
+                          "required" : [
+                            "name",
+                            "hex_code"
+                          ],
+                          "type" : "object"
+                        },
+                        "type" : "array"
+                      }
+                    },
+                    "required" : [
+                      "colors"
+                    ],
+                    "type" : "object"
+                  },
+                  "strict" : true,
+                  "type" : "json_schema"
+                }
+              }
+            }
+            """,
+            try requestBody.serialize(pretty: true)
+        )
+    }
+
 }
 

--- a/Tests/AIProxyTests/OpenAIResponseObjectTests.swift
+++ b/Tests/AIProxyTests/OpenAIResponseObjectTests.swift
@@ -14,7 +14,7 @@ final class OpenAIResponseObjectTests: XCTestCase {
         let sampleResponse = #"""
         { "type": "text" }
         """#
-        let res = try OpenAIResponse.Text.Format.deserialize(from: sampleResponse)
+        let res = try OpenAIResponse.TextConfiguration.Format.deserialize(from: sampleResponse)
         guard case .text = res else {
             return XCTFail()
         }
@@ -26,7 +26,7 @@ final class OpenAIResponseObjectTests: XCTestCase {
           "format": { "type": "text" }
         }
         """#
-        let res = try OpenAIResponse.Text.deserialize(from: sampleResponse)
+        let res = try OpenAIResponse.TextConfiguration.deserialize(from: sampleResponse)
         guard case .text = res.format else {
             return XCTFail()
         }

--- a/Tests/AIProxyTests/OpenAIResponseObjectTests.swift
+++ b/Tests/AIProxyTests/OpenAIResponseObjectTests.swift
@@ -14,18 +14,22 @@ final class OpenAIResponseObjectTests: XCTestCase {
         let sampleResponse = #"""
         { "type": "text" }
         """#
-        let res = try OpenAIResponse.ResponseTextConfig.Format.deserialize(from: sampleResponse)
-        XCTAssertEqual(.text, res)
+        let res = try OpenAIResponse.Text.Format.deserialize(from: sampleResponse)
+        guard case .text = res else {
+            return XCTFail()
+        }
     }
 
-    func testTextConfigIsDecodable() throws {
+    func testResponseTextIsDecodable() throws {
         let sampleResponse = #"""
         {
           "format": { "type": "text" }
         }
         """#
-        let res = try OpenAIResponse.ResponseTextConfig.deserialize(from: sampleResponse)
-        XCTAssertEqual(.text, res.format)
+        let res = try OpenAIResponse.Text.deserialize(from: sampleResponse)
+        guard case .text = res.format else {
+            return XCTFail()
+        }
     }
 
     func testCreateResponseResponseBodyIsDecodable() throws {
@@ -114,7 +118,9 @@ final class OpenAIResponseObjectTests: XCTestCase {
         XCTAssertNil(res.reasoning?.effort)
         XCTAssertNil(res.reasoning?.generateSummary)
         XCTAssertEqual(1.0, res.temperature)
-        XCTAssertEqual(.text, res.text?.format)
+        guard case .text = res.text?.format else {
+            return XCTFail()
+        }
 
 //        if case .option(let toolOption) = res.toolChoice {
 //            XCTAssertEqual(.auto, toolOption)
@@ -131,5 +137,184 @@ final class OpenAIResponseObjectTests: XCTestCase {
         XCTAssertEqual(36, res.usage?.totalTokens)
         XCTAssertNil(res.user)
         XCTAssertEqual(true, res.metadata?.isEmpty)
+    }
+
+
+    func testJSONModeResponseIsDecodable() throws {
+        let sampleResponse = #"""
+        {
+          "id": "resp_687e452b61d0819baf8a1bd210ebc8c40215ea063ccfb679",
+          "object": "response",
+          "created_at": 1753105707,
+          "status": "completed",
+          "background": false,
+          "error": null,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "max_tool_calls": null,
+          "model": "gpt-4o-2024-08-06",
+          "output": [
+            {
+              "id": "msg_687e452bb2bc819bbb7f330a29ee10d50215ea063ccfb679",
+              "type": "message",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "annotations": [],
+                  "logprobs": [],
+                  "text": "{\n  \"names\": [\"Alice\", \"Bob\"]\n}"
+                }
+              ],
+              "role": "assistant"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "previous_response_id": null,
+          "prompt_cache_key": null,
+          "reasoning": {
+            "effort": null,
+            "summary": null
+          },
+          "safety_identifier": null,
+          "service_tier": "default",
+          "store": true,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "json_object"
+            }
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_logprobs": 0,
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 24,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 13,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 37
+          },
+          "user": null,
+          "metadata": {}
+        }
+        """#
+        let res = try OpenAIResponse.deserialize(from: sampleResponse)
+    }
+
+    func testStructuredOutputsResponseIsDecodable() throws {
+        let sampleResponse = #"""
+        {
+          "id": "resp_687e5a064e24819aa64214483e6838e2008e7175c867dce4",
+          "object": "response",
+          "created_at": 1753111046,
+          "status": "completed",
+          "background": false,
+          "error": null,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "max_tool_calls": null,
+          "model": "gpt-4o-2024-08-06",
+          "output": [
+            {
+              "id": "msg_687e5a07008c819a97b7939a2f5c18f9008e7175c867dce4",
+              "type": "message",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "annotations": [],
+                  "logprobs": [],
+                  "text": "{\"colors\":[{\"hex_code\":\"#FFDAB9\",\"name\":\"Peach Puff\"},{\"hex_code\":\"#FFE5B4\",\"name\":\"Peaches\"},{\"hex_code\":\"#FFF5EE\",\"name\":\"Seashell\"},{\"hex_code\":\"#FFF0E1\",\"name\":\"Papaya Whip\"},{\"hex_code\":\"#FFF2E2\",\"name\":\"Cream Blush\"}]}"
+                }
+              ],
+              "role": "assistant"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "previous_response_id": null,
+          "prompt_cache_key": null,
+          "reasoning": {
+            "effort": null,
+            "summary": null
+          },
+          "safety_identifier": null,
+          "service_tier": "default",
+          "store": true,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "json_schema",
+              "description": "A list of colors that make up a color pallete",
+              "name": "palette",
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "colors": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "hex_code": {
+                          "description": "The hex code of the color",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "A descriptive name to give the color",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "hex_code"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "colors"
+                ],
+                "type": "object"
+              },
+              "strict": true
+            }
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_logprobs": 0,
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 102,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 79,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 181
+          },
+          "user": null,
+          "metadata": {}
+        }
+        """#
+        let res = try OpenAIResponse.deserialize(from: sampleResponse)
+        guard case .jsonSchema(let name, let schema, let description, let strict) = res.text?.format else {
+            return XCTFail()
+        }
+        XCTAssertEqual("palette", name)
+        XCTAssertEqual(["colors"], schema.untypedDictionary["required"] as? [String])
+        XCTAssertEqual("A list of colors that make up a color pallete", description)
+        XCTAssert(strict == true)
     }
 }


### PR DESCRIPTION
### How to make a Structured Outputs request with OpenAI's Responses API

```swift
    import AIProxy

    /* Uncomment for BYOK use cases */
    // let openAIService = AIProxy.openAIDirectService(
    //     unprotectedAPIKey: "your-openai-key"
    // )

    /* Uncomment for all other production use cases */
    // let openAIService = AIProxy.openAIService(
    //     partialKey: "partial-key-from-your-developer-dashboard",
    //     serviceURL: "service-url-from-your-developer-dashboard"
    // )

    let schema: [String: AIProxyJSONValue] = [
        "type": "object",
        "properties": [
            "colors": [
                "type": "array",
                "items": [
                    "type": "object",
                    "properties": [
                        "name": [
                            "type": "string",
                            "description": "A descriptive name to give the color"
                        ],
                        "hex_code": [
                            "type": "string",
                            "description": "The hex code of the color"
                        ]
                    ],
                    "required": ["name", "hex_code"],
                    "additionalProperties": false
                ]
            ]
        ],
        "required": ["colors"],
        "additionalProperties": false
    ]
    let requestBody = OpenAICreateResponseRequestBody(
        input: .items([
            .message(role: .system, content: .text("You are a color palette generator")),
            .message(role: .user, content: .text("Return a peaches and cream color palette"))
        ]),
        model: "gpt-4o",
        text: .init(
            format: .jsonSchema(
                name: "palette",
                schema: schema,
                description: "A list of colors that make up a color pallete",
                strict: true
            )
        )
    )

    do {
        let response = try await openAIService.createResponse(
            requestBody: requestBody,
            secondsToWait: 120
        )
        print(response.outputText)
    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
        print("Received \(statusCode) status code with response body: \(responseBody)")
    } catch {
        print("Could not get a structured output response from OpenAI: \(error.localizedDescription)")
    }
```

### How to make a JSON mode request with OpenAI's Responses API

Please also see the Structured Outputs snippet above, which is a more modern way of getting a JSON response

```swift
    import AIProxy

    /* Uncomment for BYOK use cases */
    // let openAIService = AIProxy.openAIDirectService(
    //     unprotectedAPIKey: "your-openai-key"
    // )

    /* Uncomment for all other production use cases */
    // let openAIService = AIProxy.openAIService(
    //     partialKey: "partial-key-from-your-developer-dashboard",
    //     serviceURL: "service-url-from-your-developer-dashboard"
    // )

    let requestBody = OpenAICreateResponseRequestBody(
        input: .items([
            .message(role: .system, content: .text("Return valid JSON only")),
            .message(role: .user, content: .text("Return alice and bob in a list of names"))
        ]),
        model: "gpt-4o",
        text: .init(format: .jsonObject)
    )

    do {
        let response = try await openAIService.createResponse(
            requestBody: requestBody,
            secondsToWait: 120
        )
        print(response.outputText)
    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
        print("Received \(statusCode) status code with response body: \(responseBody)")
    } catch {
        print("Could not get a JSON mode response from OpenAI: \(error.localizedDescription)")
    }
```
