### PR TITLE
Expose headers for ElevenLabs interfaces

### DIFF
--- a/AIProxy.podspec
+++ b/AIProxy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AIProxy'
-  s.version      = '0.151.0'
+  s.version      = '0.152.0'
   s.summary      = 'AIProxy Swift SDK for secure AI integrations'
   s.description  = 'Access OpenAI, Anthropic, and other AI providers securely without exposing API keys in your app. See https://www.aiproxy.com for more'
   s.homepage     = 'https://github.com/lzell/AIProxySwift'

--- a/Sources/AIProxy/AIProxy.swift
+++ b/Sources/AIProxy/AIProxy.swift
@@ -8,7 +8,7 @@ import UIKit
 public enum AIProxy {
 
     /// The current sdk version
-    nonisolated public static let sdkVersion = "0.151.0"
+    nonisolated public static let sdkVersion = "0.152.0"
 
     /// Configures the AIProxy SDK. Call this during app launch by adding an `init` to your SwiftUI MyApp.swift file, e.g.
     ///

--- a/Sources/AIProxy/AIProxyResponseMetadata.swift
+++ b/Sources/AIProxy/AIProxyResponseMetadata.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+nonisolated public struct AIProxyResponseWithHeaders<Body: Sendable>: Sendable {
+    public let body: Body
+    public let headers: [String: String]
+
+    public init(body: Body, headers: [String: String]) {
+        self.body = body
+        self.headers = headers
+    }
+}
+
+nonisolated public struct AIProxyDataStreamResponse: Sendable {
+    public let headers: [String: String]
+    public let stream: AsyncStream<Data>
+
+    public init(headers: [String: String], stream: AsyncStream<Data>) {
+        self.headers = headers
+        self.stream = stream
+    }
+}
+
+nonisolated public struct AIProxyChunkStreamResponse<Chunk: Sendable>: Sendable {
+    public let headers: [String: String]
+    public let stream: AsyncThrowingStream<Chunk, Error>
+
+    public init(headers: [String: String], stream: AsyncThrowingStream<Chunk, Error>) {
+        self.headers = headers
+        self.stream = stream
+    }
+}

--- a/Sources/AIProxy/BackgroundNetworker.swift
+++ b/Sources/AIProxy/BackgroundNetworker.swift
@@ -65,6 +65,14 @@ struct BackgroundNetworker {
         _ session: URLSession,
         _ request: URLRequest
     ) async throws -> AsyncStream<Data> {
+        let (stream, _) = try await self.makeRequestAndVendChunksWithResponse(session, request)
+        return stream
+    }
+
+    @AIProxyActor static func makeRequestAndVendChunksWithResponse(
+        _ session: URLSession,
+        _ request: URLRequest
+    ) async throws -> (AsyncStream<Data>, HTTPURLResponse) {
 
         let dataTaskBridge = URLSessionDataTaskBridge()
         let task = session.dataTask(with: request)
@@ -95,7 +103,7 @@ struct BackgroundNetworker {
             })
         }
 
-        let _: Void = try await withCheckedThrowingContinuation { @AIProxyActor continuation in
+        let httpResponse: HTTPURLResponse = try await withCheckedThrowingContinuation { @AIProxyActor continuation in
             task.resume()
             dataTaskBridge.onResponse.append { [weak dataTaskBridge] res in
                 guard let dataTaskBridge = dataTaskBridge else { return }
@@ -105,7 +113,7 @@ struct BackgroundNetworker {
                 }
                 dataTaskBridge.statusCode = httpResponse.statusCode
                 if !dataTaskBridge.isBadStatusCode {
-                    continuation.resume()
+                    continuation.resume(returning: httpResponse)
                 }
             }
 
@@ -131,6 +139,6 @@ struct BackgroundNetworker {
             }
         }
 
-        return asyncStream
+        return (asyncStream, httpResponse)
     }
 }

