### PR TITLE
Add support for OpenAI high fidelity image edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,6 @@ This snippet will print out the URL of an image generated with `dall-e-3`:
     } catch {
         print("Could not create OpenAI edit image generation: \(error.localizedDescription)")
     }
-    return
 ```
 
 ### How to upload multiple images for use in an image edit with OpenAI's gpt-image-1

--- a/README.md
+++ b/README.md
@@ -486,7 +486,63 @@ This snippet will print out the URL of an image generated with `dall-e-3`:
     }
 ```
 
-### How to edit an image with OpenAI's gpt-image-1
+### How to make a high fidelity image edit with OpenAI's gpt-image-1
+
+```swift
+    import AIProxy
+
+    /* Uncomment for BYOK use cases */
+    // let openAIService = AIProxy.openAIDirectService(
+    //     unprotectedAPIKey: "your-openai-key"
+    // )
+
+    /* Uncomment for all other production use cases */
+    // let openAIService = AIProxy.openAIService(
+    //     partialKey: "partial-key-from-your-developer-dashboard",
+    //     serviceURL: "service-url-from-your-developer-dashboard"
+    // )
+    let openAIService = getOpenAIService(config)
+
+    guard let image = UIImage(named: "my-image") else {
+        print("Could not find an image named 'my-image' in your app assets")
+        return
+    }
+
+    guard let jpegData = AIProxy.encodeImageAsJpeg(image: image, compressionQuality: 0.5) else {
+        print("Could not encode image as jpeg")
+        return
+    }
+
+    let requestBody = OpenAICreateImageEditRequestBody(
+        images: [.jpeg(jpegData)],
+        prompt: "Change the coffee cup to red",
+        inputFidelity: .high,
+        model: .gptImage1
+    )
+
+    do {
+        let response = try await openAIService.createImageEditRequest(
+            body: requestBody,
+            secondsToWait: 300
+        )
+        guard let base64Data = response.data.first?.b64JSON,
+              let imageData = Data(base64Encoded: base64Data),
+              let editedImage = UIImage(data: imageData) else {
+            print("Could not create a UIImage out of the base64 returned by OpenAI")
+            return
+        }
+
+        // Do something with 'editedImage' here
+
+    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
+        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
+    } catch {
+        print("Could not create OpenAI edit image generation: \(error.localizedDescription)")
+    }
+    return
+```
+
+### How to upload multiple images for use in an image edit with OpenAI's gpt-image-1
 
 - This snippet uploads two images to `gpt-image-1`, transfering the material of one to the other.
 - One image is uploaded as a png and the other as a jpeg.

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.123.0"
+    public static let sdkVersion = "0.124.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/OpenAI/OpenAICreateImageEditRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateImageEditRequestBody.swift
@@ -22,6 +22,16 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
 
     // MARK: Optional properties
 
+    /// Control how much effort the model will exert to match the style and features, especially facial features, of input images.
+    /// This parameter is only supported for gpt-image-1. Supports `high` and `low`. Defaults to `low`.
+    ///
+    /// High input fidelity allows you to make subtle edits to an image without altering unrelated areas.
+    /// This is ideal for controlled, localized changes.
+    ///
+    /// Setting `inputFidelity=.high` is especially useful when editing images with faces, logos, or any other details that require high fidelity in the output.
+    /// Source: https://cookbook.openai.com/examples/generate_images_with_high_input_fidelity
+    public let inputFidelity: InputFidelity?
+
     /// An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where image should be edited.
     /// If there are multiple images provided, the mask will be applied on the first image.
     /// Must be a valid PNG file, less than 4MB, and have the same dimensions as image.
@@ -69,6 +79,7 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
 
         return builder + [
             .textField(name: "prompt", content: self.prompt),
+            self.inputFidelity.flatMap { .textField(name: "input_fidelity", content: $0.rawValue) },
             self.model.flatMap { .textField(name: "model", content: $0.rawValue) },
             self.mask.flatMap { .fileField(name: "mask", content: $0, contentType: "image/png", filename: "tmpfile-mask") },
             self.n.flatMap { .textField(name: "n", content: String($0)) },
@@ -85,6 +96,7 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
     public init(
         images: [OpenAICreateImageEditRequestBody.InputImage],
         prompt: String,
+        inputFidelity: OpenAICreateImageEditRequestBody.InputFidelity? = nil,
         mask: Data? = nil,
         model: OpenAICreateImageEditRequestBody.Model? = nil,
         n: Int? = nil,
@@ -95,6 +107,7 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
     ) {
         self.images = images
         self.prompt = prompt
+        self.inputFidelity = inputFidelity
         self.mask = mask
         self.model = model
         self.n = n
@@ -105,7 +118,14 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
     }
 }
 
