### PR TITLE
Fix for Audio Engine Crash 

### DIFF
--- a/Sources/AIProxy/MicrophonePCMSampleVendorAE.swift
+++ b/Sources/AIProxy/MicrophonePCMSampleVendorAE.swift
@@ -33,8 +33,6 @@ import Foundation
 /// Apple sample code: https://developer.apple.com/documentation/avfaudio/using-voice-processing
 /// Apple technical note: https://developer.apple.com/documentation/technotes/tn3136-avaudioconverter-performing-sample-rate-conversions
 /// My apple forum question: https://developer.apple.com/forums/thread/771530
-
-
 @AIProxyActor class MicrophonePCMSampleVendorAE: MicrophonePCMSampleVendor {
     private let audioEngine: AVAudioEngine
     private let inputNode: AVAudioInputNode


### PR DESCRIPTION
### tl;dr
- Fixes a crash as described in https://github.com/lzell/AIProxySwift/issues/236 that occurred when using the Audio Engine handling for Microphone input

### Problem Description
- The `installTap(onBus:...)` closure was executed by Core Audio on a high-priority background thread (`RealtimeMessenger.mServiceQueue`). However, because the closure was defined inside an `@AIProxyActor`-isolated method (`start()`), the Swift compiler implicitly attributed the closure itself to the actor's isolation context
- When Core Audio invoked the callback on its background thread, the Swift runtime detected a mismatch between the expected Actor and the actual executor (the background thread), triggering a fatal error
- Simply wrapping the body in `Task { ... }` was insufficient because the isolation check occurred at the closure entry point before the task creation code could run

### Solution
- Introduced a nonisolated helper method, `installTapNonIsolated`, to handle the tap installation
- By moving the `installTap` call into a nonisolated context, the closure defined inside it is guaranteed to be non-isolated
- Prevents the compiler from inserting the actor isolation check at the closure entry
- Inside the safe closure, we explicitly hop back to the actor using `Task { await self.processBuffer(...) }` to safely handle the audio processing

### Changes
- Added `nonisolated private func installTapNonIsolated(...)`
- Added `private func processBuffer(...)` to handle the actor-isolated processing logic
- Updated `start()` to delegate tap installation to the non-isolated helper
