### PR TITLE
Rename OpenAIRequestBuilder -> AIProxyRequestBuilder

### DIFF
--- a/Sources/AIProxy/AIProxyRequestBuilder.swift
+++ b/Sources/AIProxy/AIProxyRequestBuilder.swift
@@ -7,9 +7,7 @@
 
 import Foundation
 
-// TODO: Rename this to AIProxyRequestBuilder.
-//       It's generic enough for other services
-@AIProxyActor internal protocol OpenAIRequestBuilder: Sendable {
+@AIProxyActor internal protocol AIProxyRequestBuilder: Sendable {
 
     func jsonPOST(
         path: String,
@@ -35,7 +33,7 @@ import Foundation
     ) async throws -> URLRequest
 }
 
-extension OpenAIRequestBuilder {
+extension AIProxyRequestBuilder {
     func jsonPOST(
         path: String,
         body: Encodable,

--- a/Sources/AIProxy/EachAI/EachAIService.swift
+++ b/Sources/AIProxy/EachAI/EachAIService.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 @AIProxyActor public class EachAIService: Sendable {
-    private let requestBuilder: OpenAIRequestBuilder
+    private let requestBuilder: AIProxyRequestBuilder
     private let serviceNetworker: ServiceMixin
 
     /// This designated initializer is not public on purpose.
     /// Customers are expected to use the factory `AIProxy.eachAIService` or `AIProxy.directEachAIService` defined in AIProxy.swift.
     nonisolated init(
-        requestBuilder: OpenAIRequestBuilder,
+        requestBuilder: AIProxyRequestBuilder,
         serviceNetworker: ServiceMixin
     ) {
         self.requestBuilder = requestBuilder

--- a/Sources/AIProxy/OpenAI/OpenAIDirectRequestBuilder.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIDirectRequestBuilder.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@AIProxyActor struct OpenAIDirectRequestBuilder: OpenAIRequestBuilder {
+@AIProxyActor struct OpenAIDirectRequestBuilder: AIProxyRequestBuilder {
     let baseURL: String
     let unprotectedAuthHeader: (key: String, value: String)
 

--- a/Sources/AIProxy/OpenAI/OpenAIProxiedRequestBuilder.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIProxiedRequestBuilder.swift
@@ -9,7 +9,7 @@ import Foundation
 
 nonisolated private let legacyURL = "https://api.aiproxy.pro"
 
-@AIProxyActor struct OpenAIProxiedRequestBuilder: OpenAIRequestBuilder {
+@AIProxyActor struct OpenAIProxiedRequestBuilder: AIProxyRequestBuilder {
     let partialKey: String
     let serviceURL: String?
     let clientID: String?

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -9,14 +9,14 @@ import Foundation
 
 @AIProxyActor public class OpenAIService: Sendable {
     private let requestFormat: OpenAIRequestFormat
-    private let requestBuilder: OpenAIRequestBuilder
+    private let requestBuilder: AIProxyRequestBuilder
     private let serviceNetworker: ServiceMixin
 
     /// This designated initializer is not public on purpose.
     /// Customers are expected to use the factory `AIProxy.openAIService` or `AIProxy.directOpenAIService` defined in AIProxy.swift.
     nonisolated init(
         requestFormat: OpenAIRequestFormat,
-        requestBuilder: OpenAIRequestBuilder,
+        requestBuilder: AIProxyRequestBuilder,
         serviceNetworker: ServiceMixin
     ) {
         self.requestFormat = requestFormat


### PR DESCRIPTION
This type is generic enough to be used in multiple places (and already is used between OpenAI and EachAI)