+
 extension OpenAICreateImageEditRequestBody {
+
+    public enum InputFidelity: String {
+        case low
+        case high
+    }
+
     public enum InputImage {
         case png(Data)
         case jpeg(Data)

--- a/Tests/AIProxyTests/OpenAIEditImageRequestTests.swift
+++ b/Tests/AIProxyTests/OpenAIEditImageRequestTests.swift
@@ -1,0 +1,61 @@
+//
+//  OpenAIEditImageRequestTests.swift
+//  AIProxy
+//
+//  Created by Lou Zell on 8/4/25.
+//
+
+import XCTest
+@testable import AIProxy
+
+final class OpenAIEditImageRequestTests: XCTestCase {
+
+    func testRequestBodyIsEncodable() throws {
+        let boundary = "my-boundary"
+        let crlf = "\r\n"
+        let image = createImage(width: 1, height: 1)
+        let jpegData = AIProxy.encodeImageAsJpeg(image: image, compressionQuality: 1.0)!
+
+        let requestBody = OpenAICreateImageEditRequestBody(
+            images: [.jpeg(jpegData)],
+            prompt: "Change the boat mast to red",
+            inputFidelity: .high,
+            model: .gptImage1
+        )
+        var expectedEncoding = Data()
+
+        let fileIntro = """
+        --\(boundary)
+        Content-Disposition: form-data; name="image[]"; filename="tmpfile0"
+        Content-Type: image/jpeg
+
+
+        """.replacingOccurrences(of: "\n", with: crlf)
+
+        expectedEncoding.append(Data(fileIntro.utf8))
+        expectedEncoding.append(jpegData)
+        expectedEncoding.append(Data(crlf.utf8))
+
+        let remainingArguments = """
+        --\(boundary)
+        Content-Disposition: form-data; name="prompt"
+
+        Change the boat mast to red
+        --\(boundary)
+        Content-Disposition: form-data; name="input_fidelity"
+
+        high
+        --\(boundary)
+        Content-Disposition: form-data; name="model"
+
+        gpt-image-1
+        --\(boundary)--
+        """.replacingOccurrences(of: "\n", with: crlf)
+        expectedEncoding.append(Data(remainingArguments.utf8))
+
+        XCTAssertEqual(
+            expectedEncoding,
+            formEncode(requestBody, boundary)
+        )
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/lzell/AIProxySwift/issues/200

### How to make a high fidelity image edit with OpenAI's gpt-image-1

```swift
    import AIProxy

    /* Uncomment for BYOK use cases */
    // let openAIService = AIProxy.openAIDirectService(
    //     unprotectedAPIKey: "your-openai-key"
    // )

    /* Uncomment for all other production use cases */
    // let openAIService = AIProxy.openAIService(
    //     partialKey: "partial-key-from-your-developer-dashboard",
    //     serviceURL: "service-url-from-your-developer-dashboard"
    // )
    let openAIService = getOpenAIService(config)

    guard let image = UIImage(named: "my-image") else {
        print("Could not find an image named 'my-image' in your app assets")
        return
    }

    guard let jpegData = AIProxy.encodeImageAsJpeg(image: image, compressionQuality: 0.5) else {
        print("Could not encode image as jpeg")
        return
    }

    let requestBody = OpenAICreateImageEditRequestBody(
        images: [.jpeg(jpegData)],
        prompt: "Change the coffee cup to red",
        inputFidelity: .high,
        model: .gptImage1
    )

    do {
        let response = try await openAIService.createImageEditRequest(
            body: requestBody,
            secondsToWait: 300
        )
        guard let base64Data = response.data.first?.b64JSON,
              let imageData = Data(base64Encoded: base64Data),
              let editedImage = UIImage(data: imageData) else {
            print("Could not create a UIImage out of the base64 returned by OpenAI")
            return
        }

        // Do something with 'editedImage' here

    } catch AIProxyError.unsuccessfulRequest(let statusCode, let responseBody) {
        print("Received non-200 status code: \(statusCode) with response body: \(responseBody)")
    } catch {
        print("Could not create OpenAI edit image generation: \(error.localizedDescription)")
    }
```
