### PR TITLE
Fix incorrect Reasoning model for OpenAIResponse OutputItem

### DIFF
--- a/Sources/AIProxy/OpenAI/OpenAIResponse.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponse.swift
@@ -370,6 +370,14 @@ extension OpenAIResponse {
                 )
             }
         }
+        
+        // MARK: - OutputItem Reasoning
+        nonisolated public struct Reasoning: Decodable, Sendable {
+            public let id: String?
+
+            /// A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process.
+            public let summary: [OpenAISummaryText]?
+        }
     }
 
     // MARK: - Compaction

--- a/Sources/AIProxy/OpenAI/OpenAIResponse.swift
+++ b/Sources/AIProxy/OpenAI/OpenAIResponse.swift
@@ -373,7 +373,7 @@ extension OpenAIResponse {
         
         // MARK: - OutputItem Reasoning
         nonisolated public struct Reasoning: Decodable, Sendable {
-            public let id: String?
+            public let id: String
 
             /// A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process.
             public let summary: [OpenAISummaryText]?


### PR DESCRIPTION
This fixes an incorrect assumption that `OpenAIResponse.Reasoning` and `OpenAIResponse.OutputItem.Reasoning` share the same schema.

In the OpenAI Responses API, these are different structures. This PR separates the models to better match the API spec.