### PR TITLE
Fix URLSession memory leak

### DIFF
--- a/AIProxy.podspec
+++ b/AIProxy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AIProxy'
-  s.version      = '0.145.0'
+  s.version      = '0.145.1'
   s.summary      = 'AIProxy Swift SDK for secure AI integrations'
   s.description  = 'Access OpenAI, Anthropic, and other AI providers securely without exposing API keys in your app. See https://www.aiproxy.com for more'
   s.homepage     = 'https://github.com/lzell/AIProxySwift'

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -195,7 +195,7 @@ public enum AIProxy {
 
     /// Returns a URLSession for communication with AIProxy.
     nonisolated public static func session() -> URLSession {
-        return AIProxyURLSession.create()
+        return AIProxyURLSession.urlSession
     }
 
     /// AIProxy's OpenAI service

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    nonisolated public static let sdkVersion = "0.145.0"
+    nonisolated public static let sdkVersion = "0.145.1"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/AIProxyURLSession.swift
+++ b/Sources/AIProxy/AIProxyURLSession.swift
@@ -10,12 +10,10 @@ import Foundation
 nonisolated public enum AIProxyURLSession {
     public static let delegate = AIProxyCertificatePinningDelegate()
 
-    /// Creates a URLSession that is configured for communication with aiproxy.com
-    static func create() -> URLSession {
-        return URLSession(
-            configuration: .ephemeral,
-            delegate: self.delegate,
-            delegateQueue: nil
-        )
-    }
+    /// A URLSession that is configured for communication with aiproxy.com
+    static let urlSession = URLSession(
+        configuration: .ephemeral,
+        delegate: delegate,
+        delegateQueue: nil
+    )
 }

--- a/Sources/AIProxy/AIProxyUtils.swift
+++ b/Sources/AIProxy/AIProxyUtils.swift
@@ -26,13 +26,11 @@ import Network
 
 enum AIProxyUtils {
 
-    nonisolated static func directURLSession() -> URLSession {
-        return URLSession(
-            configuration: .ephemeral,
-            delegate: DirectURLSessionDataDelegate(),
-            delegateQueue: nil
-        )
-    }
+    nonisolated static let directURLSession = URLSession(
+        configuration: .ephemeral,
+        delegate: DirectURLSessionDataDelegate(),
+        delegateQueue: nil
+    )
 
     nonisolated static func proxiedURLSession() -> URLSession {
         if AIProxy.resolveDNSOverTLS {
@@ -48,7 +46,7 @@ enum AIProxyUtils {
                 fallbackResolver: .tls(host, serverAddresses: endpoints)
             )
         }
-        return AIProxyURLSession.create()
+        return AIProxyURLSession.urlSession
     }
 
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)

--- a/Sources/AIProxy/DirectService.swift
+++ b/Sources/AIProxy/DirectService.swift
@@ -11,6 +11,6 @@ import Foundation
 
 extension DirectService {
     var urlSession: URLSession {
-        return AIProxyUtils.directURLSession()
+        return AIProxyUtils.directURLSession
     }
 }

--- a/Sources/AIProxy/OpenAI/OpenAIModerationRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIModerationRequestBody.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Docstrings from https://platform.openai.com/docs/api-reference/moderations/create
-nonisolated public struct OpenAIModerationRequestBody: Encodable {
+nonisolated public struct OpenAIModerationRequestBody: Encodable, Sendable {
     /// An array of multi-modal inputs to classify.
     public let input: [ModerationInput]
 

--- a/Tests/AIProxyTests/URLSessionTests.swift
+++ b/Tests/AIProxyTests/URLSessionTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+import Foundation
+@testable import AIProxy
+
+#if false // Flip to true and enter your OpenAI API key to test this
+
+final class URLSessionTests: XCTestCase {
+    /// This reproduces a URLSession memory leak and exception, unless the issue has been fixed:
+    /// https://github.com/lzell/AIProxySwift/issues/262
+    func testURLSessionMemoryLeak() async throws {
+        let openAIKey = "" // Enter your OpenAI API key here
+        let openAIService = AIProxy.openAIDirectService(unprotectedAPIKey: openAIKey)
+        
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for i in 1...1000 {
+                if i >= 12 { try await group.next() } // Limit number of parallel requests
+                
+                group.addTask {
+                    let requestBody = OpenAIModerationRequestBody(
+                        input: [.text("is this bad \(i)")],
+                        model: "omni-moderation-latest"
+                    )
+                    _ = try await openAIService.moderationRequest(body: requestBody, secondsToWait: 60)
+                    print("Received response for #\(i)")
+                }
+            }
+            
+            try await group.waitForAll()
+        }
+    }
+}
+
+#endif

--- a/Tests/AIProxyTests/URLSessionTests.swift
+++ b/Tests/AIProxyTests/URLSessionTests.swift
@@ -13,7 +13,7 @@ final class URLSessionTests: XCTestCase {
         
         try await withThrowingTaskGroup(of: Void.self) { group in
             for i in 1...1000 {
-                if i >= 12 { try await group.next() } // Limit number of parallel requests
+                if i > 12 { try await group.next() } // Limit number of parallel requests
                 
                 group.addTask {
                     let requestBody = OpenAIModerationRequestBody(


### PR DESCRIPTION
Fixes issue https://github.com/lzell/AIProxySwift/issues/262 and includes a unit test for verification.

Also makes OpenAIModerationRequestBody `Sendable` because I stumbled across that.