### PR TITLE
Provisional fix for reported crash in elevenlabs client

### DIFF
--- a/Sources/AIProxy/BackgroundNetworker.swift
+++ b/Sources/AIProxy/BackgroundNetworker.swift
@@ -113,6 +113,7 @@ struct BackgroundNetworker {
                 }
                 dataTaskBridge.statusCode = httpResponse.statusCode
                 if !dataTaskBridge.isBadStatusCode {
+                    dataTaskBridge.responseDelivered = true
                     continuation.resume(returning: httpResponse)
                 }
             }
@@ -126,14 +127,20 @@ struct BackgroundNetworker {
 
             dataTaskBridge.onComplete.append { [weak dataTaskBridge] err in
                 guard let dataTaskBridge = dataTaskBridge else { return }
+                if dataTaskBridge.responseDelivered {
+                    return
+                }
                 if let err = err {
+                    dataTaskBridge.responseDelivered = true
                     continuation.resume(throwing: err)
+                    return
                 }
                 if dataTaskBridge.isBadStatusCode {
                     let err = AIProxyError.unsuccessfulRequest(
                         statusCode: dataTaskBridge.statusCode,
                         responseBody: String(data: dataTaskBridge.accumulatedErrorBody, encoding: .utf8) ?? ""
                     )
+                    dataTaskBridge.responseDelivered = true
                     continuation.resume(throwing: err)
                 }
             }

--- a/Sources/AIProxy/URLSessionDataTaskBridge.swift
+++ b/Sources/AIProxy/URLSessionDataTaskBridge.swift
@@ -12,6 +12,7 @@ import Foundation
 @AIProxyActor final class URLSessionDataTaskBridge: Sendable {
     var statusCode: Int = 200
     var accumulatedErrorBody = Data()
+    var responseDelivered = false
     var onResponse: [(@AIProxyActor (URLResponse) -> Void)] = []
     var onData: [(@AIProxyActor (Data) -> Void)] = []
     var onComplete: [(@AIProxyActor (Error?) -> Void)] = []


### PR DESCRIPTION
- Prevents a double-resume on a continuation
- There's a customer report of a crash:
> My read is that the continuation inside withCheckedThrowingContinuation can resume once when didReceive response receives a successful HTTP response, then later resume again from didCompleteWithError if the URLSession task completes with an error. Swift traps on that with EXC_BREAKPOINT / SIGTRAP.


Thanks to Michael for the report.
