### PR TITLE
Also parse call ID from responseFunctionCallArgumentsDone event

### DIFF
--- a/Sources/AIProxy/OpenAI/OpenAIRealtimeMessage.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRealtimeMessage.swift
@@ -12,7 +12,7 @@ nonisolated public enum OpenAIRealtimeMessage: Sendable {
     case responseCreated // "response.created"
     case responseAudioDelta(String) // "response.audio.delta"
     case inputAudioBufferSpeechStarted // "input_audio_buffer.speech_started"
-    case responseFunctionCallArgumentsDone(String, String) // "response.function_call_arguments.done"
+    case responseFunctionCallArgumentsDone(String, String, String) // "response.function_call_arguments.done"
     
     // Add new cases for transcription
     case responseTranscriptDelta(String) // "response.audio_transcript.delta"

--- a/Sources/AIProxy/OpenAI/OpenAIRealtimeSession.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRealtimeSession.swift
@@ -153,8 +153,9 @@ nonisolated private let kWebsocketDisconnectedEarlyThreshold: TimeInterval = 3
             self.continuation?.yield(.inputAudioBufferSpeechStarted)
         case "response.function_call_arguments.done":
             if let name = json["name"] as? String,
-               let arguments = json["arguments"] as? String {
-                self.continuation?.yield(.responseFunctionCallArgumentsDone(name, arguments))
+               let arguments = json["arguments"] as? String,
+               let callId = json["call_id"] as? String {
+                self.continuation?.yield(.responseFunctionCallArgumentsDone(name, arguments, callId))
             }
         
         // New cases for handling transcription messages


### PR DESCRIPTION
The `call_id` parameter is required to be able to respond to the function call later. That's why it should be part of the `responseFunctionCallArgumentsDone` case.