### PR TITLE
Add new 'verbosity' parameter and 'minimal' reasoning effort.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1375,8 +1375,10 @@ Note: there is also a streaming version of this snippet below.
 
     let requestBody = OpenAICreateResponseRequestBody(
         input: .text("hello world"),
-        previousResponseId: nil,  // Pass this in on future requests to save chat history
-        model: "gpt-4o"
+        model: "gpt-5",
+        reasoning: .init(effort: .minimal, summary: .detailed),  // Optional: Use minimal effort with auto summary
+        text: .init(verbosity: .high),                           // Optional: Use low verbosity for concise responses
+        previousResponseId: nil                                  // Pass this in on future requests to save chat history
     )
 
     do {

--- a/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
@@ -587,7 +587,7 @@ extension OpenAICreateResponseRequestBody {
     public struct Reasoning: Encodable {
         private enum CodingKeys: String, CodingKey {
             case effort
-            case generateSummary = "generate_summary"
+            case summary
         }
 
         /// Constrains effort on reasoning for reasoning models.
@@ -595,17 +595,16 @@ extension OpenAICreateResponseRequestBody {
         /// Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
         public let effort: Effort?
 
-        /// computer_use_preview only
         /// A summary of the reasoning performed by the model. This can be useful for debugging and
-        /// understanding the model's reasoning process. One of concise or detailed.
-        public let generateSummary: SummaryType?
+        /// understanding the model's reasoning process. One of auto, concise, or detailed.
+        public let summary: SummaryType?
 
         public init(
             effort: Effort? = nil,
-            generateSummary: SummaryType? = nil
+            summary: SummaryType? = nil
         ) {
             self.effort = effort
-            self.generateSummary = generateSummary
+            self.summary = summary
         }
     }
 }
@@ -614,13 +613,15 @@ extension OpenAICreateResponseRequestBody {
 extension OpenAICreateResponseRequestBody.Reasoning {
     /// Supported effort levels for reasoning models
     public enum Effort: String, Encodable {
+        case minimal
         case low
         case medium
         case high
     }
 
-    /// Summary types for reasoning models with computer use preview
+    /// Summary types for reasoning models
     public enum SummaryType: String, Encodable {
+        case auto
         case concise
         case detailed
     }

--- a/Sources/AIProxy/OpenAI/OpenAIResponseTextConfiguration.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponseTextConfiguration.swift
@@ -10,8 +10,30 @@ extension OpenAIResponse {
         /// The format specification for the text output
         public let format: Format?
 
-        public init(format: Format) {
+        /// Constrains the verbosity of the model's response. Lower values will result in more concise responses,
+        /// while higher values will result in more verbose responses. Currently supported values are low, medium, and high.
+        public let verbosity: Verbosity?
+
+        private enum CodingKeys: String, CodingKey {
+            case format
+            case verbosity
+        }
+
+        public init(format: Format? = nil, verbosity: Verbosity? = nil) {
             self.format = format
+            self.verbosity = verbosity
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(format, forKey: .format)
+            try container.encodeIfPresent(verbosity, forKey: .verbosity)
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            format = try container.decodeIfPresent(Format.self, forKey: .format)
+            verbosity = try container.decodeIfPresent(Verbosity.self, forKey: .verbosity)
         }
     }
 }
@@ -117,5 +139,12 @@ extension OpenAIResponse.TextConfiguration {
                 )
             }
         }
+    }
+
+    /// Supported verbosity levels for model responses
+    public enum Verbosity: String, Codable {
+        case low
+        case medium
+        case high
     }
 }

--- a/Tests/AIProxyTests/OpenAICreateResponseRequestTests.swift
+++ b/Tests/AIProxyTests/OpenAICreateResponseRequestTests.swift
@@ -229,5 +229,95 @@ final class OpenAICreateResponseRequestTests: XCTestCase {
         )
     }
 
+    func testResponseRequestWithMinimalReasoningEffort() throws {
+        let requestBody = OpenAICreateResponseRequestBody(
+            input: .text("Explain quantum physics"),
+            model: "o1-mini",
+            reasoning: .init(effort: .minimal)
+        )
+        
+        XCTAssertEqual(
+            """
+            {
+              "input" : "Explain quantum physics",
+              "model" : "o1-mini",
+              "reasoning" : {
+                "effort" : "minimal"
+              }
+            }
+            """,
+            try requestBody.serialize(pretty: true)
+        )
+    }
+
+    func testResponseRequestWithVerbosity() throws {
+        let requestBody = OpenAICreateResponseRequestBody(
+            input: .text("Write a short story"),
+            model: "gpt-4o",
+            text: .init(verbosity: .low)
+        )
+        
+        XCTAssertEqual(
+            """
+            {
+              "input" : "Write a short story",
+              "model" : "gpt-4o",
+              "text" : {
+                "verbosity" : "low"
+              }
+            }
+            """,
+            try requestBody.serialize(pretty: true)
+        )
+    }
+
+    func testResponseRequestWithReasoningSummary() throws {
+        let requestBody = OpenAICreateResponseRequestBody(
+            input: .text("Explain your reasoning"),
+            model: "o1",
+            reasoning: .init(effort: .high, summary: .detailed)
+        )
+        
+        XCTAssertEqual(
+            """
+            {
+              "input" : "Explain your reasoning",
+              "model" : "o1",
+              "reasoning" : {
+                "effort" : "high",
+                "summary" : "detailed"
+              }
+            }
+            """,
+            try requestBody.serialize(pretty: true)
+        )
+    }
+
+    func testResponseRequestWithAllNewFeatures() throws {
+        let requestBody = OpenAICreateResponseRequestBody(
+            input: .text("Solve this complex problem with full detail"),
+            model: "o1",
+            reasoning: .init(effort: .minimal, summary: .auto),
+            text: .init(verbosity: .high)
+        )
+        
+        XCTAssertEqual(
+            """
+            {
+              "input" : "Solve this complex problem with full detail",
+              "model" : "o1",
+              "reasoning" : {
+                "effort" : "minimal",
+                "summary" : "auto"
+              },
+              "text" : {
+                "verbosity" : "high"
+              }
+            }
+            """,
+            try requestBody.serialize(pretty: true)
+        )
+    }
+
 }
 


### PR DESCRIPTION
* Add new OpenAI Responses API parameters

- Add 'minimal' to reasoning effort levels (minimal, low, medium, high)
- Add verbosity control to text configuration (low, medium, high)
- Replace deprecated generateSummary with summary parameter (auto, concise, detailed)

🤖 Generated with [Claude Code](https://claude.ai/code)