--- a/Sources/AIProxy/ElevenLabs/ElevenLabsDirectService.swift
+++ b/Sources/AIProxy/ElevenLabs/ElevenLabsDirectService.swift
@@ -35,6 +35,19 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> Data {
+        let response = try await self.ttsRequestWithMetadata(
+            voiceID: voiceID,
+            body: body,
+            secondsToWait: secondsToWait
+        )
+        return response.body
+    }
+
+    public func ttsRequestWithMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSResponse<Data> {
         let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.elevenlabs.io",
             path: "/v1/text-to-speech/\(voiceID)",
@@ -46,11 +59,11 @@ import Foundation
                 "xi-api-key": self.unprotectedAPIKey
             ]
         )
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
+        let (data, httpResponse) = try await BackgroundNetworker.makeRequestAndWaitForData(
             self.urlSession,
             request
         )
-        return data
+        return ElevenLabsTTSResponse(body: data, headers: httpResponse.readableHeaders)
     }
     
     /// Converts text to speech with a request to `/v1/text-to-speech/<voice-id>/with-timestamps`
@@ -72,6 +85,19 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> ElevenLabsTTSWithTimestampsResponseBody {
+        let response = try await self.ttsRequestWithTimestampsAndMetadata(
+            voiceID: voiceID,
+            body: body,
+            secondsToWait: secondsToWait
+        )
+        return response.body
+    }
+
+    func ttsRequestWithTimestampsAndMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSResponse<ElevenLabsTTSWithTimestampsResponseBody> {
         let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.elevenlabs.io",
             path: "/v1/text-to-speech/\(voiceID)/with-timestamps",
@@ -84,7 +110,7 @@ import Foundation
             ]
         )
         
-        return try await self.makeRequestAndDeserializeResponse(request)
+        return try await self.makeRequestAndDeserializeResponseWithMetadata(request)
     }
 
     /// Converts text to speech with a request to `/v1/text-to-speech/<voice-id>/stream?output_format=pcm_24000`
@@ -107,6 +133,19 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> AsyncStream<Data> {
+        let response = try await self.streamingTTSRequestWithMetadata(
+            voiceID: voiceID,
+            body: body,
+            secondsToWait: secondsToWait
+        )
+        return response.stream
+    }
+
+    func streamingTTSRequestWithMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSAudioStreamResponse {
         let request = try AIProxyURLRequest.createDirect(
             baseURL: "https://api.elevenlabs.io",
             path: "/v1/text-to-speech/\(voiceID)/stream?output_format=pcm_24000",
@@ -118,7 +157,8 @@ import Foundation
                 "xi-api-key": self.unprotectedAPIKey
             ]
         )
-        return try await BackgroundNetworker.makeRequestAndVendChunks(self.urlSession, request)
+        let (stream, httpResponse) = try await BackgroundNetworker.makeRequestAndVendChunksWithResponse(self.urlSession, request)
+        return ElevenLabsTTSAudioStreamResponse(headers: httpResponse.readableHeaders, stream: stream)
     }
 
     /// Converts text to speech with a request to `/v1/text-to-speech/<voice-id>/with-timestamps`
@@ -143,6 +183,19 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> AsyncThrowingStream<ElevenLabsTTSWithTimestampsResponseBody, Error>  {
+        let response = try await self.streamingTTSWithTimestampsRequestWithMetadata(
+            voiceID: voiceID,
+            body: body,
+            secondsToWait: secondsToWait
+        )
+        return response.stream
+    }
+
+    func streamingTTSWithTimestampsRequestWithMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSChunkStreamResponse<ElevenLabsTTSWithTimestampsResponseBody>  {
         let path = "/v1/text-to-speech/\(voiceID)/stream/with-timestamps?output_format=pcm_24000"
 
         let request = try AIProxyURLRequest.createDirect(
@@ -157,7 +210,7 @@ import Foundation
             ]
         )
 
-        return try await self.makeRequestAndDeserializeNDJSONChunks(request)
+        return try await self.makeRequestAndDeserializeNDJSONChunksWithMetadata(request)
 
     }
 

