### PR TITLE
Add support for updated Web Search tooling

### DIFF
--- a/Sources/AIProxy/OpenAI/OpenAIResponse.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponse.swift
@@ -339,6 +339,18 @@ extension OpenAIResponse {
         public var type = "web_search_call"
         public let id: String
         public let status: String
+        public let action: WebSearchAction?
+
+        public struct WebSearchAction: Decodable {
+            public let type: String
+            public let query: String?
+            public let sources: [WebSearchSource]?
+        }
+
+        public struct WebSearchSource: Decodable {
+            public let type: String
+            public let url: String
+        }
     }
 
     // MARK: - File Search Call


### PR DESCRIPTION
Added support for the newer version of the built-in OpenAI Web Search tool:

- Updated .webSearch tooling to send the newer `web_search` tool
- Created .webSearchPreview (deprecated) to support older models.  Still uses `web_search_preview`

The new tooling returns search results in a different way (at least in the GPT-5 models):

- Added support for the `include` parameter on OpenAICreateResponseRequestBody, to inform the tool to return search results
- *New* This also enables the search query to be retrieved 👍


This PR addresses issue https://github.com/lzell/AIProxySwift/issues/212
