### PR TITLE
Add background option to OpenAI's edit image

### DIFF
--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    public static let sdkVersion = "0.127.0"
+    public static let sdkVersion = "0.128.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/OpenAI/OpenAICreateImageEditRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateImageEditRequestBody.swift
@@ -22,6 +22,14 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
 
     // MARK: Optional properties
 
+    /// Allows to set transparency for the background of the generated image(s).
+    /// This parameter is only supported for `gpt-image-1`.
+    /// Must be one of `.transparent`, `.opaque` or `.auto` (default value).
+    /// When `.auto` is used, the model will automatically determine the best background for the image.
+    ///
+    /// If `.transparent`, the `outputFormat` needs to support transparency, so it should be set to either `.png` (default value) or `.webp`
+    public let background: Background?
+
     /// Control how much effort the model will exert to match the style and features, especially facial features, of input images.
     /// This parameter is only supported for gpt-image-1. Supports `high` and `low`. Defaults to `low`.
     ///
@@ -43,6 +51,12 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
 
     /// The number of images to generate. Must be between 1 and 10.
     public let n: Int?
+
+    /// The format in which the generated images are returned.
+    /// This parameter is only supported for `gpt-image-1`.
+    /// Must be one of `.png`, `.jpeg`, or `.webp`.
+    /// The default value is `.png`
+    public let outputFormat: OutputFormat?
 
     /// The quality of the image that will be generated.
     /// high, medium and low are only supported for gpt-image-1.
@@ -79,10 +93,12 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
 
         return builder + [
             .textField(name: "prompt", content: self.prompt),
+            self.background.flatMap { .textField(name: "background", content: $0.rawValue) },
             self.inputFidelity.flatMap { .textField(name: "input_fidelity", content: $0.rawValue) },
             self.model.flatMap { .textField(name: "model", content: $0.rawValue) },
             self.mask.flatMap { .fileField(name: "mask", content: $0, contentType: "image/png", filename: "tmpfile-mask") },
             self.n.flatMap { .textField(name: "n", content: String($0)) },
+            self.outputFormat.flatMap { .textField(name: "output_format", content: $0.rawValue) },
             self.quality.flatMap { .textField(name: "quality", content: $0.rawValue) },
             self.responseFormat.flatMap { .textField(name: "response_format", content: $0.rawValue) },
             self.size.flatMap { .textField(name: "size", content: $0) },
@@ -96,10 +112,12 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
     public init(
         images: [OpenAICreateImageEditRequestBody.InputImage],
         prompt: String,
+        background: Background? = nil,
         inputFidelity: OpenAICreateImageEditRequestBody.InputFidelity? = nil,
         mask: Data? = nil,
         model: OpenAICreateImageEditRequestBody.Model? = nil,
         n: Int? = nil,
+        outputFormat: OutputFormat? = nil,
         quality: OpenAICreateImageEditRequestBody.Quality? = nil,
         responseFormat: OpenAICreateImageEditRequestBody.ResponseFormat? = nil,
         size: String? = nil,
@@ -107,10 +125,12 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
     ) {
         self.images = images
         self.prompt = prompt
+        self.background = background
         self.inputFidelity = inputFidelity
         self.mask = mask
         self.model = model
         self.n = n
+        self.outputFormat = outputFormat
         self.quality = quality
         self.responseFormat = responseFormat
         self.size = size
@@ -120,6 +140,12 @@ public struct OpenAICreateImageEditRequestBody: MultipartFormEncodable {
 
 
 extension OpenAICreateImageEditRequestBody {
+
+    public enum Background: String {
+        case auto
+        case opaque
+        case transparent
+    }
 
     public enum InputFidelity: String {
         case low
@@ -150,6 +176,12 @@ extension OpenAICreateImageEditRequestBody {
     public enum Model: String, Encodable {
         case dallE2 = "dall-e-2"
         case gptImage1 = "gpt-image-1"
+    }
+
+    public enum OutputFormat: String {
+        case jpeg
+        case png
+        case webp
     }
 
     public enum Quality: String, Encodable {

--- a/Tests/AIProxyTests/OpenAIEditImageRequestTests.swift
+++ b/Tests/AIProxyTests/OpenAIEditImageRequestTests.swift
@@ -19,8 +19,10 @@ final class OpenAIEditImageRequestTests: XCTestCase {
         let requestBody = OpenAICreateImageEditRequestBody(
             images: [.jpeg(jpegData)],
             prompt: "Change the boat mast to red",
+            background: .transparent,
             inputFidelity: .high,
-            model: .gptImage1
+            model: .gptImage1,
+            outputFormat: .png
         )
         var expectedEncoding = Data()
 
@@ -42,6 +44,10 @@ final class OpenAIEditImageRequestTests: XCTestCase {
 
         Change the boat mast to red
         --\(boundary)
+        Content-Disposition: form-data; name="background"
+
+        transparent
+        --\(boundary)
         Content-Disposition: form-data; name="input_fidelity"
 
         high
@@ -49,6 +55,10 @@ final class OpenAIEditImageRequestTests: XCTestCase {
         Content-Disposition: form-data; name="model"
 
         gpt-image-1
+        --\(boundary)
+        Content-Disposition: form-data; name="output_format"
+
+        png
         --\(boundary)--
         """.replacingOccurrences(of: "\n", with: crlf)
         expectedEncoding.append(Data(remainingArguments.utf8))


### PR DESCRIPTION
Image edits can produce transparent background using `gpt-image-1`. For example:

```swift
        let requestBody = OpenAICreateImageEditRequestBody(
            images: [.jpeg(myImageData)],
            prompt: "Change the coffee cup to red",
            background: .transparent,
            inputFidelity: .high,
            model: .gptImage1,
            outputFormat: .png
        )
```