### PR TITLE
Add OpenAI Realtime and transcription usage parity

### DIFF
--- a/Sources/AIProxy/OpenAI/OpenAICreateTranscriptionRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateTranscriptionRequestBody.swift
@@ -9,11 +9,13 @@ import Foundation
 
 /// Request body for the 'Create transcription' endpoint:
 /// https://platform.openai.com/docs/api-reference/audio/createTranscription
+///
+/// This type models the core request fields exposed by AIProxySwift for the transcription API.
 nonisolated public struct OpenAICreateTranscriptionRequestBody: MultipartFormEncodable {
     /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
     public let file: Data
 
-    /// ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.
+    /// ID of the model to use, for example `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-transcribe-diarize`, or `whisper-1`.
     public let model: String
 
     // MARK: Optional properties
@@ -24,9 +26,28 @@ nonisolated public struct OpenAICreateTranscriptionRequestBody: MultipartFormEnc
     /// An optional text to guide the model's style or continue a previous audio segment. The prompt should match the audio language.
     public let prompt: String?
 
-    /// Set this to `verbose_json` to create a transcription object with metadata.
-    /// The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.
+    /// The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, `vtt`, or `diarized_json`.
+    /// Some models restrict which response formats are accepted.
     public let responseFormat: String?
+
+    /// If set to true, OpenAI streams transcription events using server-sent events.
+    /// Prefer `OpenAIService.streamingTranscriptionRequest` when consuming streamed transcriptions.
+    public var stream: Bool?
+
+    /// Controls how the audio is split into chunks before transcription.
+    /// Required by `gpt-4o-transcribe-diarize` for inputs longer than 30 seconds.
+    public let chunkingStrategy: ChunkingStrategy?
+
+    /// Additional information to include in the transcription response.
+    /// `logprobs` is currently returned on `json` responses for supported `gpt-4o-transcribe` models.
+    public let include: [IncludeField]?
+
+    /// Optional speaker labels that correspond to `knownSpeakerReferences`.
+    /// Up to four speakers are supported by OpenAI.
+    public let knownSpeakerNames: [String]?
+
+    /// Optional data URLs containing 2-10 second speaker audio samples matching `knownSpeakerNames`.
+    public let knownSpeakerReferences: [String]?
 
     /// The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower
     /// values like 0.2 will make it more focused and deterministic. If set to 0, the model will use log probability to automatically
@@ -46,8 +67,43 @@ nonisolated public struct OpenAICreateTranscriptionRequestBody: MultipartFormEnc
             self.language.flatMap { .textField(name: "language", content: $0)},
             self.prompt.flatMap { .textField(name: "prompt", content: $0)},
             self.responseFormat.flatMap { .textField(name: "response_format", content: $0)},
-            self.temperature.flatMap { .textField(name: "temperature", content: String($0))},
+            self.stream.flatMap { .textField(name: "stream", content: $0 ? "true" : "false")},
+            self.chunkingStrategy.flatMap { .textField(name: "chunking_strategy", content: $0.formValue)},
+            self.temperature.flatMap { .textField(name: "temperature", content: String($0))}
         ].compactMap { $0 }