--- a/Sources/AIProxy/ElevenLabs/ElevenLabsProxiedService.swift
+++ b/Sources/AIProxy/ElevenLabs/ElevenLabsProxiedService.swift
@@ -38,6 +38,19 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> Data {
+        let response = try await self.ttsRequestWithMetadata(
+            voiceID: voiceID,
+            body: body,
+            secondsToWait: secondsToWait
+        )
+        return response.body
+    }
+
+    public func ttsRequestWithMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSResponse<Data> {
         let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
@@ -48,11 +61,11 @@ import Foundation
             secondsToWait: secondsToWait,
             contentType: "application/json"
         )
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
+        let (data, httpResponse) = try await BackgroundNetworker.makeRequestAndWaitForData(
             self.urlSession,
             request
         )
-        return data
+        return ElevenLabsTTSResponse(body: data, headers: httpResponse.readableHeaders)
     }
     
     /// Converts text to speech with a request to `/v1/text-to-speech/<voice-id>/with-timestamps`
@@ -74,6 +87,19 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> ElevenLabsTTSWithTimestampsResponseBody {
+        let response = try await self.ttsRequestWithTimestampsAndMetadata(
+            voiceID: voiceID,
+            body: body,
+            secondsToWait: secondsToWait
+        )
+        return response.body
+    }
+
+    public func ttsRequestWithTimestampsAndMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSResponse<ElevenLabsTTSWithTimestampsResponseBody> {
         let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
@@ -84,7 +110,7 @@ import Foundation
             secondsToWait: secondsToWait,
             contentType: "application/json"
         )
-        return try await self.makeRequestAndDeserializeResponse(request)
+        return try await self.makeRequestAndDeserializeResponseWithMetadata(request)
     }
     
     /// Converts text to speech with a request to `/v1/text-to-speech/<voice-id>/stream?output_format=pcm_24000`
@@ -107,6 +133,19 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> AsyncStream<Data> {
+        let response = try await self.streamingTTSRequestWithMetadata(
+            voiceID: voiceID,
+            body: body,
+            secondsToWait: secondsToWait
+        )
+        return response.stream
+    }
+
+    func streamingTTSRequestWithMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSAudioStreamResponse {
         let request = try await AIProxyURLRequest.create(
             partialKey: self.partialKey,
             serviceURL: self.serviceURL,
@@ -117,7 +156,8 @@ import Foundation
             secondsToWait: secondsToWait,
             contentType: "application/json"
         )
-        return try await BackgroundNetworker.makeRequestAndVendChunks(self.urlSession, request)
+        let (stream, httpResponse) = try await BackgroundNetworker.makeRequestAndVendChunksWithResponse(self.urlSession, request)
+        return ElevenLabsTTSAudioStreamResponse(headers: httpResponse.readableHeaders, stream: stream)
     }
     
     
@@ -141,6 +181,19 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> AsyncThrowingStream<ElevenLabsTTSWithTimestampsResponseBody, Error> {
+        let response = try await self.streamingTTSWithTimestampsRequestWithMetadata(
+            voiceID: voiceID,
+            body: body,
+            secondsToWait: secondsToWait
+        )
+        return response.stream
+    }
+
+    func streamingTTSWithTimestampsRequestWithMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSChunkStreamResponse<ElevenLabsTTSWithTimestampsResponseBody> {
         let path = "/v1/text-to-speech/\(voiceID)/stream/with-timestamps?output_format=pcm_24000"
         
         let request = try await AIProxyURLRequest.create(
@@ -153,7 +206,7 @@ import Foundation
             secondsToWait: secondsToWait,
             contentType: "application/json"
         )
-        return try await self.makeRequestAndDeserializeNDJSONChunks(request)
+        return try await self.makeRequestAndDeserializeNDJSONChunksWithMetadata(request)
         
     }
     

--- a/Sources/AIProxy/ElevenLabs/ElevenLabsService.swift
+++ b/Sources/AIProxy/ElevenLabs/ElevenLabsService.swift
@@ -26,6 +26,13 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> Data
+
+    /// Same as `ttsRequest`, but also returns the response headers from ElevenLabs.
+    func ttsRequestWithMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSResponse<Data>
     
     
     /// Converts text to speech with a request to `/v1/text-to-speech/<voice-id>/with-timestamps`
