### PR TITLE
Add OpenAI Responses context management and compaction parity

### DIFF
--- a/AIProxy.podspec
+++ b/AIProxy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AIProxy'
-  s.version      = '0.148.0'
+  s.version      = '0.150.0'
   s.summary      = 'AIProxy Swift SDK for secure AI integrations'
   s.description  = 'Access OpenAI, Anthropic, and other AI providers securely without exposing API keys in your app. See https://www.aiproxy.com for more'
   s.homepage     = 'https://github.com/lzell/AIProxySwift'

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    nonisolated public static let sdkVersion = "0.148.0"
+    nonisolated public static let sdkVersion = "0.150.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/OpenAI/Conversations/Bidirectional/OpenAICompactionItem.swift
+++ b/Sources/AIProxy/OpenAI/Conversations/Bidirectional/OpenAICompactionItem.swift
@@ -17,15 +17,28 @@ nonisolated public struct OpenAICompactionItem: Encodable, Sendable {
     /// The ID of the compaction item.
     public let id: String?
 
+    /// Present when the API includes `created_by` on the compaction object.
+    public let createdBy: String?
+
     private enum CodingKeys: String, CodingKey {
         case encryptedContent = "encrypted_content"
         case type
         case id
+        case createdBy = "created_by"
     }
 
-    public init(encryptedContent: String, id: String? = nil) {
+    public init(encryptedContent: String, id: String? = nil, createdBy: String? = nil) {
         self.encryptedContent = encryptedContent
         self.id = id
+        self.createdBy = createdBy
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(encryptedContent, forKey: .encryptedContent)
+        try container.encode(type, forKey: .type)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(createdBy, forKey: .createdBy)
     }
 }
 

--- a/Sources/AIProxy/OpenAI/Conversations/Outputs/OpenAIConversationItem.swift
+++ b/Sources/AIProxy/OpenAI/Conversations/Outputs/OpenAIConversationItem.swift
@@ -39,6 +39,10 @@ nonisolated public enum OpenAIConversationItem: Decodable, Sendable {
     /// Be sure to include these items in your input to the Responses API for subsequent turns of a conversation if you are manually managing context: https://platform.openai.com/docs/guides/conversation-state
     case reasoning(OpenAIReasoningItem)
 
+    /// A compaction item (same shape as a compaction entry in a Response `output` array).
+    /// API reference (conversation item schema, compaction variant): https://developers.openai.com/api/reference/resources/conversations#(resource)%20conversations.items%20%3E%20(model)%20conversation_item%20%3E%20(schema)%20%3E%20(variant)%2011
+    case compaction(OpenAIResponse.Compaction)
+
     /// A tool call to run code.
     case codeInterpreterToolCall(OpenAICodeInterpreterToolCall)
 
@@ -127,6 +131,8 @@ nonisolated public enum OpenAIConversationItem: Decodable, Sendable {
             self = .message(try OpenAIMessage(from: decoder))
         case "reasoning":
             self = .reasoning(try OpenAIReasoningItem(from: decoder))
+        case "compaction":
+            self = .compaction(try OpenAIResponse.Compaction(from: decoder))
         case "shell_call":
             self = .functionShellCall(try OpenAIShellToolCall(from: decoder))
         case "shell_call_output":

--- a/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
+++ b/Sources/AIProxy/OpenAI/OpenAICreateResponseRequestBody.swift
@@ -32,6 +32,9 @@ nonisolated public struct OpenAICreateResponseRequestBody: Encodable, Sendable {
     /// including visible output tokens and reasoning tokens: https://developers.openai.com/docs/guides/reasoning
     public let maxOutputTokens: Int?
 
+    /// Elements of the JSON `context_management` array on the create-response request.
+    public let contextManagement: [ContextManagementItem]?
+
     /// Model ID used to generate the response, like gpt-4o or o1.
     /// OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points.
     /// Refer to the model guide to browse and compare available models: https://platform.openai.com/docs/models
@@ -101,6 +104,7 @@ nonisolated public struct OpenAICreateResponseRequestBody: Encodable, Sendable {
         case input
         case instructions
         case maxOutputTokens = "max_output_tokens"
+        case contextManagement = "context_management"
         case model
         case tools
         case toolChoice = "tool_choice"
@@ -126,6 +130,7 @@ nonisolated public struct OpenAICreateResponseRequestBody: Encodable, Sendable {
         input: OpenAIResponse.Input? = nil,
         instructions: String? = nil,
         maxOutputTokens: Int? = nil,
+        contextManagement: [OpenAICreateResponseRequestBody.ContextManagementItem]? = nil,
         model: String? = nil,
         parallelToolCalls: Bool? = nil,
         previousResponseId: String? = nil,
@@ -146,6 +151,7 @@ nonisolated public struct OpenAICreateResponseRequestBody: Encodable, Sendable {
         self.input = input
         self.instructions = instructions
         self.maxOutputTokens = maxOutputTokens
+        self.contextManagement = contextManagement
         self.model = model
         self.parallelToolCalls = parallelToolCalls
         self.previousResponseId = previousResponseId
@@ -169,12 +175,42 @@ nonisolated public struct OpenAICreateResponseRequestBody: Encodable, Sendable {
 
 extension OpenAICreateResponseRequestBody {
 
+    /// One object in the JSON `context_management` array (`type`, `compact_threshold`, …).
+    nonisolated public struct ContextManagementItem: Encodable, Sendable {
+        /// The context management entry type. Currently only `compaction` is supported.
+        public let type: EntryType
+
+        /// Token threshold at which compaction should be triggered for this entry.
+        public let compactThreshold: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case type
+            case compactThreshold = "compact_threshold"
+        }
+
+        public init(
+            type: EntryType = .compaction,
+            compactThreshold: Int? = nil
+        ) {
+            self.type = type
+            self.compactThreshold = compactThreshold
+        }
+
+        nonisolated public enum EntryType: String, Encodable, Sendable {
+            case compaction
+        }
+    }
+
+    /// Legacy name for one element of the JSON `context_management` array.
+    @available(*, deprecated, renamed: "ContextManagementItem")
+    public typealias ContextManagement = ContextManagementItem
+
     /// The truncation strategy to use for the model response.
     nonisolated public enum Truncation: String, Encodable, Sendable {
-        /// If the context of this response and previous ones exceeds the model's context window size, the model will truncate the response to fit the context window by dropping input items in the middle of the conversation.
+        /// If the input to this response exceeds the model's context window size, the model will truncate the response to fit the context window by dropping items from the beginning of the conversation.
         case auto
 
-        /// If a model response will exceed the context window size for a model, the request will fail with a 400 error.
+        /// If the input size will exceed the context window size for a model, the request will fail with a 400 error.
         case disabled
     }
 

--- a/Sources/AIProxy/OpenAI/OpenAIResponse.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponse.swift
@@ -116,8 +116,8 @@ nonisolated public struct OpenAIResponse: Decodable, Sendable {
     public let topP: Double?
 
     /// The truncation strategy to use for the model response.
-    /// - `auto`: If the context of this response and previous ones exceeds the model's context window size, the model will truncate the response to fit the context window by dropping input items in the middle of the conversation.
-    /// - `disabled` (default): If a model response will exceed the context window size for a model, the request will fail with a 400 error.
+    /// - `auto`: If the input to this response exceeds the model's context window size, the model will truncate the response to fit the context window by dropping items from the beginning of the conversation.
+    /// - `disabled` (default): If the input size will exceed the context window size for a model, the request will fail with a 400 error.
     public let truncation: String?
 
     /// Represents token usage details including input tokens, output tokens, a breakdown of output tokens, and the total tokens used.
@@ -188,7 +188,7 @@ nonisolated public struct OpenAIResponse: Decodable, Sendable {
                         break
                     }
                 }
-            case .webSearchCall, .fileSearchCall, .functionCall, .computerCall, .reasoning:
+            case .webSearchCall, .fileSearchCall, .functionCall, .computerCall, .reasoning, .compaction:
                 break
             }
         }
@@ -337,6 +337,7 @@ extension OpenAIResponse {
         case functionCall(FunctionCall)
         case computerCall(ComputerCall)
         case reasoning(Reasoning)
+        case compaction(Compaction)
 
         private enum CodingKeys: String, CodingKey {
             case type
@@ -359,6 +360,8 @@ extension OpenAIResponse {
                 self = .computerCall(try ComputerCall(from: decoder))
             case "reasoning":
                 self = .reasoning(try Reasoning(from: decoder))
+            case "compaction":
+                self = .compaction(try Compaction(from: decoder))
             default:
                 throw DecodingError.dataCorruptedError(
                     forKey: .type,
@@ -366,6 +369,21 @@ extension OpenAIResponse {
                     debugDescription: "Unknown output item type: \(type)"
                 )
             }
+        }
+    }
+
+    // MARK: - Compaction
+    nonisolated public struct Compaction: Decodable, Sendable {
+        public let encryptedContent: String
+        public let id: String?
+
+        /// The identifier of the actor that created the item, when present on the wire.
+        public let createdBy: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case encryptedContent = "encrypted_content"
+            case id
+            case createdBy = "created_by"
         }
     }
 

--- a/Tests/AIProxyTests/OpenAIConversationItemTests.swift
+++ b/Tests/AIProxyTests/OpenAIConversationItemTests.swift
@@ -1,0 +1,46 @@
+//
+//  OpenAIConversationItemTests.swift
+//  AIProxy
+//
+
+import XCTest
+@testable import AIProxy
+
+final class OpenAIConversationItemTests: XCTestCase {
+
+    func testCompactionConversationItemDecodesWithIdAndCreatedBy() throws {
+        let json = #"""
+        {
+          "type": "compaction",
+          "id": "cmp_123",
+          "encrypted_content": "enc_abc123",
+          "created_by": "system"
+        }
+        """#
+
+        let item = try OpenAIConversationItem.deserialize(from: json)
+        guard case .compaction(let compaction) = item else {
+            return XCTFail("Expected .compaction")
+        }
+        XCTAssertEqual("cmp_123", compaction.id)
+        XCTAssertEqual("enc_abc123", compaction.encryptedContent)
+        XCTAssertEqual("system", compaction.createdBy)
+    }
+
+    func testCompactionConversationItemDecodesWithoutOptionalFields() throws {
+        let json = #"""
+        {
+          "type": "compaction",
+          "encrypted_content": "enc_only"
+        }
+        """#
+
+        let item = try OpenAIConversationItem.deserialize(from: json)
+        guard case .compaction(let compaction) = item else {
+            return XCTFail("Expected .compaction")
+        }
+        XCTAssertNil(compaction.id)
+        XCTAssertNil(compaction.createdBy)
+        XCTAssertEqual("enc_only", compaction.encryptedContent)
+    }
+}

--- a/Tests/AIProxyTests/OpenAICreateResponseRequestTests.swift
+++ b/Tests/AIProxyTests/OpenAICreateResponseRequestTests.swift
@@ -365,5 +365,58 @@ final class OpenAICreateResponseRequestTests: XCTestCase {
         )
     }
 
+    func testResponseRequestWithTruncationAndContextManagement() throws {
+        let requestBody = OpenAICreateResponseRequestBody(
+            input: .text("Continue the long-running task"),
+            contextManagement: [
+                .init(compactThreshold: 200000)
+            ],
+            model: "gpt-5.3-codex",
+            truncation: .auto
+        )
+
+        XCTAssertEqual(
+            """
+            {
+              "context_management" : [
+                {
+                  "compact_threshold" : 200000,
+                  "type" : "compaction"
+                }
+              ],
+              "input" : "Continue the long-running task",
+              "model" : "gpt-5.3-codex",
+              "truncation" : "auto"
+            }
+            """,
+            try requestBody.serialize(pretty: true)
+        )
+    }
+
+    func testResponseRequestWithContextManagementCompactionOnlyType() throws {
+        let requestBody = OpenAICreateResponseRequestBody(
+            input: .text("hello"),
+            contextManagement: [
+                .init(type: .compaction, compactThreshold: nil)
+            ],
+            model: "gpt-4o"
+        )
+
+        XCTAssertEqual(
+            """
+            {
+              "context_management" : [
+                {
+                  "type" : "compaction"
+                }
+              ],
+              "input" : "hello",
+              "model" : "gpt-4o"
+            }
+            """,
+            try requestBody.serialize(pretty: true)
+        )
+    }
+
 }
 

--- a/Tests/AIProxyTests/OpenAIResponseObjectTests.swift
+++ b/Tests/AIProxyTests/OpenAIResponseObjectTests.swift
@@ -470,4 +470,116 @@ final class OpenAIResponseObjectTests: XCTestCase {
         XCTAssertEqual(.futureProof, res.effort)
     }
 
+    func testResponseWithCompactionOutputItemIsDecodable() throws {
+        let sampleResponse = #"""
+        {
+          "id": "resp_compaction",
+          "object": "response",
+          "created_at": 1753111046,
+          "status": "completed",
+          "error": null,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "model": "gpt-5.3-codex",
+          "output": [
+            {
+              "id": "cmp_123",
+              "type": "compaction",
+              "encrypted_content": "enc_abc123",
+              "created_by": "system"
+            },
+            {
+              "id": "msg_123",
+              "type": "message",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "text": "Done",
+                  "annotations": []
+                }
+              ],
+              "role": "assistant"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "previous_response_id": null,
+          "reasoning": {
+            "effort": null,
+            "summary": null
+          },
+          "store": false,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "text"
+            }
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": null,
+          "user": null,
+          "metadata": {}
+        }
+        """#
+
+        let res = try OpenAIResponse.deserialize(from: sampleResponse)
+        XCTAssertEqual(2, res.output.count)
+
+        guard case .compaction(let compaction) = res.output.first else {
+            return XCTFail("Expected first output item to be a compaction item")
+        }
+
+        XCTAssertEqual("cmp_123", compaction.id)
+        XCTAssertEqual("enc_abc123", compaction.encryptedContent)
+        XCTAssertEqual("system", compaction.createdBy)
+        XCTAssertEqual("Done", res.outputText)
+    }
+
+    func testResponseWithCompactionOutputItemWithoutIdIsDecodable() throws {
+        let sampleResponse = #"""
+        {
+          "id": "resp_compaction2",
+          "object": "response",
+          "created_at": 1753111046,
+          "status": "completed",
+          "error": null,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "model": "gpt-5.3-codex",
+          "output": [
+            {
+              "type": "compaction",
+              "encrypted_content": "enc_only"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "previous_response_id": null,
+          "reasoning": { "effort": null, "summary": null },
+          "store": false,
+          "temperature": 1.0,
+          "text": { "format": { "type": "text" } },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": null,
+          "user": null,
+          "metadata": {}
+        }
+        """#
+
+        let res = try OpenAIResponse.deserialize(from: sampleResponse)
+        guard case .compaction(let compaction) = res.output.first else {
+            return XCTFail("Expected compaction output item")
+        }
+        XCTAssertNil(compaction.id)
+        XCTAssertNil(compaction.createdBy)
+        XCTAssertEqual("enc_only", compaction.encryptedContent)
+    }
+
 }

--- a/Tests/AIProxyTests/OpenAIResponseStreamingEventTests.swift
+++ b/Tests/AIProxyTests/OpenAIResponseStreamingEventTests.swift
@@ -229,6 +229,22 @@ class OpenAIResponseStreamingEventTests: XCTestCase {
 
     }
 
+    func testResponseOutputItemDoneWithCompactionIsDecodable() throws {
+        let line = #"data: {"type":"response.output_item.done","sequence_number":74,"output_index":0,"item":{"created_by":"system","encrypted_content":"enc_abc123","id":"cmp_123","type":"compaction"}}"#
+        let event = OpenAIResponseStreamingEvent.deserialize(fromLine: line)
+        guard case .outputItemDone(let outputItemDone) = event else {
+            return XCTFail("Expected response.output_item.done")
+        }
+        XCTAssertEqual(outputItemDone.sequenceNumber, 74)
+
+        guard case .compaction(let compaction) = outputItemDone.item else {
+            return XCTFail("Expected the output item to contain a compaction item")
+        }
+        XCTAssertEqual(compaction.id, "cmp_123")
+        XCTAssertEqual(compaction.encryptedContent, "enc_abc123")
+        XCTAssertEqual(compaction.createdBy, "system")
+    }
+
     func testResponseCompletedEventIsDecodable() throws {
         let line = #"data: {"type":"response.completed","sequence_number":74,"response":{"id":"resp_6862e16d59ec819c82a9bb2ef50b05580011e56165dda6f9","object":"response","created_at":1751310701,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"ws_6862e16e17b8819c9704cda771dc37e10011e56165dda6f9","type":"web_search_call","status":"completed","action":{"type":"search","query":"Apple stock price today"}},{"id":"msg_6862e1709424819cbd4b8c0d552e48970011e56165dda6f9","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"As of June 30, 2025, <snip>"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"web_search_preview","search_context_size":"low","user_location":{"type":"approximate","city":null,"country":"US","region":null,"timezone":null}}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":308,"input_tokens_details":{"cached_tokens":0},"output_tokens":192,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":500},"user":null,"metadata":{}}}"#
         let event = OpenAIResponseStreamingEvent.deserialize(fromLine: line)


### PR DESCRIPTION
## Summary

This PR aligns AIProxySwift with OpenAI’s Responses API around **context management**, **truncation** wording, and **compaction** items that can appear on the wire when using documented context features.

It adds support for:

* **`context_management`** on `OpenAICreateResponseRequestBody`, encoded as `context_management` in JSON (with a `ContextManagementItem` model and a deprecated `ContextManagement` typealias for backward compatibility).
* **Truncation** documentation on the request body updated to match current OpenAI language (beginning-of-context / input over limit behavior).
* **`compaction`** as a first-class **`OpenAIResponse` output item**, including `encrypted_content`, optional `id`, and optional **`created_by`**, and ensuring consolidated **`outputText`** ignores compaction entries.
* **Symmetrical decoding** of **`type: "compaction"`** on **`OpenAIConversationItem`** (conversation list items), reusing the same compaction payload shape as Response output.
* **Outbound compaction items** via **`OpenAICompactionItem`**: optional **`created_by`** encoding so clients can echo server metadata when sending compaction back in conversation input.

## Why

OpenAI documents **`context_management`** and **compaction** as part of managing long-running Responses and conversation state. Without these fields and output branches, Swift callers could not encode the full request surface or decode compaction rows returned in **response output** or **conversation item lists**, which breaks parity with the HTTP JSON and complicates context handoff.

## Test Plan

Ran the full package test suite:

`swift test`

Additional focused runs while developing:

`swift test --filter 'OpenAICreateResponseRequestTests|OpenAIResponseObjectTests|OpenAIResponseStreamingEventTests|OpenAIConversationItemTests'`