+
+        if let include {
+            for includeField in include {
+                fields.append(
+                    .textField(
+                        name: "include[]",
+                        content: includeField.rawValue
+                    )
+                )
+            }
+        }
+
+        if let knownSpeakerNames {
+            for knownSpeakerName in knownSpeakerNames {
+                fields.append(
+                    .textField(
+                        name: "known_speaker_names[]",
+                        content: knownSpeakerName
+                    )
+                )
+            }
+        }
+
+        if let knownSpeakerReferences {
+            for knownSpeakerReference in knownSpeakerReferences {
+                fields.append(
+                    .textField(
+                        name: "known_speaker_references[]",
+                        content: knownSpeakerReference
+                    )
+                )
+            }
+        }
 
         if let timestampGranularities = self.timestampGranularities {
             for timestampGranularity in timestampGranularities {
@@ -71,6 +127,11 @@ nonisolated public struct OpenAICreateTranscriptionRequestBody: MultipartFormEnc
         language: String? = nil,
         prompt: String? = nil,
         responseFormat: String? = nil,
+        stream: Bool? = nil,
+        chunkingStrategy: ChunkingStrategy? = nil,
+        include: [IncludeField]? = nil,
+        knownSpeakerNames: [String]? = nil,
+        knownSpeakerReferences: [String]? = nil,
         temperature: Double? = nil,
         timestampGranularities: [TimestampGranularity]? = nil
     ) {
@@ -79,8 +140,64 @@ nonisolated public struct OpenAICreateTranscriptionRequestBody: MultipartFormEnc
         self.language = language
         self.prompt = prompt
         self.responseFormat = responseFormat
+        self.stream = stream
+        self.chunkingStrategy = chunkingStrategy
+        self.include = include
+        self.knownSpeakerNames = knownSpeakerNames
+        self.knownSpeakerReferences = knownSpeakerReferences
         self.temperature = temperature
         self.timestampGranularities = timestampGranularities
+    }
+}
+
+// MARK: -
+extension OpenAICreateTranscriptionRequestBody {
+    nonisolated public enum ChunkingStrategy: Sendable {
+        case auto
+        case serverVAD(ServerVADConfiguration)
+
+        fileprivate var formValue: String {
+            switch self {
+            case .auto:
+                return "auto"
+            case .serverVAD(let configuration):
+                return configuration.formValue
+            }
+        }
+    }
+
+    nonisolated public struct ServerVADConfiguration: Sendable {
+        public let prefixPaddingMs: Int?
+        public let silenceDurationMs: Int?
+        public let threshold: Double?
+
+        public init(
+            prefixPaddingMs: Int? = nil,
+            silenceDurationMs: Int? = nil,
+            threshold: Double? = nil
+        ) {
+            self.prefixPaddingMs = prefixPaddingMs
+            self.silenceDurationMs = silenceDurationMs
+            self.threshold = threshold
+        }
+
+        fileprivate var formValue: String {
+            var fields = [#""type":"server_vad""#]
+            if let prefixPaddingMs {
+                fields.append(#""prefix_padding_ms":\#(prefixPaddingMs)"#)
+            }
+            if let silenceDurationMs {
+                fields.append(#""silence_duration_ms":\#(silenceDurationMs)"#)
+            }
+            if let threshold {
+                fields.append(#""threshold":\#(threshold)"#)
+            }
+            return "{\(fields.joined(separator: ","))}"
+        }
+    }
+
+    nonisolated public enum IncludeField: String, Sendable {
+        case logprobs
     }
 }
 

--- a/Sources/AIProxy/OpenAI/OpenAICreateTranscriptionResponseBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateTranscriptionResponseBody.swift
@@ -10,11 +10,14 @@ import Foundation
 /// The response body for create transcription requests.
 ///
 /// This object is deserialized from one of:
-///   - https://platform.openai.com/docs/api-reference/audio/verbose-json-object
 ///   - https://platform.openai.com/docs/api-reference/audio/json-object
+///   - https://platform.openai.com/docs/api-reference/audio/verbose-json-object
+///   - a `diarized_json` response from https://platform.openai.com/docs/api-reference/audio/createTranscription
 ///
-/// If you would like all properties to be populated, make sure to set the response format to `verbose_json` when you
-/// create the request body. See the docstring on `OpenAICreateTranscriptionRequestBody` for details.
+/// Different response formats populate different fields:
+/// - `json`: `text`, optional `usage`, and optional `logprobs` when requested via `include[]=logprobs`
+/// - `verbose_json`: `text`, `language`, `duration`, optional `words`, optional `segments`, and optional duration usage
+/// - `diarized_json`: `text`, `duration`, optional `diarizedSegments`, and optional duration usage
 nonisolated public struct OpenAICreateTranscriptionResponseBody: Decodable, Sendable {
     public let text: String
 
@@ -30,12 +33,34 @@ nonisolated public struct OpenAICreateTranscriptionResponseBody: Decodable, Send
     /// Segments of the transcribed text and their corresponding details.
     public let segments: [Segment]?
 
-    public init(text: String, language: String?, duration: Double?, words: [Word]?, segments: [Segment]?) {
+    /// Segments of a diarized transcription, including speaker labels.
+    public let diarizedSegments: [DiarizedSegment]?
+
+    /// The log probabilities of the tokens in the transcription.
+    public let logprobs: [OpenAITranscriptionLogprob]?
+
+    /// Usage statistics for the transcription request.
+    /// Unlike the Responses API, transcription usage may be billed by tokens or by audio duration.
+    public let usage: OpenAITranscriptionUsage?
+
+    public init(
+        text: String,
+        language: String?,
+        duration: Double?,
+        words: [Word]?,
+        segments: [Segment]?,
+        diarizedSegments: [DiarizedSegment]? = nil,
+        logprobs: [OpenAITranscriptionLogprob]? = nil,
+        usage: OpenAITranscriptionUsage? = nil
+    ) {
         self.text = text
         self.language = language
         self.duration = duration
         self.words = words
         self.segments = segments
+        self.diarizedSegments = diarizedSegments
+        self.logprobs = logprobs
+        self.usage = usage
     }
 
     enum CodingKeys: String, CodingKey {
@@ -44,6 +69,22 @@ nonisolated public struct OpenAICreateTranscriptionResponseBody: Decodable, Send
         case duration
         case words
         case segments
+        case logprobs
+        case usage
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.text = try container.decode(String.self, forKey: .text)
+        self.language = try container.decodeIfPresent(String.self, forKey: .language)
+        self.duration = try container.decodeIfPresent(Double.self, forKey: .duration)
+        self.words = try container.decodeIfPresent([Word].self, forKey: .words)
+        self.segments = try? container.decodeIfPresent([Segment].self, forKey: .segments)
+        self.diarizedSegments = self.segments == nil
+            ? (try? container.decodeIfPresent([DiarizedSegment].self, forKey: .segments))
+            : nil
+        self.logprobs = try container.decodeIfPresent([OpenAITranscriptionLogprob].self, forKey: .logprobs)
+        self.usage = try container.decodeIfPresent(OpenAITranscriptionUsage.self, forKey: .usage)
     }
 }
 
@@ -78,6 +119,8 @@ extension OpenAICreateTranscriptionResponseBody {
 extension OpenAICreateTranscriptionResponseBody {
     /// See https://platform.openai.com/docs/api-reference/audio/verbose-json-object#audio/verbose-json-object-segments
     nonisolated public struct Segment: Decodable, Sendable {
+        /// Unique identifier of the segment.
+        public let id: Int?
 
         /// Seek offset of the segment.
         public let seek: Int
@@ -106,7 +149,19 @@ extension OpenAICreateTranscriptionResponseBody {
         /// Probability of no speech in the segment. If the value is higher than 1.0 and the avg_logprob is below -1, consider this segment silent.
         public let noSpeechProb: Double
 
-        public init(seek: Int, start: Double, end: Double, text: String, tokens: [Int], temperature: Double, avgLogprob: Double, compressionRatio: Double, noSpeechProb: Double) {
+        public init(
+            id: Int? = nil,
+            seek: Int,
+            start: Double,
+            end: Double,
+            text: String,
+            tokens: [Int],
+            temperature: Double,
+            avgLogprob: Double,
+            compressionRatio: Double,
+            noSpeechProb: Double
+        ) {
+            self.id = id
             self.seek = seek
             self.start = start
             self.end = end
@@ -119,6 +174,7 @@ extension OpenAICreateTranscriptionResponseBody {
         }
 
         enum CodingKeys: String, CodingKey {
+            case id
             case seek
             case start
             case end
@@ -129,6 +185,19 @@ extension OpenAICreateTranscriptionResponseBody {
             case compressionRatio = "compression_ratio"
             case noSpeechProb = "no_speech_prob"
         }
+    }
+}
+
+// MARK: -
+extension OpenAICreateTranscriptionResponseBody {
+    /// See https://platform.openai.com/docs/api-reference/audio/createTranscription for the diarized_json response shape.
+    nonisolated public struct DiarizedSegment: Decodable, Sendable {
+        public let type: String?
+        public let id: String?
+        public let start: Double
+        public let end: Double
+        public let text: String
+        public let speaker: String?
     }
 }
 

--- a/Sources/AIProxy/OpenAI/OpenAIRealtimeMessage.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRealtimeMessage.swift
@@ -38,6 +38,8 @@ nonisolated public enum OpenAIRealtimeMessage: Decodable, Sendable {
     case inputAudioBufferTranscript(OpenAIRealtimeInputAudioBufferTranscriptEvent) // "input_audio_buffer.transcript"
     case inputAudioTranscriptionDelta(OpenAIRealtimeInputAudioTranscriptionDeltaEvent) // "conversation.item.input_audio_transcription.delta"
     case inputAudioTranscriptionCompleted(OpenAIRealtimeInputAudioTranscriptionCompletedEvent) // "conversation.item.input_audio_transcription.completed"
+    case inputAudioTranscriptionFailed(OpenAIRealtimeInputAudioTranscriptionFailedEvent) // "conversation.item.input_audio_transcription.failed"
+    case inputAudioTranscriptionSegment(OpenAIRealtimeInputAudioTranscriptionSegmentEvent) // "conversation.item.input_audio_transcription.segment"
 
     case futureProof
 
@@ -106,6 +108,10 @@ nonisolated public enum OpenAIRealtimeMessage: Decodable, Sendable {
             self = .inputAudioTranscriptionDelta(try OpenAIRealtimeInputAudioTranscriptionDeltaEvent(from: decoder))
         case "conversation.item.input_audio_transcription.completed":
             self = .inputAudioTranscriptionCompleted(try OpenAIRealtimeInputAudioTranscriptionCompletedEvent(from: decoder))
+        case "conversation.item.input_audio_transcription.failed":
+            self = .inputAudioTranscriptionFailed(try OpenAIRealtimeInputAudioTranscriptionFailedEvent(from: decoder))
+        case "conversation.item.input_audio_transcription.segment":
+            self = .inputAudioTranscriptionSegment(try OpenAIRealtimeInputAudioTranscriptionSegmentEvent(from: decoder))
         default:
             logIf(.info)?.info("Received unknown OpenAI realtime event of type \(type).")
             self = .futureProof
@@ -467,17 +473,20 @@ public struct OpenAIRealtimeResponseDoneEvent: Decodable, Sendable {
     public let responseID: String?
     public let conversationID: String?
     public let status: String?
+    public let usage: OpenAIRealtimeResponseUsage?
     public let eventID: String?
 
     private struct ResponseBody: Decodable {
         let id: String?
         let conversationID: String?
         let status: String?
+        let usage: OpenAIRealtimeResponseUsage?
 
         private enum CodingKeys: String, CodingKey {
             case id
             case conversationID = "conversation_id"
             case status
+            case usage
         }
     }
 
@@ -494,7 +503,65 @@ public struct OpenAIRealtimeResponseDoneEvent: Decodable, Sendable {
         self.responseID = response?.id ?? fallbackResponseID
         self.conversationID = response?.conversationID
         self.status = response?.status
+        self.usage = response?.usage
         self.eventID = try container.decodeIfPresent(String.self, forKey: .eventID)
+    }
+}
+
+public struct OpenAIRealtimeResponseUsage: Decodable, Sendable {
+    /// The Swift properties use Responses-style names while decoding Realtime wire keys like `input_token_details`.
+    public let inputTokens: Int?
+    public let inputTokensDetails: InputTokensDetails?
+    public let outputTokens: Int?
+    public let outputTokensDetails: OutputTokensDetails?
+    public let totalTokens: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case inputTokens = "input_tokens"
+        case inputTokensDetails = "input_token_details"
+        case outputTokens = "output_tokens"
+        case outputTokensDetails = "output_token_details"
+        case totalTokens = "total_tokens"
+    }
+}
+
+extension OpenAIRealtimeResponseUsage {
+    nonisolated public struct InputTokensDetails: Decodable, Sendable {
+        public let audioTokens: Int?
+        public let cachedTokens: Int?
+        public let cachedTokensDetails: CachedTokensDetails?
+        public let imageTokens: Int?
+        public let textTokens: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case audioTokens = "audio_tokens"
+            case cachedTokens = "cached_tokens"
+            case cachedTokensDetails = "cached_tokens_details"
+            case imageTokens = "image_tokens"
+            case textTokens = "text_tokens"
+        }
+    }
+
+    nonisolated public struct CachedTokensDetails: Decodable, Sendable {
+        public let audioTokens: Int?
+        public let imageTokens: Int?
+        public let textTokens: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case audioTokens = "audio_tokens"
+            case imageTokens = "image_tokens"
+            case textTokens = "text_tokens"
+        }
+    }
+
+    nonisolated public struct OutputTokensDetails: Decodable, Sendable {
+        public let audioTokens: Int?
+        public let textTokens: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case audioTokens = "audio_tokens"
+            case textTokens = "text_tokens"
+        }
     }
 }
 
@@ -619,9 +686,11 @@ public struct OpenAIRealtimeInputAudioBufferTranscriptEvent: Decodable, Sendable
 }
 
 public struct OpenAIRealtimeInputAudioTranscriptionDeltaEvent: Decodable, Sendable {
-    public let delta: String
+    /// The text delta. OpenAI documents this as optional; it may be absent in edge cases.
+    public let delta: String?
     public let itemID: String?
     public let contentIndex: Int?
+    public let logprobs: [OpenAITranscriptionLogprob]?
     public let eventID: String?
 
     private struct ItemBody: Decodable {
@@ -633,15 +702,17 @@ public struct OpenAIRealtimeInputAudioTranscriptionDeltaEvent: Decodable, Sendab
         case itemID = "item_id"
         case item
         case contentIndex = "content_index"
+        case logprobs
         case eventID = "event_id"
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let item = try container.decodeIfPresent(ItemBody.self, forKey: .item)
-        self.delta = try container.decode(String.self, forKey: .delta)
+        self.delta = try container.decodeIfPresent(String.self, forKey: .delta)
         self.itemID = try container.decodeIfPresent(String.self, forKey: .itemID) ?? item?.id
         self.contentIndex = container.decodeFlexibleIntIfPresent(forKey: .contentIndex)
+        self.logprobs = try container.decodeIfPresent([OpenAITranscriptionLogprob].self, forKey: .logprobs)
         self.eventID = try container.decodeIfPresent(String.self, forKey: .eventID)
     }
 }
@@ -650,6 +721,8 @@ public struct OpenAIRealtimeInputAudioTranscriptionCompletedEvent: Decodable, Se
     public let transcript: String
     public let itemID: String?
     public let contentIndex: Int?
+    public let usage: OpenAITranscriptionUsage?
+    public let logprobs: [OpenAITranscriptionLogprob]?
     public let eventID: String?
 
     private struct ItemBody: Decodable {
@@ -661,6 +734,8 @@ public struct OpenAIRealtimeInputAudioTranscriptionCompletedEvent: Decodable, Se
         case itemID = "item_id"
         case item
         case contentIndex = "content_index"
+        case usage
+        case logprobs
         case eventID = "event_id"
     }
 
@@ -670,6 +745,83 @@ public struct OpenAIRealtimeInputAudioTranscriptionCompletedEvent: Decodable, Se
         self.transcript = try container.decode(String.self, forKey: .transcript)
         self.itemID = try container.decodeIfPresent(String.self, forKey: .itemID) ?? item?.id
         self.contentIndex = container.decodeFlexibleIntIfPresent(forKey: .contentIndex)
+        self.usage = try container.decodeIfPresent(OpenAITranscriptionUsage.self, forKey: .usage)
+        self.logprobs = try container.decodeIfPresent([OpenAITranscriptionLogprob].self, forKey: .logprobs)
+        self.eventID = try container.decodeIfPresent(String.self, forKey: .eventID)
+    }
+}
+
+public struct OpenAIRealtimeInputAudioTranscriptionFailedEvent: Decodable, Sendable {
+    public let itemID: String?
+    public let contentIndex: Int?
+    public let error: ErrorBody?
+    public let eventID: String?
+
+    private struct ItemBody: Decodable {
+        let id: String?
+    }
+
+    public struct ErrorBody: Decodable, Sendable {
+        public let code: String?
+        public let message: String?
+        public let param: String?
+        public let type: String?
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case itemID = "item_id"
+        case item
+        case contentIndex = "content_index"
+        case error
+        case eventID = "event_id"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let item = try container.decodeIfPresent(ItemBody.self, forKey: .item)
+        self.itemID = try container.decodeIfPresent(String.self, forKey: .itemID) ?? item?.id
+        self.contentIndex = container.decodeFlexibleIntIfPresent(forKey: .contentIndex)
+        self.error = try container.decodeIfPresent(ErrorBody.self, forKey: .error)
+        self.eventID = try container.decodeIfPresent(String.self, forKey: .eventID)
+    }
+}
+
+public struct OpenAIRealtimeInputAudioTranscriptionSegmentEvent: Decodable, Sendable {
+    public let id: String
+    public let itemID: String?
+    public let contentIndex: Int?
+    public let start: Double?
+    public let end: Double?
+    public let text: String
+    public let speaker: String?
+    public let eventID: String?
+
+    private struct ItemBody: Decodable {
+        let id: String?
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case itemID = "item_id"
+        case item
+        case contentIndex = "content_index"
+        case start
+        case end
+        case text
+        case speaker
+        case eventID = "event_id"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let item = try container.decodeIfPresent(ItemBody.self, forKey: .item)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.itemID = try container.decodeIfPresent(String.self, forKey: .itemID) ?? item?.id
+        self.contentIndex = container.decodeFlexibleIntIfPresent(forKey: .contentIndex)
+        self.start = container.decodeFlexibleDoubleIfPresent(forKey: .start)
+        self.end = container.decodeFlexibleDoubleIfPresent(forKey: .end)
+        self.text = try container.decode(String.self, forKey: .text)
+        self.speaker = try container.decodeIfPresent(String.self, forKey: .speaker)
         self.eventID = try container.decodeIfPresent(String.self, forKey: .eventID)
     }
 }

--- a/Sources/AIProxy/OpenAI/OpenAIService.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIService.swift
@@ -138,6 +138,8 @@ import Foundation
         additionalHeaders: [String: String] = [:],
         progressCallback: (@Sendable (Double) -> Void)? = nil
     ) async throws -> OpenAICreateTranscriptionResponseBody {
+        var body = body
+        body.stream = false
         let request = try await self.requestBuilder.multipartPOST(
             path: self.resolvedPath("audio/transcriptions"),
             body: body,
@@ -157,6 +159,29 @@ import Foundation
         }
 
         return try OpenAICreateTranscriptionResponseBody.deserialize(from: data)
+    }
+
+    /// Initiates a streaming create transcription request to v1/audio/transcriptions.
+    ///
+    /// - Parameters:
+    ///   - body: The request body to send to aiproxy and openai. `stream` is set to true by this method.
+    ///   - secondsToWait: Seconds to wait before raising `URLError.timedOut`
+    ///   - additionalHeaders: Optional headers to pass up with the request alongside the lib's default headers
+    /// - Returns: An async sequence of transcription stream events.
+    public func streamingTranscriptionRequest(
+        body: OpenAICreateTranscriptionRequestBody,
+        secondsToWait: UInt,
+        additionalHeaders: [String: String] = [:]
+    ) async throws -> AsyncThrowingStream<OpenAITranscriptionStreamingEvent, Error> {
+        var body = body
+        body.stream = true
+        let request = try await self.requestBuilder.multipartPOST(
+            path: self.resolvedPath("audio/transcriptions"),
+            body: body,
+            secondsToWait: secondsToWait,
+            additionalHeaders: additionalHeaders
+        )
+        return try await self.serviceNetworker.makeRequestAndDeserializeStreamingChunks(request)
     }
 
     /// Initiates a create text to speech request to v1/audio/speech

--- a/Sources/AIProxy/OpenAI/OpenAITranscriptionStreamingEvent.swift
+++ b/Sources/AIProxy/OpenAI/OpenAITranscriptionStreamingEvent.swift
@@ -1,0 +1,67 @@
+//
+//  OpenAITranscriptionStreamingEvent.swift
+//  AIProxy
+//
+
+import Foundation
+
+/// Represents a server-sent event from the OpenAI create transcription endpoint.
+/// https://platform.openai.com/docs/api-reference/audio/createTranscription
+nonisolated public enum OpenAITranscriptionStreamingEvent: Decodable, Sendable {
+    case textDelta(TextDelta)
+    case textDone(TextDone)
+    case textSegment(OpenAICreateTranscriptionResponseBody.DiarizedSegment)
+    case futureProof
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "transcript.text.delta":
+            self = .textDelta(try TextDelta(from: decoder))
+        case "transcript.text.done":
+            self = .textDone(try TextDone(from: decoder))
+        case "transcript.text.segment":
+            self = .textSegment(try OpenAICreateTranscriptionResponseBody.DiarizedSegment(from: decoder))
+        default:
+            logIf(.info)?.info("Received unknown OpenAI transcription stream event of type \(type).")
+            self = .futureProof
+        }
+    }
+}
+
+extension OpenAITranscriptionStreamingEvent {
+    nonisolated public struct TextDelta: Decodable, Sendable {
+        /// Incremental transcript text for this event.
+        public let delta: String
+
+        /// When present (for example with diarized streaming), ties this delta to a `transcript.text.segment` by id.
+        public let segmentID: String?
+
+        public let logprobs: [OpenAITranscriptionLogprob]?
+
+        private enum CodingKeys: String, CodingKey {
+            case delta
+            case segmentID = "segment_id"
+            case logprobs
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.delta = try container.decode(String.self, forKey: .delta)
+            self.segmentID = try container.decodeIfPresent(String.self, forKey: .segmentID)
+            self.logprobs = try container.decodeIfPresent([OpenAITranscriptionLogprob].self, forKey: .logprobs)
+        }
+    }
+
+    nonisolated public struct TextDone: Decodable, Sendable {
+        public let text: String
+        public let logprobs: [OpenAITranscriptionLogprob]?
+        public let usage: OpenAITranscriptionUsage?
+    }
+}

--- a/Sources/AIProxy/OpenAI/OpenAITranscriptionUsage.swift
+++ b/Sources/AIProxy/OpenAI/OpenAITranscriptionUsage.swift
@@ -1,0 +1,99 @@
+//
+//  OpenAITranscriptionUsage.swift
+//  AIProxy
+//
+
+import Foundation
+
+/// Shared usage and token-confidence models used by OpenAI transcription APIs.
+nonisolated public struct OpenAITranscriptionUsage: Decodable, Sendable {
+    /// The billing model used for this transcription response.
+    public let type: UsageType
+
+    /// Number of input tokens billed for the request when `type == .tokens`.
+    public let inputTokens: Int?
+
+    /// Number of output tokens generated when `type == .tokens`.
+    public let outputTokens: Int?
+
+    /// Total billed tokens when `type == .tokens`.
+    public let totalTokens: Int?
+
+    /// Token usage details. The Swift property uses Responses-style naming while decoding the transcription wire key `input_token_details`.
+    public let inputTokensDetails: InputTokensDetails?
+
+    /// Duration billed for the request when `type == .duration`.
+    public let seconds: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case inputTokens = "input_tokens"
+        case outputTokens = "output_tokens"
+        case totalTokens = "total_tokens"
+        case inputTokensDetails = "input_token_details"
+        case seconds
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.inputTokens = try container.decodeIfPresent(Int.self, forKey: .inputTokens)
+        self.outputTokens = try container.decodeIfPresent(Int.self, forKey: .outputTokens)
+        self.totalTokens = try container.decodeIfPresent(Int.self, forKey: .totalTokens)
+        self.inputTokensDetails = try container.decodeIfPresent(InputTokensDetails.self, forKey: .inputTokensDetails)
+        self.seconds = try container.decodeIfPresent(Double.self, forKey: .seconds)
+
+        if let type = try container.decodeIfPresent(UsageType.self, forKey: .type) {
+            self.type = type
+        } else if inputTokens != nil || outputTokens != nil || totalTokens != nil || inputTokensDetails != nil {
+            self.type = .tokens
+        } else if seconds != nil {
+            self.type = .duration
+        } else {
+            self.type = .futureProof
+        }
+    }
+}
+
+extension OpenAITranscriptionUsage {
+    nonisolated public enum UsageType: Decodable, Sendable {
+        case tokens
+        case duration
+        case futureProof
+
+        public init(from decoder: Decoder) throws {
+            let raw = try decoder.singleValueContainer().decode(String.self)
+            switch raw {
+            case "tokens":
+                self = .tokens
+            case "duration":
+                self = .duration
+            default:
+                self = .futureProof
+            }
+        }
+    }
+
+    nonisolated public struct InputTokensDetails: Decodable, Sendable {
+        /// Number of audio tokens billed for the request.
+        public let audioTokens: Int?
+
+        /// Number of text tokens billed for the request.
+        public let textTokens: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case audioTokens = "audio_tokens"
+            case textTokens = "text_tokens"
+        }
+    }
+}
+
+nonisolated public struct OpenAITranscriptionLogprob: Decodable, Sendable {
+    /// The emitted token.
+    public let token: String?
+
+    /// Raw bytes for the emitted token.
+    public let bytes: [Int]?
+
+    /// Log-probability for the emitted token.
+    public let logprob: Double?
+}

