### PR TITLE
Add manual echo cancellation usage to README

### DIFF
--- a/AIProxy.podspec
+++ b/AIProxy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AIProxy'
-  s.version      = '0.150.0'
+  s.version      = '0.151.0'
   s.summary      = 'AIProxy Swift SDK for secure AI integrations'
   s.description  = 'Access OpenAI, Anthropic, and other AI providers securely without exposing API keys in your app. See https://www.aiproxy.com for more'
   s.homepage     = 'https://github.com/lzell/AIProxySwift'

--- a/README.md
+++ b/README.md
@@ -1373,7 +1373,10 @@ final class RealtimeManager {
         // Set to false if you want your user to speak first
         let aiSpeaksFirst = true
 
-        let audioController = try await AudioController(modes: [.playback, .record])
+        let audioController = try await AudioController(
+            modes: [.playback, .record],
+            useManualEchoCancellation: true
+        )
         let micStream = try audioController.micStream()
 
         // Start the realtime session:
@@ -1446,26 +1449,24 @@ final class RealtimeManager {
 }
 ```
 
-#### GA Realtime migration notes
+#### General Availability (GA) Realtime migration notes
 
-- `realtimeSessionGA(...)` is the GA-native path and supports GA-only `session.update` fields.
-- `realtimeSession(...)` now defaults to GA. Use `apiVersion: .betaV1` only as an explicit opt-in fallback.
-- OpenAI has announced Realtime beta (`OpenAI-Beta: realtime=v1`) deprecation and shutdown on 2026-05-07. Prefer GA paths for new integrations.
+- OpenAI has announced Realtime beta (`OpenAI-Beta: realtime=v1`) deprecation and shutdown on 2026-05-07.
 - For `response.create`, GA uses `output_modalities` (not `modalities`).
-- GA `output_modalities` behavior is nuanced:
+- The new `output_modalities` for OpenAI realtime GA (general availability) is as follows:
   - `["audio"]` returns audio with transcript.
   - `["text"]` returns text only.
-- For voice mode with built-in web search, use GA tools (`.webSearch`) and GA tool choice.
+- For voice mode with built-in web search, use GA tool (`.webSearch`) and specify `.auto` for toolChoice to let the model decide when to use it.
 
 ```swift
-let configuration = OpenAIRealtimeSessionConfigurationGA(
+let configuration = OpenAIRealtimeSessionConfiguration(
     outputModalities: [.audio],
     voice: .builtin("alloy"),
     tools: [.webSearch(.init(searchContextSize: .medium))],
     toolChoice: .auto
 )
 
-let session = try await openAIService.realtimeSessionGA(
+let session = try await openAIService.realtimeSession(
     model: "gpt-realtime",
     configuration: configuration,
     logLevel: .info

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    nonisolated public static let sdkVersion = "0.150.0"
+    nonisolated public static let sdkVersion = "0.151.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/AudioController.swift
+++ b/Sources/AIProxy/AudioController.swift
@@ -18,38 +18,42 @@ import AVFoundation
 /// We use either AVAudioEngine or AudioToolbox for mic data, depending on the platform and whether headphones are attached.
 /// The following arrangement provides for the best user experience:
 ///
-///     +----------+---------------+--------------------------------------+
-///     | Platform | Headphones    | Audio API                            |
-///     +----------+---------------+--------------------------------------+
-///     | macOS    | Yes           | AudioEngine                          |
-///     | macOS    | No            | AudioToolbox                         |
-///     | iOS      | Yes           | AudioEngine                          |
-///     | iOS      | No            | AudioToolbox + manual rendering AEC  |
-///     | watchOS  | Yes           | AudioEngine                          |
-///     | watchOS  | No            | AudioEngine                          |
-///     +----------+---------------+--------------------------------------+
+///     +----------+--------------------------------+-------------------------------------+
+///     | Platform | Headphones                     | Audio API                           |
+///     +----------+--------------------------------+-------------------------------------+
+///     | macOS    | Yes                            | AudioEngine                         |
+///     | macOS    | No                             | AudioToolbox                        |
+///     | iOS      | Yes                            | AudioEngine                         |
+///     | iOS      | No                             | AudioToolbox                        |
+///     | iOS      | No + useManualEchoCancellation | AudioToolbox + manual rendering AEC |
+///     | watchOS  | Yes                            | AudioEngine                         |
+///     | watchOS  | No                             | AudioEngine                         |
+///     +----------+--------------------------------+-------------------------------------+
 ///
 @AIProxyActor public final class AudioController {
     public enum Mode {
         case record
         case playback
     }
+
+    public let useManualEchoCancellation: Bool
     public let modes: [Mode]
     private let audioEngine: AVAudioEngine
     private var microphonePCMSampleVendor: MicrophonePCMSampleVendor? = nil
     private var audioPCMPlayer: AudioPCMPlayer? = nil
     private var pendingUTF8Byte: UInt8? = nil
 
-    public init(modes: [Mode]) async throws {
+    public init(
+        modes: [Mode],
+        useManualEchoCancellation: Bool = false
+    ) async throws {
         self.modes = modes
-        #if os(iOS) // iOS-first guard: non-iOS behavior has not been validated for this path yet.
-        let needsManualRendering = modes.contains(.record) && modes.contains(.playback)
-                                   && !AIProxyUtils.headphonesConnected
-        #else
-        let needsManualRendering = false
-        #endif
+        self.useManualEchoCancellation = useManualEchoCancellation
+                                         && modes.contains(.record) && modes.contains(.playback)
+                                         && !AIProxyUtils.headphonesConnected
 
-        #if os(iOS) // iOS-first guard: non-iOS behavior has not been validated for this path yet.
+
+        #if os(iOS)
         // This is not respected if `setVoiceProcessingEnabled(true)` is used :/
         // Instead, I've added my own accumulator.
         // try? AVAudioSession.sharedInstance().setPreferredIOBufferDuration(0.1)
@@ -68,8 +72,7 @@ import AVFoundation
 
         self.audioEngine = AVAudioEngine()
 
-        #if os(iOS) // iOS-first guard: non-iOS behavior has not been validated for this path yet.
-        if needsManualRendering {
+        if self.useManualEchoCancellation {
             let renderFormat = AVAudioFormat(
                 commonFormat: .pcmFormatFloat32,
                 sampleRate: 44100,
@@ -82,13 +85,15 @@ import AVFoundation
                 maximumFrameCount: 4096
             )
         }
-        #endif
 
         if modes.contains(.record) {
             #if os(macOS) || os(iOS)
             self.microphonePCMSampleVendor = AIProxyUtils.headphonesConnected
                                                ? try MicrophonePCMSampleVendorAE(audioEngine: self.audioEngine)
-                                               : MicrophonePCMSampleVendorAT(audioEngine: self.audioEngine)
+                                               : MicrophonePCMSampleVendorAT(
+                                                   audioEngine: self.audioEngine,
+                                                   useManualEchoCancellation: self.useManualEchoCancellation
+                                               )
             #else
             self.microphonePCMSampleVendor = try MicrophonePCMSampleVendorAE(audioEngine: self.audioEngine)
             #endif
@@ -104,16 +109,12 @@ import AVFoundation
         // Nesting `start` in a Task is necessary on watchOS.
         // There is some sort of race, and letting the runloop tick seems to "fix" it.
         // If I call `prepare` and `start` in serial succession, then there is no playback on watchOS (sometimes).
-        #if os(iOS) // iOS-first guard: non-iOS behavior has not been validated for this path yet.
-        try self.audioEngine.start()
-        #elseif os(watchOS)
+        #if os(watchOS)
         Task {
             try self.audioEngine.start()
         }
         #else
-        Task {
-            try self.audioEngine.start()
-        }
+        try self.audioEngine.start()
         #endif
     }
 

--- a/Sources/AIProxy/MicrophonePCMSampleVendorAT.swift
+++ b/Sources/AIProxy/MicrophonePCMSampleVendorAT.swift
@@ -66,13 +66,19 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
     private let microphonePCMSampleVendorCommon = MicrophonePCMSampleVendorCommon()
     private var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
     private var audioEngine: AVAudioEngine?
+    private let shouldEnableSpeakerBusForAEC: Bool
     private var outputLikelyActiveUntilUptime: TimeInterval = 0
     private var outputSmoothedRMS: Float = 0
     private var micLoudFrameStreak = 0
     private var bargeInOpenUntilUptime: TimeInterval = 0
 
-    public init(audioEngine: AVAudioEngine? = nil) {
+    public init(
+        audioEngine: AVAudioEngine? = nil,
+        useManualEchoCancellation: Bool = false
+    ) {
         self.audioEngine = audioEngine
+        self.shouldEnableSpeakerBusForAEC = useManualEchoCancellation
+                                           && (audioEngine?.isInManualRenderingMode ?? false)
     }
 
     deinit {
@@ -115,18 +121,13 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
             )
         }
 
-        #if os(iOS) // iOS-first guard: non-iOS behavior has not been validated for this path yet.
-        let shouldEnableSpeakerBusForAEC = audioEngine?.isInManualRenderingMode ?? false
-        #else
-        let shouldEnableSpeakerBusForAEC = true
-        #endif
-        var one_output: UInt32 = shouldEnableSpeakerBusForAEC ? 1 : 0
+        var oneOutput: UInt32 = self.shouldEnableSpeakerBusForAEC ? 1 : 0
         err = AudioUnitSetProperty(audioUnit,
                                    kAudioOutputUnitProperty_EnableIO,
                                    kAudioUnitScope_Output,
                                    0,
-                                   &one_output,
-                                   UInt32(MemoryLayout.size(ofValue: one_output)))
+                                   &oneOutput,
+                                   UInt32(MemoryLayout.size(ofValue: oneOutput)))
 
         guard err == noErr else {
             throw MicrophonePCMSampleVendorError.couldNotConfigureAudioUnit(
@@ -255,7 +256,6 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
             )
         }
 
-        #if os(iOS) // iOS-first guard: non-iOS behavior has not been validated for this path yet.
         // Make voice processing explicit so route changes do not accidentally bypass AEC.
         var disableBypass: UInt32 = 0
         err = AudioUnitSetProperty(
@@ -283,11 +283,10 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
         if err != noErr {
             logIf(.warning)?.warning("Could not disable VPIO AGC: \(err)")
         }
-        #endif
 
         // If we have an AVAudioEngine in manual rendering mode, set up the VPIO output bus
         // to pull rendered audio. This gives the VPIO visibility into playback for AEC.
-        if shouldEnableSpeakerBusForAEC, audioEngine != nil {
+        if self.shouldEnableSpeakerBusForAEC, audioEngine != nil {
             var outputFormat = AudioStreamBasicDescription(
                 mSampleRate: kVoiceProcessingInputSampleRate,  // 44100
                 mFormatID: kAudioFormatLinearPCM,
@@ -365,6 +364,11 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
         _ inBusNumber: UInt32,
         _ inNumberFrames: UInt32
     ) {
+        var allocatedMicData: UnsafeMutableRawPointer?
+        defer {
+            allocatedMicData?.deallocate()
+        }
+
         // iOS does not respect the buffer size we ask for. macOS is much closer. I'm accumulating them downstream anyway:
         // print("Got \(inNumberFrames) frames - expected \(UInt(kVoiceProcessingInputSampleRate /  20))")
         guard let audioUnit = audioUnit else {
@@ -376,10 +380,14 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
             mBuffers: AudioBuffer(
                 mNumberChannels: 1,
                 mDataByteSize: inNumberFrames * 2,
-                mData: UnsafeMutableRawPointer.allocate(
-                    byteCount: Int(inNumberFrames) * 2,
-                    alignment: MemoryLayout<Int16>.alignment
-                )
+                mData: {
+                    let data = UnsafeMutableRawPointer.allocate(
+                        byteCount: Int(inNumberFrames) * 2,
+                        alignment: MemoryLayout<Int16>.alignment
+                    )
+                    allocatedMicData = data
+                    return data
+                }()
             )
         )
 
@@ -395,11 +403,10 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
             return
         }
 
-        #if os(iOS) // iOS-first guard: non-iOS behavior has not been validated for this path yet.
-        if self.shouldSuppressLikelyEchoInput(bufferList: bufferList, frameCount: inNumberFrames) {
+        if self.shouldEnableSpeakerBusForAEC
+            && self.shouldSuppressLikelyEchoInput(bufferList: bufferList, frameCount: inNumberFrames) {
             return
         }
-        #endif
 
         guard let audioFormat = AVAudioFormat(
             commonFormat: .pcmFormatInt16,
@@ -413,6 +420,7 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
 
         if let sampleBuffer = AVAudioPCMBuffer(pcmFormat: audioFormat, bufferListNoCopy: &bufferList),
            let accumulatedBuffer = self.microphonePCMSampleVendorCommon.resampleAndAccumulate(sampleBuffer) {
+            allocatedMicData = nil
             // If the buffer has accumulated to a sufficient level, give it back to the caller
             Task { @AIProxyActor in
                 self.continuation?.yield(accumulatedBuffer)
@@ -448,17 +456,16 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
             for i in 0..<buf.count {
                 memset(buf[i].mData, 0, Int(buf[i].mDataByteSize))
             }
-            #if os(iOS) // iOS-first guard: non-iOS behavior has not been validated for this path yet.
-            self.noteRenderedOutput(ioData, frameCount: inNumberFrames)
-            #endif
+            if self.shouldEnableSpeakerBusForAEC {
+                self.noteRenderedOutput(ioData, frameCount: inNumberFrames)
+            }
             return
         }
-        #if os(iOS) // iOS-first guard: non-iOS behavior has not been validated for this path yet.
-        self.noteRenderedOutput(ioData, frameCount: inNumberFrames)
-        #endif
+        if self.shouldEnableSpeakerBusForAEC {
+            self.noteRenderedOutput(ioData, frameCount: inNumberFrames)
+        }
     }
 
-    #if os(iOS) // iOS-first guard: non-iOS behavior has not been validated for this path yet.
     private func noteRenderedOutput(
         _ ioData: UnsafeMutablePointer<AudioBufferList>,
         frameCount: UInt32
@@ -563,7 +570,6 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
         }
         return sqrt(sumSquares / Float(sampleCount))
     }
-    #endif
 }
 
 // NOTE:

--- a/Sources/AIProxy/MicrophonePCMSampleVendorAT.swift
+++ b/Sources/AIProxy/MicrophonePCMSampleVendorAT.swift
@@ -286,7 +286,7 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
 
         // If we have an AVAudioEngine in manual rendering mode, set up the VPIO output bus
         // to pull rendered audio. This gives the VPIO visibility into playback for AEC.
-        if self.shouldEnableSpeakerBusForAEC, audioEngine != nil {
+        if self.shouldEnableSpeakerBusForAEC, self.audioEngine != nil {
             var outputFormat = AudioStreamBasicDescription(
                 mSampleRate: kVoiceProcessingInputSampleRate,  // 44100
                 mFormatID: kAudioFormatLinearPCM,
@@ -364,11 +364,6 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
         _ inBusNumber: UInt32,
         _ inNumberFrames: UInt32
     ) {
-        var allocatedMicData: UnsafeMutableRawPointer?
-        defer {
-            allocatedMicData?.deallocate()
-        }
-
         // iOS does not respect the buffer size we ask for. macOS is much closer. I'm accumulating them downstream anyway:
         // print("Got \(inNumberFrames) frames - expected \(UInt(kVoiceProcessingInputSampleRate /  20))")
         guard let audioUnit = audioUnit else {
@@ -380,14 +375,10 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
             mBuffers: AudioBuffer(
                 mNumberChannels: 1,
                 mDataByteSize: inNumberFrames * 2,
-                mData: {
-                    let data = UnsafeMutableRawPointer.allocate(
-                        byteCount: Int(inNumberFrames) * 2,
-                        alignment: MemoryLayout<Int16>.alignment
-                    )
-                    allocatedMicData = data
-                    return data
-                }()
+                mData: UnsafeMutableRawPointer.allocate(
+                    byteCount: Int(inNumberFrames) * 2,
+                    alignment: MemoryLayout<Int16>.alignment
+                )
             )
         )
 
@@ -420,7 +411,6 @@ nonisolated private let kEchoGuardBargeInHoldSeconds: TimeInterval = 1.0
 
         if let sampleBuffer = AVAudioPCMBuffer(pcmFormat: audioFormat, bufferListNoCopy: &bufferList),
            let accumulatedBuffer = self.microphonePCMSampleVendorCommon.resampleAndAccumulate(sampleBuffer) {
-            allocatedMicData = nil
             // If the buffer has accumulated to a sufficient level, give it back to the caller
             Task { @AIProxyActor in
                 self.continuation?.yield(accumulatedBuffer)

--- a/Sources/AIProxy/OpenAI/OpenAIRealtimeSessionConfiguration.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIRealtimeSessionConfiguration.swift
@@ -3,8 +3,7 @@
 //  AIProxy
 //
 
-/// Realtime session configuration for `session.update`.
-///
+/// Represents OpenAI's `RealtimeSessionCreateRequest` type, which is a member of the `session.update` event:
 /// https://developers.openai.com/api/reference/resources/realtime/client-events#session.update
 nonisolated public struct OpenAIRealtimeSessionConfiguration: Encodable, Sendable {
     public let include: [IncludeField]?


### PR DESCRIPTION
Follow-up to: https://github.com/lzell/AIProxySwift/pull/264

Callers can opt-in to the manual echo cancellation by passing `useManualEchoCancellation: true` to their AudioController setup. I've made this the default snippet in our README for realtime usage.

Thank you @kavimathur for the addition!