@@ -47,6 +54,13 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> ElevenLabsTTSWithTimestampsResponseBody
+
+    /// Same as `ttsRequestWithTimestamps`, but also returns the response headers from ElevenLabs.
+    func ttsRequestWithTimestampsAndMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSResponse<ElevenLabsTTSWithTimestampsResponseBody>
 
 
     /// Converts text to speech with a request to `/v1/text-to-speech/<voice-id>/stream?output_format=pcm_24000`
@@ -70,6 +84,13 @@ import Foundation
         secondsToWait: UInt
     ) async throws -> AsyncStream<Data>
 
+    /// Same as `streamingTTSRequest`, but also returns the response headers from ElevenLabs.
+    func streamingTTSRequestWithMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSAudioStreamResponse
+
     /// Converts text to speech with a request to `/v1/text-to-speech/<voice-id>/stream/with-timestamps`
     /// and returns a stream of JSONs containing audio as base64 together with character timing information.
     ///
@@ -91,6 +112,13 @@ import Foundation
         body: ElevenLabsTTSRequestBody,
         secondsToWait: UInt
     ) async throws -> AsyncThrowingStream<ElevenLabsTTSWithTimestampsResponseBody, Error>
+
+    /// Same as `streamingTTSWithTimestampsRequest`, but also returns the response headers from ElevenLabs.
+    func streamingTTSWithTimestampsRequestWithMetadata(
+        voiceID: String,
+        body: ElevenLabsTTSRequestBody,
+        secondsToWait: UInt
+    ) async throws -> ElevenLabsTTSChunkStreamResponse<ElevenLabsTTSWithTimestampsResponseBody>
     
     /// Converts speech to speech with a request to `/v1/speech-to-speech/<voice-id>`
     ///

--- a/Sources/AIProxy/ElevenLabs/ElevenLabsTTSResponseMetadata.swift
+++ b/Sources/AIProxy/ElevenLabs/ElevenLabsTTSResponseMetadata.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+nonisolated public struct ElevenLabsTTSResponse<Body: Sendable>: Sendable {
+    public let body: Body
+    public let headers: [String: String]
+
+    public init(body: Body, headers: [String: String]) {
+        self.body = body
+        self.headers = headers
+    }
+}
+
+nonisolated public struct ElevenLabsTTSAudioStreamResponse: Sendable {
+    public let headers: [String: String]
+    public let stream: AsyncStream<Data>
+
+    public init(headers: [String: String], stream: AsyncStream<Data>) {
+        self.headers = headers
+        self.stream = stream
+    }
+}
+
+nonisolated public struct ElevenLabsTTSChunkStreamResponse<Chunk: Sendable>: Sendable {
+    public let headers: [String: String]
+    public let stream: AsyncThrowingStream<Chunk, Error>
+
+    public init(headers: [String: String], stream: AsyncThrowingStream<Chunk, Error>) {
+        self.headers = headers
+        self.stream = stream
+    }
+}

--- a/Sources/AIProxy/ElevenLabs/ElevenLabsTTSResponseMetadata.swift
+++ b/Sources/AIProxy/ElevenLabs/ElevenLabsTTSResponseMetadata.swift
@@ -1,31 +1,5 @@
 import Foundation
 