--- a/Tests/AIProxyTests/OpenAIAudioCodablesTests.swift
+++ b/Tests/AIProxyTests/OpenAIAudioCodablesTests.swift
@@ -29,6 +29,109 @@ final class OpenAIAudioCodablesTests: XCTestCase {
         XCTAssertEqual(expected, String(data: result, encoding: .utf8)!)
     }
 
+    func testAudioTranscriptBodyEncodesIncludeFields() {
+        let body = OpenAICreateTranscriptionRequestBody(
+            file: "AUDIO".data(using: .utf8)!,
+            model: "gpt-4o-transcribe",
+            responseFormat: "json",
+            include: [.logprobs]
+        )
+
+        let boundary = UUID().uuidString
+        let result = formEncode(body, boundary)
+
+        let expected = """
+        --\(boundary)\r
+        Content-Disposition: form-data; name="file"; filename="aiproxy.m4a"\r
+        Content-Type: audio/mpeg\r
+        \r
+        AUDIO\r
+        --\(boundary)\r
+        Content-Disposition: form-data; name="model"\r
+        \r
+        gpt-4o-transcribe\r
+        --\(boundary)\r
+        Content-Disposition: form-data; name="response_format"\r
+        \r
+        json\r
+        --\(boundary)\r
+        Content-Disposition: form-data; name="include[]"\r
+        \r
+        logprobs\r
+        --\(boundary)--
+        """
+        XCTAssertEqual(expected, String(data: result, encoding: .utf8)!)
+    }
+
+    func testAudioTranscriptBodyEncodesStreamingAndDiarizationFields() {
+        let body = OpenAICreateTranscriptionRequestBody(
+            file: "AUDIO".data(using: .utf8)!,
+            model: "gpt-4o-transcribe-diarize",
+            responseFormat: "diarized_json",
+            stream: true,
+            chunkingStrategy: .auto,
+            knownSpeakerNames: ["agent"],
+            knownSpeakerReferences: ["data:audio/wav;base64,AAA..."]
+        )
+
+        let boundary = UUID().uuidString
+        let result = formEncode(body, boundary)
+
+        let expected = """
+        --\(boundary)\r
+        Content-Disposition: form-data; name="file"; filename="aiproxy.m4a"\r
+        Content-Type: audio/mpeg\r
+        \r
+        AUDIO\r
+        --\(boundary)\r
+        Content-Disposition: form-data; name="model"\r
+        \r
+        gpt-4o-transcribe-diarize\r
+        --\(boundary)\r
+        Content-Disposition: form-data; name="response_format"\r
+        \r
+        diarized_json\r
+        --\(boundary)\r
+        Content-Disposition: form-data; name="stream"\r
+        \r
+        true\r
+        --\(boundary)\r
+        Content-Disposition: form-data; name="chunking_strategy"\r
+        \r
+        auto\r
+        --\(boundary)\r
+        Content-Disposition: form-data; name="known_speaker_names[]"\r
+        \r
+        agent\r
+        --\(boundary)\r
+        Content-Disposition: form-data; name="known_speaker_references[]"\r
+        \r
+        data:audio/wav;base64,AAA...\r
+        --\(boundary)--
+        """
+        XCTAssertEqual(expected, String(data: result, encoding: .utf8)!)
+    }
+
+    func testAudioTranscriptBodyEncodesServerVADChunkingStrategy() {
+        let body = OpenAICreateTranscriptionRequestBody(
+            file: "AUDIO".data(using: .utf8)!,
+            model: "gpt-4o-transcribe",
+            chunkingStrategy: .serverVAD(
+                .init(
+                    prefixPaddingMs: 250,
+                    silenceDurationMs: 700,
+                    threshold: 0.4
+                )
+            )
+        )
+
+        let boundary = UUID().uuidString
+        let result = String(data: formEncode(body, boundary), encoding: .utf8)!
+
+        XCTAssertTrue(result.contains(#"Content-Disposition: form-data; name="chunking_strategy""#))
+        XCTAssertTrue(result.contains(#"{"type":"server_vad","prefix_padding_ms":250,"silence_duration_ms":700,"threshold":0.4}"#))
+    }
+
     func testAudioTranscriptResponseIsDecodableWithWordTimestampGranularities() {
         let sampleResponse = """
         {
@@ -59,6 +162,96 @@ final class OpenAIAudioCodablesTests: XCTestCase {
         XCTAssertEqual("Hello", res.words!.first!.word)
     }
 
+    func testAudioTranscriptResponseIsDecodableWithTokenUsageAndLogprobs() {
+        let sampleResponse = """
+        {
+          "text": "Hello, world.",
+          "logprobs": [
+            {
+              "token": "Hello",
+              "bytes": [72, 101, 108, 108, 111],
+              "logprob": -0.1
+            }
+          ],
+          "usage": {
+            "type": "tokens",
+            "input_tokens": 14,
+            "input_token_details": {
+              "text_tokens": 0,
+              "audio_tokens": 14
+            },
+            "output_tokens": 3,
+            "total_tokens": 17
+          }
+        }
+        """
+        let decoder = JSONDecoder()
+
+        let res = try! decoder.decode(
+            OpenAICreateTranscriptionResponseBody.self,
+            from: sampleResponse.data(using: .utf8)!
+        )
+        XCTAssertEqual("Hello, world.", res.text)
+        XCTAssertEqual("Hello", res.logprobs?.first?.token)
+        XCTAssertEqual([72, 101, 108, 108, 111], res.logprobs?.first?.bytes)
+        switch res.usage?.type {
+        case .tokens?:
+            break
+        default:
+            XCTFail("Expected token-based transcription usage")
+        }
+        XCTAssertEqual(14, res.usage?.inputTokens)
+        XCTAssertEqual(14, res.usage?.inputTokensDetails?.audioTokens)
+        XCTAssertEqual(0, res.usage?.inputTokensDetails?.textTokens)
+        XCTAssertEqual(3, res.usage?.outputTokens)
+        XCTAssertEqual(17, res.usage?.totalTokens)
+    }
+
+    func testAudioTranscriptResponseInfersDurationUsageWhenTypeIsOmitted() {
+        let sampleResponse = """
+        {
+          "text": "Hello",
+          "usage": {
+            "seconds": 9.5
+          }
+        }
+        """
+        let decoder = JSONDecoder()
+        let res = try! decoder.decode(
+            OpenAICreateTranscriptionResponseBody.self,
+            from: sampleResponse.data(using: .utf8)!
+        )
+        switch res.usage?.type {
+        case .duration?:
+            break
+        default:
+            XCTFail("Expected inferred duration usage")
+        }
+        XCTAssertEqual(9.5, res.usage?.seconds)
+    }
+
+    func testAudioTranscriptResponseUnknownUsageTypeIsFutureProof() {
+        let sampleResponse = """
+        {
+          "text": "Hello",
+          "usage": {
+            "type": "credits",
+            "credits_used": 3
+          }
+        }
+        """
+        let decoder = JSONDecoder()
+        let res = try! decoder.decode(
+            OpenAICreateTranscriptionResponseBody.self,
+            from: sampleResponse.data(using: .utf8)!
+        )
+        switch res.usage?.type {
+        case .futureProof?:
+            break
+        default:
+            XCTFail("Expected future-proof usage type")
+        }
+    }
 
     func testAudioTranscriptResponseIsDecodableWithSegmentTimestampGranularities() {
         let sampleResponse = """
@@ -67,6 +260,10 @@ final class OpenAIAudioCodablesTests: XCTestCase {
           "language": "english",
           "duration": 2.4200000762939453,
           "text": "Hello, world.",
+          "usage": {
+            "type": "duration",
+            "seconds": 2.42
+          },
           "segments": [
             {
               "id": 0,
@@ -96,6 +293,54 @@ final class OpenAIAudioCodablesTests: XCTestCase {
             OpenAICreateTranscriptionResponseBody.self,
             from: sampleResponse.data(using: .utf8)!
         )
+        switch res.usage?.type {
+        case .duration?:
+            break
+        default:
+            XCTFail("Expected duration-based transcription usage")
+        }
+        XCTAssertEqual(2.42, res.usage?.seconds)
+        XCTAssertEqual(0, res.segments!.first!.id)
         XCTAssertEqual("Hello, world.", res.segments!.first!.text)
+    }
+
+    func testAudioTranscriptResponseIsDecodableWithDiarizedSegmentsAndDurationUsage() {
+        let sampleResponse = """
+        {
+          "task": "transcribe",
+          "duration": 27.4,
+          "text": "Agent: Thanks for calling OpenAI support.",
+          "segments": [
+            {
+              "type": "transcript.text.segment",
+              "id": "seg_001",
+              "start": 0.0,
+              "end": 4.7,
+              "text": "Thanks for calling OpenAI support.",
+              "speaker": "agent"
+            }
+          ],
+          "usage": {
+            "type": "duration",
+            "seconds": 27
+          }
+        }
+        """
+        let decoder = JSONDecoder()
+
+        let res = try! decoder.decode(
+            OpenAICreateTranscriptionResponseBody.self,
+            from: sampleResponse.data(using: .utf8)!
+        )
+        XCTAssertNil(res.segments)
+        XCTAssertEqual("seg_001", res.diarizedSegments?.first?.id)
+        XCTAssertEqual("agent", res.diarizedSegments?.first?.speaker)
+        switch res.usage?.type {
+        case .duration?:
+            break
+        default:
+            XCTFail("Expected duration-based transcription usage")
+        }
+        XCTAssertEqual(27, res.usage?.seconds)
     }
 }

--- a/Tests/AIProxyTests/OpenAIRealtimeMessageTests.swift
+++ b/Tests/AIProxyTests/OpenAIRealtimeMessageTests.swift
@@ -157,6 +157,265 @@ struct OpenAIRealtimeMessageTests {
         #expect(donePayload.text == "AB")
     }
 
+    @Test
+    func testResponseDoneUsageIsDecodable() throws {
+        let event = try decode(
+            #"""
+            {
+              "type": "response.done",
+              "event_id": "event_30",
+              "response": {
+                "id": "resp_30",
+                "conversation_id": "conv_30",
+                "status": "completed",
+                "usage": {
+                  "input_tokens": 141,
+                  "input_token_details": {
+                    "text_tokens": 18,
+                    "audio_tokens": 91,
+                    "image_tokens": 12,
+                    "cached_tokens": 20,
+                    "cached_tokens_details": {
+                      "text_tokens": 7,
+                      "audio_tokens": 11,
+                      "image_tokens": 2
+                    }
+                  },
+                  "output_tokens": 84,
+                  "output_token_details": {
+                    "text_tokens": 24,
+                    "audio_tokens": 60
+                  },
+                  "total_tokens": 225
+                }
+              }
+            }
+            """#
+        )
+
+        guard case .responseDone(let payload) = event else {
+            Issue.record("Expected responseDone")
+            return
+        }
+        #expect(payload.responseID == "resp_30")
+        #expect(payload.conversationID == "conv_30")
+        #expect(payload.status == "completed")
+        #expect(payload.usage?.inputTokens == 141)
+        #expect(payload.usage?.inputTokensDetails?.textTokens == 18)
+        #expect(payload.usage?.inputTokensDetails?.audioTokens == 91)
+        #expect(payload.usage?.inputTokensDetails?.imageTokens == 12)
+        #expect(payload.usage?.inputTokensDetails?.cachedTokens == 20)
+        #expect(payload.usage?.inputTokensDetails?.cachedTokensDetails?.textTokens == 7)
+        #expect(payload.usage?.inputTokensDetails?.cachedTokensDetails?.audioTokens == 11)
+        #expect(payload.usage?.inputTokensDetails?.cachedTokensDetails?.imageTokens == 2)
+        #expect(payload.usage?.outputTokens == 84)
+        #expect(payload.usage?.outputTokensDetails?.textTokens == 24)
+        #expect(payload.usage?.outputTokensDetails?.audioTokens == 60)
+        #expect(payload.usage?.totalTokens == 225)
+    }
+
+    @Test
+    func testInputAudioTranscriptionDeltaLogprobsAreDecodable() throws {
+        let event = try decode(
+            #"{"type":"conversation.item.input_audio_transcription.delta","event_id":"event_31","item_id":"item_31","content_index":0,"delta":"Hel","logprobs":[{"token":"Hel","bytes":[72,101,108],"logprob":-0.21}]}"#
+        )
+
+        guard case .inputAudioTranscriptionDelta(let payload) = event else {
+            Issue.record("Expected inputAudioTranscriptionDelta")
+            return
+        }
+        #expect(payload.itemID == "item_31")
+        #expect(payload.contentIndex == 0)
+        #expect(payload.delta == "Hel")
+        #expect(payload.logprobs?.count == 1)
+        #expect(payload.logprobs?.first?.token == "Hel")
+        #expect(payload.logprobs?.first?.bytes == [72, 101, 108])
+    }
+
+    @Test
+    func testInputAudioTranscriptionDeltaDecodesWithoutDelta() throws {
+        let event = try decode(
+            #"{"type":"conversation.item.input_audio_transcription.delta","event_id":"event_36","item_id":"item_36","content_index":0,"logprobs":[{"token":"x","bytes":[120],"logprob":-0.1}]}"#
+        )
+
+        guard case .inputAudioTranscriptionDelta(let payload) = event else {
+            Issue.record("Expected inputAudioTranscriptionDelta")
+            return
+        }
+        #expect(payload.delta == nil)
+        #expect(payload.itemID == "item_36")
+        #expect(payload.logprobs?.first?.token == "x")
+    }
+
+    @Test
+    func testInputAudioTranscriptionCompletedTokenUsageIsDecodable() throws {
+        let event = try decode(
+            #"""
+            {
+              "type": "conversation.item.input_audio_transcription.completed",
+              "event_id": "event_32",
+              "item_id": "item_32",
+              "content_index": 0,
+              "transcript": "Hello there",
+              "usage": {
+                "type": "tokens",
+                "input_tokens": 12,
+                "input_token_details": {
+                  "audio_tokens": 10,
+                  "text_tokens": 2
+                },
+                "output_tokens": 4,
+                "total_tokens": 16
+              },
+              "logprobs": [
+                {
+                  "token": "Hello",
+                  "bytes": [72, 101, 108, 108, 111],
+                  "logprob": -0.12
+                }
+              ]
+            }
+            """#
+        )
+
+        guard case .inputAudioTranscriptionCompleted(let payload) = event else {
+            Issue.record("Expected inputAudioTranscriptionCompleted")
+            return
+        }
+        #expect(payload.itemID == "item_32")
+        #expect(payload.contentIndex == 0)
+        #expect(payload.transcript == "Hello there")
+        switch payload.usage?.type {
+        case .tokens?:
+            break
+        default:
+            Issue.record("Expected token-based transcription usage")
+        }
+        #expect(payload.usage?.inputTokens == 12)
+        #expect(payload.usage?.inputTokensDetails?.audioTokens == 10)
+        #expect(payload.usage?.inputTokensDetails?.textTokens == 2)
+        #expect(payload.usage?.outputTokens == 4)
+        #expect(payload.usage?.totalTokens == 16)
+        #expect(payload.logprobs?.first?.token == "Hello")
+        #expect(payload.logprobs?.first?.bytes == [72, 101, 108, 108, 111])
+    }
+
+    @Test
+    func testInputAudioTranscriptionCompletedDurationUsageIsDecodable() throws {
+        let event = try decode(
+            #"{"type":"conversation.item.input_audio_transcription.completed","event_id":"event_33","item":{"id":"item_33"},"content_index":0,"transcript":"A short phrase","usage":{"type":"duration","seconds":3.75}}"#
+        )
+
+        guard case .inputAudioTranscriptionCompleted(let payload) = event else {
+            Issue.record("Expected inputAudioTranscriptionCompleted")
+            return
+        }
+        #expect(payload.itemID == "item_33")
+        #expect(payload.transcript == "A short phrase")
+        switch payload.usage?.type {
+        case .duration?:
+            break
+        default:
+            Issue.record("Expected duration-based transcription usage")
+        }
+        #expect(payload.usage?.seconds == 3.75)
+        #expect(payload.usage?.inputTokens == nil)
+    }
+
+    @Test
+    func testInputAudioTranscriptionFailedIsDecodable() throws {
+        let event = try decode(
+            #"""
+            {
+              "type": "conversation.item.input_audio_transcription.failed",
+              "event_id": "event_34",
+              "item_id": "item_34",
+              "content_index": 0,
+              "error": {
+                "type": "invalid_request_error",
+                "code": "unsupported_audio",
+                "message": "Audio could not be transcribed.",
+                "param": "audio"
+              }
+            }
+            """#
+        )
+
+        guard case .inputAudioTranscriptionFailed(let payload) = event else {
+            Issue.record("Expected inputAudioTranscriptionFailed")
+            return
+        }
+        #expect(payload.eventID == "event_34")
+        #expect(payload.itemID == "item_34")
+        #expect(payload.contentIndex == 0)
+        #expect(payload.error?.type == "invalid_request_error")
+        #expect(payload.error?.code == "unsupported_audio")
+        #expect(payload.error?.message == "Audio could not be transcribed.")
+        #expect(payload.error?.param == "audio")
+    }
+
+    @Test
+    func testInputAudioTranscriptionSegmentIsDecodable() throws {
+        let event = try decode(
+            #"""
+            {
+              "type": "conversation.item.input_audio_transcription.segment",
+              "event_id": "event_35",
+              "id": "seg_35",
+              "item": {
+                "id": "item_35"
+              },
+              "content_index": 0,
+              "start": 1.2,
+              "end": 4.8,
+              "text": "Thanks for calling.",
+              "speaker": "agent"
+            }
+            """#
+        )
+
+        guard case .inputAudioTranscriptionSegment(let payload) = event else {
+            Issue.record("Expected inputAudioTranscriptionSegment")
+            return
+        }
+        #expect(payload.eventID == "event_35")
+        #expect(payload.id == "seg_35")
+        #expect(payload.itemID == "item_35")
+        #expect(payload.contentIndex == 0)
+        #expect(payload.start == 1.2)
+        #expect(payload.end == 4.8)
+        #expect(payload.text == "Thanks for calling.")
+        #expect(payload.speaker == "agent")
+    }
+
+    @Test
+    func testInputAudioTranscriptionSegmentDecodesTopLevelItemId() throws {
+        let event = try decode(
+            #"""
+            {
+              "type": "conversation.item.input_audio_transcription.segment",
+              "event_id": "event_37",
+              "id": "seg_37",
+              "item_id": "item_37",
+              "content_index": 0,
+              "start": 0.5,
+              "end": 2.5,
+              "text": "Hello.",
+              "speaker": "A"
+            }
+            """#
+        )
+
+        guard case .inputAudioTranscriptionSegment(let payload) = event else {
+            Issue.record("Expected inputAudioTranscriptionSegment")
+            return
+        }
+        #expect(payload.itemID == "item_37")
+        #expect(payload.id == "seg_37")
+        #expect(payload.text == "Hello.")
+        #expect(payload.speaker == "A")
+    }
+
     private func decode(_ json: String) throws -> OpenAIRealtimeMessage {
         try JSONDecoder().decode(OpenAIRealtimeMessage.self, from: Data(json.utf8))
     }

--- a/Tests/AIProxyTests/OpenAIRealtimeSessionEncodingTests.swift
+++ b/Tests/AIProxyTests/OpenAIRealtimeSessionEncodingTests.swift
@@ -64,6 +64,20 @@ struct OpenAIRealtimeSessionEncodingTests {
     }
 
     @Test
+    func sessionUpdateEncodesInputAudioTranscriptionLogprobsInclude() throws {
+        let update = OpenAIRealtimeSessionUpdate(
+            session: OpenAIRealtimeSessionConfiguration(
+                include: [.inputAudioTranscriptionLogprobs],
+                inputAudioTranscription: .init(model: "gpt-4o-transcribe")
+            )
+        )
+        let encoded = try encoder.encode(update)
+        let session = (try Self.jsonObject(encoded) as! [String: Any])["session"] as! [String: Any]
+
+        #expect(session["include"] as? [String] == ["item.input_audio_transcription.logprobs"])
+    }
+
+    @Test
     func serverVADTurnDetectionEncodesUnderAudioInput() throws {
         let update = OpenAIRealtimeSessionUpdate(
             session: OpenAIRealtimeSessionConfiguration(

--- a/Tests/AIProxyTests/OpenAITranscriptionStreamingEventTests.swift
+++ b/Tests/AIProxyTests/OpenAITranscriptionStreamingEventTests.swift
@@ -1,0 +1,145 @@
+//
+//  OpenAITranscriptionStreamingEventTests.swift
+//  AIProxyTests
+//
+
+import Foundation
+import Testing
+@testable import AIProxy
+
+struct OpenAITranscriptionStreamingEventTests {
+
+    @Test
+    func textDeltaIsDecodable() throws {
+        let event = try decode(#"{"type":"transcript.text.delta","delta":"Hello"}"#)
+
+        guard case .textDelta(let payload) = event else {
+            Issue.record("Expected textDelta")
+            return
+        }
+        #expect(payload.delta == "Hello")
+        #expect(payload.logprobs == nil)
+    }
+
+    @Test
+    func textDeltaLogprobsAreDecodable() throws {
+        let event = try decode(
+            #"{"type":"transcript.text.delta","delta":" Hi","logprobs":[{"token":" Hi","logprob":-0.001,"bytes":[32,72,105]}]}"#
+        )
+
+        guard case .textDelta(let payload) = event else {
+            Issue.record("Expected textDelta")
+            return
+        }
+        #expect(payload.delta == " Hi")
+        #expect(payload.logprobs?.first?.token == " Hi")
+        #expect(payload.logprobs?.first?.logprob == -0.001)
+        #expect(payload.logprobs?.first?.bytes == [32, 72, 105])
+    }
+
+    @Test
+    func textDeltaSegmentIdIsDecodable() throws {
+        let event = try decode(
+            #"{"type":"transcript.text.delta","delta":"Hi","segment_id":"seg_42"}"#
+        )
+
+        guard case .textDelta(let payload) = event else {
+            Issue.record("Expected textDelta")
+            return
+        }
+        #expect(payload.delta == "Hi")
+        #expect(payload.segmentID == "seg_42")
+    }
+
+    @Test
+    func unknownStreamingEventDecodesAsFutureProof() throws {
+        let event = try decode(#"{"type":"transcript.unknown.event","foo":1}"#)
+        guard case .futureProof = event else {
+            Issue.record("Expected futureProof")
+            return
+        }
+    }
+
+    @Test
+    func textDoneUsageAndLogprobsAreDecodableWhenUsageTypeIsOmitted() throws {
+        let event = try decode(
+            #"""
+            {
+              "type": "transcript.text.done",
+              "text": "Hello there",
+              "logprobs": [
+                {
+                  "token": "Hello",
+                  "logprob": -0.02,
+                  "bytes": [72, 101, 108, 108, 111]
+                }
+              ],
+              "usage": {
+                "input_tokens": 14,
+                "input_token_details": {
+                  "text_tokens": 0,
+                  "audio_tokens": 14
+                },
+                "output_tokens": 3,
+                "total_tokens": 17
+              }
+            }
+            """#
+        )
+
+        guard case .textDone(let payload) = event else {
+            Issue.record("Expected textDone")
+            return
+        }
+        #expect(payload.text == "Hello there")
+        #expect(payload.logprobs?.first?.token == "Hello")
+        switch payload.usage?.type {
+        case .tokens?:
+            break
+        default:
+            Issue.record("Expected inferred token usage")
+        }
+        #expect(payload.usage?.inputTokens == 14)
+        #expect(payload.usage?.inputTokensDetails?.audioTokens == 14)
+        #expect(payload.usage?.inputTokensDetails?.textTokens == 0)
+        #expect(payload.usage?.outputTokens == 3)
+        #expect(payload.usage?.totalTokens == 17)
+    }
+
+    @Test
+    func textSegmentIsDecodable() throws {
+        let event = try decode(
+            #"{"type":"transcript.text.segment","id":"seg_001","start":0.0,"end":4.7,"text":"Thanks for calling.","speaker":"agent"}"#
+        )
+
+        guard case .textSegment(let payload) = event else {
+            Issue.record("Expected textSegment")
+            return
+        }
+        #expect(payload.type == "transcript.text.segment")
+        #expect(payload.id == "seg_001")
+        #expect(payload.start == 0.0)
+        #expect(payload.end == 4.7)
+        #expect(payload.text == "Thanks for calling.")
+        #expect(payload.speaker == "agent")
+    }
+
+    @Test
+    func sseLineParsingIgnoresDoneSentinel() throws {
+        let event = OpenAITranscriptionStreamingEvent.deserialize(
+            fromLine: #"data: {"type":"transcript.text.delta","delta":"A"}"#
+        )
+        let done = OpenAITranscriptionStreamingEvent.deserialize(fromLine: "data: [DONE]")
+
+        guard case .textDelta(let payload)? = event else {
+            Issue.record("Expected textDelta")
+            return
+        }
+        #expect(payload.delta == "A")
+        #expect(done == nil)
+    }
+
+    private func decode(_ json: String) throws -> OpenAITranscriptionStreamingEvent {
+        try JSONDecoder().decode(OpenAITranscriptionStreamingEvent.self, from: Data(json.utf8))
+    }
+}


### PR DESCRIPTION
## Summary

This PR fills a schema coverage gap in the OpenAI integration: several documented Realtime and transcription response fields were present on the wire but not modeled by AIProxySwift, especially around usage, token accounting, logprobs, and streamed transcription events.

It adds support for:

- Realtime `response.done` usage fields, including input/output/total tokens and token details.
- Realtime input-audio transcription usage, logprobs, failure events, and segment events (including top-level `item_id` and optional `delta` where the API allows it).
- Transcription response usage for token-billed and duration-billed responses, with inference when `usage.type` is omitted on the wire and a `futureProof` bucket for unknown usage types.
- Transcription `logprobs`, diarized segments, and segment IDs.
- Streamed `/audio/transcriptions` events, including `transcript.text.delta` (with optional `segment_id` for diarized streaming), `transcript.text.done`, and `transcript.text.segment`, plus `futureProof` handling for unknown stream event types.
- Request-side transcription fields for streaming, chunking (including `server_vad` JSON in the multipart field), speaker references, timestamp granularities, and `include[]=logprobs`.
- `OpenAIService.streamingTranscriptionRequest` for SSE transcription responses, while the buffered API continues to set `stream` off by default.

## Why

OpenAI documents usage and transcription metadata that can be important for billing visibility, debugging, confidence scoring, and diarized transcript handling. Before this change, some of those fields were not exposed by the Swift models, so callers could not reliably inspect them after decoding.

This PR brings the Swift API closer to OpenAI’s documented response and streaming shapes while preserving the existing buffered transcription API.

## Test Plan

Ran focused tests covering request encoding, buffered transcription decoding, streamed transcription event decoding, Realtime event decoding, and session include encoding:

`swift test --filter 'OpenAIAudioCodablesTests|OpenAITranscriptionStreamingEventTests|OpenAIRealtimeMessageTests|OpenAIRealtimeSessionEncodingTests'`
