### PR TITLE
Rename Direct and Proxied request builders

### DIFF
--- a/Sources/AIProxy/AIProxyDirectRequestBuilder.swift
+++ b/Sources/AIProxy/AIProxyDirectRequestBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  OpenAIDirectRequestBuilder.swift
+//  AIProxyDirectRequestBuilder.swift
 //  AIProxy
 //
 //  Created by Lou Zell on 7/12/25.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@AIProxyActor struct OpenAIDirectRequestBuilder: AIProxyRequestBuilder {
+@AIProxyActor struct AIProxyDirectRequestBuilder: AIProxyRequestBuilder {
     let baseURL: String
     let unprotectedAuthHeader: (key: String, value: String)
 

--- a/Sources/AIProxy/AIProxyProxiedRequestBuilder.swift
+++ b/Sources/AIProxy/AIProxyProxiedRequestBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  OpenAIProxiedRequestBuilder.swift
+//  AIProxyProxiedRequestBuilder.swift
 //  AIProxy
 //
 //  Created by Lou Zell on 7/12/25.
@@ -9,7 +9,7 @@ import Foundation
 
 nonisolated private let legacyURL = "https://api.aiproxy.pro"
 
-@AIProxyActor struct OpenAIProxiedRequestBuilder: AIProxyRequestBuilder {
+@AIProxyActor struct AIProxyProxiedRequestBuilder: AIProxyRequestBuilder {
     let partialKey: String
     let serviceURL: String?
     let clientID: String?

--- a/Sources/AIProxy/AIProxyRequestBuilder.swift
+++ b/Sources/AIProxy/AIProxyRequestBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  OpenAIRequestBuilder.swift
+//  AIProxyRequestBuilder.swift
 //  AIProxy
 //
 //  Created by Lou Zell on 7/12/25.

--- a/Sources/AIProxy/EachAI/EachAIDirectService.swift
+++ b/Sources/AIProxy/EachAI/EachAIDirectService.swift
@@ -13,7 +13,7 @@ import Foundation
     nonisolated init(
         unprotectedAPIKey: String
     ) {
-        let requestBuilder = OpenAIDirectRequestBuilder(
+        let requestBuilder = AIProxyDirectRequestBuilder(
             baseURL: "https://flows.eachlabs.ai", // EachAI has different baseURLs depending on which functionality you want to use.
             unprotectedAuthHeader: (key: "X-API-Key", value: unprotectedAPIKey)
         )

--- a/Sources/AIProxy/EachAI/EachAIProxiedService.swift
+++ b/Sources/AIProxy/EachAI/EachAIProxiedService.swift
@@ -15,7 +15,7 @@ import Foundation
         serviceURL: String,
         clientID: String?
     ) {
-        let requestBuilder = OpenAIProxiedRequestBuilder(
+        let requestBuilder = AIProxyProxiedRequestBuilder(
             partialKey: partialKey,
             serviceURL: serviceURL,
             clientID: clientID

--- a/Sources/AIProxy/OpenAI/OpenAIDirectService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIDirectService.swift
@@ -14,7 +14,7 @@
         baseURL: String? = nil
     ) {
         let baseURL = baseURL ?? "https://api.openai.com"
-        let requestBuilder = OpenAIDirectRequestBuilder(
+        let requestBuilder = AIProxyDirectRequestBuilder(
             baseURL: baseURL,
             unprotectedAuthHeader: (key: "Authorization", value: "Bearer \(unprotectedAPIKey)")
         )

--- a/Sources/AIProxy/OpenAI/OpenAIProxiedService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIProxiedService.swift
@@ -13,7 +13,7 @@
         clientID: String?,
         requestFormat: OpenAIRequestFormat = .standard
     ) {
-        let requestBuilder = OpenAIProxiedRequestBuilder(
+        let requestBuilder = AIProxyProxiedRequestBuilder(
             partialKey: partialKey,
             serviceURL: serviceURL,
             clientID: clientID


### PR DESCRIPTION
These types are generic enough for general use, not limited to OpenAI