-nonisolated public struct ElevenLabsTTSResponse<Body: Sendable>: Sendable {
-    public let body: Body
-    public let headers: [String: String]
-
-    public init(body: Body, headers: [String: String]) {
-        self.body = body
-        self.headers = headers
-    }
-}
-
-nonisolated public struct ElevenLabsTTSAudioStreamResponse: Sendable {
-    public let headers: [String: String]
-    public let stream: AsyncStream<Data>
-
-    public init(headers: [String: String], stream: AsyncStream<Data>) {
-        self.headers = headers
-        self.stream = stream
-    }
-}
-
-nonisolated public struct ElevenLabsTTSChunkStreamResponse<Chunk: Sendable>: Sendable {
-    public let headers: [String: String]
-    public let stream: AsyncThrowingStream<Chunk, Error>
-
-    public init(headers: [String: String], stream: AsyncThrowingStream<Chunk, Error>) {
-        self.headers = headers
-        self.stream = stream
-    }
-}
+public typealias ElevenLabsTTSResponse<Body: Sendable> = AIProxyResponseWithHeaders<Body>
+public typealias ElevenLabsTTSAudioStreamResponse = AIProxyDataStreamResponse
+public typealias ElevenLabsTTSChunkStreamResponse<Chunk: Sendable> = AIProxyChunkStreamResponse<Chunk>

