### PR TITLE
Protect against multiple configure calls

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.122.0"
+    public static let sdkVersion = "0.122.1"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -85,16 +85,10 @@ public enum AIProxy {
         useStableID: Bool
     ) {
         aiproxyCallerDesiredLogLevel = logLevel
-        self.printRequestBodies = printRequestBodies
-        self.printResponseBodies = printResponseBodies
-        self.resolveDNSOverTLS = resolveDNSOverTLS
-        if useStableID {
-            Task.detached {
-                if let stableID = await self._getStableIdentifier() {
-                    self.stableID = stableID
-                }
-            }
-        }
+        AIProxyConfiguration.printRequestBodies = printRequestBodies
+        AIProxyConfiguration.printResponseBodies = printResponseBodies
+        AIProxyConfiguration.resolveDNSOverTLS = resolveDNSOverTLS
+        AIProxyConfiguration.useStableID = useStableID
     }
 
     /// Flag to use DNS over TLS.
@@ -112,21 +106,21 @@ public enum AIProxy {
     /// Or using cloudflare's resolver
     ///
     ///    kdig @1.1.1.1 api.aiproxy.com +noall +stats
-    public static var resolveDNSOverTLS = true
-
-    public private(set) static var stableID: String? {
-        get {
-            protectedPropertyQueue.sync { _stableID }
-        }
-        set {
-            protectedPropertyQueue.async(flags: .barrier) { _stableID = newValue }
-        }
+    public static var resolveDNSOverTLS: Bool {
+        AIProxyConfiguration.resolveDNSOverTLS
     }
-    private static var _stableID: String?
 
-    public static var printRequestBodies: Bool = false
-    public static var printResponseBodies: Bool = false
+    public static var stableID: String? {
+        AIProxyConfiguration.stableID
+    }
 
+    public static var printRequestBodies: Bool {
+        AIProxyConfiguration.printRequestBodies
+    }
+
+    public static var printResponseBodies: Bool {
+        AIProxyConfiguration.printResponseBodies
+    }
 
     /// - Parameters:
     ///   - partialKey: Your partial key is displayed in the AIProxy dashboard when you submit your provider's key.
@@ -1007,21 +1001,7 @@ public enum AIProxy {
 
     @available(*, deprecated, message: "Use AIProxy.configure and pass true for useStableID")
     public static func getStableIdentifier() async -> String? {
-        return await self._getStableIdentifier()
-    }
-
-    private static func _getStableIdentifier() async -> String? {
-        #if !DEBUG
-        if let appTransactionID = await AIProxyUtils.getAppTransactionID() {
-            return appTransactionID
-        }
-        #endif
-        do {
-            return try await AnonymousAccountStorage.sync()
-        } catch {
-            logIf(.error)?.error("AIProxy: Could not configure an anonymous account: \(error.localizedDescription)")
-        }
-        return nil
+        return await AIProxyConfiguration._getStableIdentifier()
     }
 
     public static func base64EncodeAudioPCMBuffer(from buffer: AVAudioPCMBuffer) -> String? {

--- a/Sources/AIProxy/AIProxyConfiguration.swift
+++ b/Sources/AIProxy/AIProxyConfiguration.swift
@@ -1,0 +1,62 @@
+//
+//  AIProxyConfiguration.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 7/31/25.
+//
+
+internal enum AIProxyConfiguration {
+
+    static var resolveDNSOverTLS: Bool = true
+    static var printRequestBodies: Bool = false
+    static var printResponseBodies: Bool = false
+
+    static var stableID: String? {
+        get {
+            ProtectedPropertyQueue.stableID.sync { AIProxyConfiguration._stableID }
+        }
+        set {
+            ProtectedPropertyQueue.stableID.async(flags: .barrier) { AIProxyConfiguration._stableID = newValue }
+        }
+    }
+    static var _stableID: String?
+
+    static var useStableID: Bool {
+        get {
+            ProtectedPropertyQueue.useStableID.sync { _useStableID }
+        }
+        set {
+            ProtectedPropertyQueue.useStableID.async(flags: .barrier) { _useStableID = newValue }
+        }
+    }
+    private static var _useStableID: Bool = false {
+        willSet {
+            guard newValue != self._useStableID else {
+                return
+            }
+            if newValue {
+                Task.detached {
+                    if let stableID = await self._getStableIdentifier() {
+                        self.stableID = stableID
+                    }
+                }
+            } else {
+                self.stableID = nil
+            }
+        }
+    }
+
+    internal static func _getStableIdentifier() async -> String? {
+        #if !DEBUG
+        if let appTransactionID = await AIProxyUtils.getAppTransactionID() {
+            return appTransactionID
+        }
+        #endif
+        do {
+            return try await AnonymousAccountStorage.sync()
+        } catch {
+            logIf(.error)?.error("AIProxy: Could not configure an anonymous account: \(error.localizedDescription)")
+        }
+        return nil
+    }
+}

--- a/Sources/AIProxy/AIProxyIdentifier.swift
+++ b/Sources/AIProxy/AIProxyIdentifier.swift
@@ -20,7 +20,7 @@ enum AIProxyIdentifier {
     /// - Returns: The AIProxy stableID if the developer configured the SDK with `useStableID`.
     ///            Otherwise, a UIDevice ID on iOS, an IOKit ID on macOS
     internal static func getClientID() -> String {
-        if let stableID = AIProxy.stableID {
+        if let stableID = AIProxyConfiguration.stableID {
             return stableID
         }
 #if os(watchOS)

--- a/Sources/AIProxy/AIProxyUtils.swift
+++ b/Sources/AIProxy/AIProxyUtils.swift
@@ -31,7 +31,7 @@ enum AIProxyUtils {
     }
 
     static func proxiedURLSession() -> URLSession {
-        if AIProxy.resolveDNSOverTLS {
+        if AIProxyConfiguration.resolveDNSOverTLS {
             let host = NWEndpoint.hostPort(host: "one.one.one.one", port: 853)
             let endpoints: [NWEndpoint] = [
                 .hostPort(host: "1.1.1.1", port: 853),

--- a/Sources/AIProxy/AnonymousAccount/AnonymousAccountStorage.swift
+++ b/Sources/AIProxy/AnonymousAccount/AnonymousAccountStorage.swift
@@ -18,10 +18,10 @@ final class AnonymousAccountStorage {
     /// A best-effort anonymous ID that is stable across multiple devices of an iCloud account
     static var resolvedAccount: AnonymousAccount? {
         get {
-            protectedPropertyQueue.sync { _resolvedAccount }
+            ProtectedPropertyQueue.resolvedAccount.sync { _resolvedAccount }
         }
         set {
-            protectedPropertyQueue.async(flags: .barrier) { _resolvedAccount = newValue }
+            ProtectedPropertyQueue.resolvedAccount.async(flags: .barrier) { _resolvedAccount = newValue }
         }
     }
     private static var _resolvedAccount: AnonymousAccount?
@@ -31,6 +31,7 @@ final class AnonymousAccountStorage {
 
     /// This is expected to be called as part of the application launch.
     static func sync() async throws -> String {
+
         #if false
         try await AIProxyStorage.clear()
         #endif

--- a/Sources/AIProxy/ProtectedPropertyQueue.swift
+++ b/Sources/AIProxy/ProtectedPropertyQueue.swift
@@ -17,7 +17,7 @@ internal enum ProtectedPropertyQueue {
         attributes: .concurrent
     )
     static let useStableID = DispatchQueue(
-        label: "aiproxy-caller-use-stable-id",
+        label: "aiproxy-protected-use-stable-id",
         attributes: .concurrent
     )
 }

--- a/Sources/AIProxy/ProtectedPropertyQueue.swift
+++ b/Sources/AIProxy/ProtectedPropertyQueue.swift
@@ -7,7 +7,17 @@
 
 import Foundation
 
-internal let protectedPropertyQueue = DispatchQueue(
-    label: "aiproxy-protected-property-queue",
-    attributes: .concurrent
-)
+internal enum ProtectedPropertyQueue {
+    static let resolvedAccount = DispatchQueue(
+        label: "aiproxy-protected-resolved-account",
+        attributes: .concurrent
+    )
+    static let stableID = DispatchQueue(
+        label: "aiproxy-protected-stable-id",
+        attributes: .concurrent
+    )
+    static let useStableID = DispatchQueue(
+        label: "aiproxy-caller-use-stable-id",
+        attributes: .concurrent
+    )
+}

--- a/Sources/AIProxy/Serializable.swift
+++ b/Sources/AIProxy/Serializable.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Encodable {
     func serialize(pretty: Bool = false) throws -> Data {
-        let pretty = pretty || AIProxy.printRequestBodies
+        let pretty = pretty || AIProxyConfiguration.printRequestBodies
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         if pretty {

--- a/Sources/AIProxy/ServiceMixin.swift
+++ b/Sources/AIProxy/ServiceMixin.swift
@@ -13,21 +13,21 @@ protocol ServiceMixin {
 
 extension ServiceMixin {
     func makeRequestAndDeserializeResponse<T: Decodable>(_ request: URLRequest) async throws -> T {
-        if AIProxy.printRequestBodies {
+        if AIProxyConfiguration.printRequestBodies {
             printRequestBody(request)
         }
         let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
             self.urlSession,
             request
         )
-        if AIProxy.printResponseBodies {
+        if AIProxyConfiguration.printResponseBodies {
             printBufferedResponseBody(data)
         }
         return try T.deserialize(from: data)
     }
 
     func makeRequestAndDeserializeStreamingChunks<T: Decodable>(_ request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
-        if AIProxy.printRequestBodies {
+        if AIProxyConfiguration.printRequestBodies {
             printRequestBody(request)
         }
 
@@ -37,7 +37,7 @@ extension ServiceMixin {
         )
 
         let sequence = asyncBytes.lines.compactMap { (line: String) -> T? in
-            if AIProxy.printResponseBodies {
+            if AIProxyConfiguration.printResponseBodies {
                 printStreamingResponseChunk(line)
             }
             return T.deserialize(fromLine: line)


### PR DESCRIPTION
- There's a report in the wild of multiple `AIProxy.configure` calls causing a bad access when setting up the stable anon identifier.
- The `configure` method now sets up the stable ID only once, regardless of number of times `configure` is called.
- Cleaned up `AIProxy.swift`, the main interface into the lib, by moving some configuration options and protected accessors to `AIProxyConfiguration.swift`
