### PR TITLE
Add cached prompt token count to responses object

### DIFF
--- a/Sources/AIProxy/OpenAI/OpenAIResponse.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponse.swift
@@ -266,6 +266,14 @@ extension OpenAIResponse {
         case required = "required"
     }
 
+    nonisolated public struct InputTokensDetails: Decodable, Sendable {
+        public let cachedTokens: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case cachedTokens = "cached_tokens"
+        }
+    }
+
     nonisolated public struct OutputTokensDetails: Decodable, Sendable {
         public let reasoningTokens: Int
 
@@ -276,12 +284,14 @@ extension OpenAIResponse {
 
     nonisolated public struct ResponseUsage: Decodable, Sendable {
         public let inputTokens: Int?
+        public let inputTokensDetails: InputTokensDetails?
         public let outputTokens: Int?
         public let outputTokensDetails: OutputTokensDetails?
         public let totalTokens: Int?
 
         private enum CodingKeys: String, CodingKey {
             case inputTokens = "input_tokens"
+            case inputTokensDetails = "input_tokens_details"
             case outputTokens = "output_tokens"
             case outputTokensDetails = "output_tokens_details"
             case totalTokens = "total_tokens"

--- a/Tests/AIProxyTests/OpenAIResponseObjectTests.swift
+++ b/Tests/AIProxyTests/OpenAIResponseObjectTests.swift
@@ -130,6 +130,7 @@ final class OpenAIResponseObjectTests: XCTestCase {
         XCTAssertEqual(1.0, res.topP)
         XCTAssertEqual("disabled", res.truncation)
         XCTAssertEqual(26, res.usage?.inputTokens)
+        XCTAssertEqual(0, res.usage?.inputTokensDetails?.cachedTokens)
         XCTAssertEqual(10, res.usage?.outputTokens)
         XCTAssertEqual(0, res.usage?.outputTokensDetails?.reasoningTokens)
         XCTAssertEqual(36, res.usage?.totalTokens)


### PR DESCRIPTION
Addresses https://github.com/lzell/AIProxySwift/issues/228

Cached prompt token count is available on the OpenAI response object with the following access pattern:
`response.usage?.inputTokensDetails?.cachedTokens`