--- a/Sources/AIProxy/ServiceMixin.swift
+++ b/Sources/AIProxy/ServiceMixin.swift
@@ -13,11 +13,11 @@ import Foundation
 
 extension ServiceMixin {
     @AIProxyActor func makeRequestAndDeserializeResponse<T: Decodable & Sendable>(_ request: URLRequest) async throws -> T {
-        let response: ElevenLabsTTSResponse<T> = try await self.makeRequestAndDeserializeResponseWithMetadata(request)
+        let response: AIProxyResponseWithHeaders<T> = try await self.makeRequestAndDeserializeResponseWithMetadata(request)
         return response.body
     }
 
-    @AIProxyActor func makeRequestAndDeserializeResponseWithMetadata<T: Decodable & Sendable>(_ request: URLRequest) async throws -> ElevenLabsTTSResponse<T> {
+    @AIProxyActor func makeRequestAndDeserializeResponseWithMetadata<T: Decodable & Sendable>(_ request: URLRequest) async throws -> AIProxyResponseWithHeaders<T> {
         if AIProxy.printRequestBodies {
             printRequestBody(request)
         }
@@ -28,7 +28,7 @@ extension ServiceMixin {
         if AIProxy.printResponseBodies {
             printBufferedResponseBody(data)
         }
-        return ElevenLabsTTSResponse(
+        return AIProxyResponseWithHeaders(
             body: try T.deserialize(from: data),
             headers: httpResponse.readableHeaders
         )
@@ -79,11 +79,11 @@ extension ServiceMixin {
     /// Unlike `makeRequestAndDeserializeStreamingChunks`, this method does not expect
     /// SSE-style "data: " prefixes. Each line is treated as raw JSON.
     @AIProxyActor func makeRequestAndDeserializeNDJSONChunks<T: Decodable & Sendable>(_ request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
-        let response: ElevenLabsTTSChunkStreamResponse<T> = try await self.makeRequestAndDeserializeNDJSONChunksWithMetadata(request)
+        let response: AIProxyChunkStreamResponse<T> = try await self.makeRequestAndDeserializeNDJSONChunksWithMetadata(request)
         return response.stream
     }
 
-    @AIProxyActor func makeRequestAndDeserializeNDJSONChunksWithMetadata<T: Decodable & Sendable>(_ request: URLRequest) async throws -> ElevenLabsTTSChunkStreamResponse<T> {
+    @AIProxyActor func makeRequestAndDeserializeNDJSONChunksWithMetadata<T: Decodable & Sendable>(_ request: URLRequest) async throws -> AIProxyChunkStreamResponse<T> {
         if AIProxy.printRequestBodies {
             printRequestBody(request)
         }
@@ -126,7 +126,7 @@ extension ServiceMixin {
                 task.cancel()
             }
         }
-        return ElevenLabsTTSChunkStreamResponse(
+        return AIProxyChunkStreamResponse(
             headers: httpResponse.readableHeaders,
             stream: stream
         )

--- a/Sources/AIProxy/ServiceMixin.swift
+++ b/Sources/AIProxy/ServiceMixin.swift
@@ -13,17 +13,25 @@ import Foundation
 
 extension ServiceMixin {
     @AIProxyActor func makeRequestAndDeserializeResponse<T: Decodable & Sendable>(_ request: URLRequest) async throws -> T {
+        let response: ElevenLabsTTSResponse<T> = try await self.makeRequestAndDeserializeResponseWithMetadata(request)
+        return response.body
+    }
+
+    @AIProxyActor func makeRequestAndDeserializeResponseWithMetadata<T: Decodable & Sendable>(_ request: URLRequest) async throws -> ElevenLabsTTSResponse<T> {
         if AIProxy.printRequestBodies {
             printRequestBody(request)
         }
-        let (data, _) = try await BackgroundNetworker.makeRequestAndWaitForData(
+        let (data, httpResponse) = try await BackgroundNetworker.makeRequestAndWaitForData(
             self.urlSession,
             request
         )
         if AIProxy.printResponseBodies {
             printBufferedResponseBody(data)
         }
-        return try T.deserialize(from: data)
+        return ElevenLabsTTSResponse(
+            body: try T.deserialize(from: data),
+            headers: httpResponse.readableHeaders
+        )
     }
 
     @AIProxyActor func makeRequestAndDeserializeStreamingChunks<T: Decodable & Sendable>(_ request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
@@ -71,16 +79,21 @@ extension ServiceMixin {
     /// Unlike `makeRequestAndDeserializeStreamingChunks`, this method does not expect
     /// SSE-style "data: " prefixes. Each line is treated as raw JSON.
     @AIProxyActor func makeRequestAndDeserializeNDJSONChunks<T: Decodable & Sendable>(_ request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
+        let response: ElevenLabsTTSChunkStreamResponse<T> = try await self.makeRequestAndDeserializeNDJSONChunksWithMetadata(request)
+        return response.stream
+    }
+
+    @AIProxyActor func makeRequestAndDeserializeNDJSONChunksWithMetadata<T: Decodable & Sendable>(_ request: URLRequest) async throws -> ElevenLabsTTSChunkStreamResponse<T> {
         if AIProxy.printRequestBodies {
             printRequestBody(request)
         }
 
-        let (asyncBytes, _) = try await BackgroundNetworker.makeRequestAndWaitForAsyncBytes(
+        let (asyncBytes, httpResponse) = try await BackgroundNetworker.makeRequestAndWaitForAsyncBytes(
             self.urlSession,
             request
         )
 
-        return AsyncThrowingStream { @AIProxyActor continuation in
+        let stream = AsyncThrowingStream<T, Error> { @AIProxyActor continuation in
             let task = Task {
                 do {
                     for try await line in asyncBytes.lines {
@@ -113,6 +126,10 @@ extension ServiceMixin {
                 task.cancel()
             }
         }
+        return ElevenLabsTTSChunkStreamResponse(
+            headers: httpResponse.readableHeaders,
+            stream: stream
+        )
     }
 }
 
@@ -156,4 +173,14 @@ nonisolated private func printStreamingResponseChunk(_ chunk: String) {
         \(chunk)
         """
     )
+}
+
+extension HTTPURLResponse {
+    var readableHeaders: [String: String] {
+        var headers: [String: String] = [:]
+        for (key, value) in self.allHeaderFields {
+            headers[String(describing: key)] = String(describing: value)
+        }
+        return headers
+    }
 }


### PR DESCRIPTION
Surfaces headers for both streaming and buffered responses. To access headers, switch your callsite from:


```swift
        let stream = try await elevenLabsService.streamingTTSRequest(
            voiceID: "EXAVITQu4vr4xnSDxMaL",
            body: body,
            secondsToWait: 120
        )

        for await chunk in stream {
            await audioController?.playPCM16Audio(data: chunk)
        }
```

To:

```swift
        let response = try await elevenLabsService.streamingTTSRequestWithMetadata(
            voiceID: "EXAVITQu4vr4xnSDxMaL",
            body: body,
            secondsToWait: 120
        )

        print("ElevenLabs returned headers: \(response.headers)")

        for await chunk in response.stream {
            await audioController?.playPCM16Audio(data: chunk)
        }
```